### PR TITLE
feat(collector): runtime detection specs

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,12 +1,8 @@
-# line length https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013
+# line length
 MD013: false
 
-# allow duplicate headings under different parents (e.g. changelog sections)
-MD024:
-  siblings_only: true
+# duplicate headings allowed (needed for CHANGELOG sections)
+MD024: false
 
 # punctuation in headings
 MD026: false
-
-# duplicate headings allowed (needed for CHANGELOG)
-MD024: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -7,3 +7,6 @@ MD024:
 
 # punctuation in headings
 MD026: false
+
+# duplicate headings allowed (needed for CHANGELOG)
+MD024: false

--- a/openspec/changes/multi-runtime-detection/.openspec.yaml
+++ b/openspec/changes/multi-runtime-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-25

--- a/openspec/changes/multi-runtime-detection/design.md
+++ b/openspec/changes/multi-runtime-detection/design.md
@@ -69,7 +69,7 @@ Each function: finds projects on the filesystem → detects running processes �
 
 Instead of a two-step flow (pick a runtime → pick a project), the orchestrator scans all GA runtimes at once and shows a single list:
 
-```
+```text
   Detected projects:
   ──────────────────────────────────────────────────
   [1] Python   /home/user/projects/api  (pyproject.toml)

--- a/openspec/changes/multi-runtime-detection/design.md
+++ b/openspec/changes/multi-runtime-detection/design.md
@@ -10,10 +10,12 @@ The Python implementation establishes a clear pattern: a `*InstrumentationPlan` 
 
 **Goals:**
 
-- Extend the preparation phase of `InstallOtelCollector` to detect Java, Node.js, and Go runtimes alongside Python.
+- Extend the preparation phase of `InstallOtelCollector` to detect Java, Node.js, and Go projects alongside Python.
 - Follow the established pattern: `Detect<Lang>Plan()` → `*<Lang>InstrumentationPlan` with `PrintPlanSteps()` and `Execute()`.
-- Present a single runtime selection menu; the user picks one runtime (or skips). Only one runtime is instrumented per invocation.
+- Scan all GA runtimes for projects and present a single unified project list; the user picks one project (or skips). Only one project is instrumented per invocation.
 - Keep each runtime's detection and instrumentation logic in its own file (`otel_java.go`, `otel_nodejs.go`, `otel_go.go`).
+- Extract shared project scanning, process detection, and env var generation into `otel_common.go` to avoid duplication.
+- Support Windows process detection alongside Unix.
 
 **Non-Goals:**
 
@@ -37,9 +39,19 @@ No formal Go interface is introduced — the orchestrator in `otel.go` calls the
 
 **Alternative considered:** A shared `InstrumentationPlan` interface. Rejected because it would require refactoring the existing Python code and the plans have different fields (virtualenv flags, JAR paths, etc.).
 
-**Alternative considered:** Supporting multiple runtime selections in a single invocation. Rejected for now — adds complexity to the confirmation preview, execution ordering, and error handling. Users can re-run `dtwiz install otel` to instrument additional runtimes.
+**Alternative considered:** Supporting multiple project selections in a single invocation. Rejected for now — adds complexity to the confirmation preview, execution ordering, and error handling. Users can re-run `dtwiz install otel` to instrument additional projects.
 
-### 2. Detection functions per runtime
+### 2. Shared utilities in `otel_common.go`
+
+Common logic extracted into `otel_common.go` to eliminate duplication across runtime-specific files:
+
+- `scanProjectDirs(markers, excludeNames)` — scans CWD + home-directory project locations for directories containing marker files.
+- `detectProcesses(filterTerm, excludeTerms)` — finds running processes. On Unix uses `ps ax` and `lsof`; on Windows uses PowerShell `Get-CimInstance Win32_Process`.
+- `processMatchPIDs(dirPath, procs)` — matches processes to project directories by CWD or command line.
+- `generateBaseOtelEnvVars(apiURL, token, serviceName)` — returns the common OTEL_* environment variables shared by all runtimes.
+- `getProcessCWD(pid)` — resolves process working directory. On Unix uses `lsof`; on Windows uses `Get-CimInstance`.
+
+### 3. Detection functions per runtime
 
 Each file exports a single detection entry point matching the Python pattern:
 
@@ -51,37 +63,56 @@ Each file exports a single detection entry point matching the Python pattern:
 
 Each function: finds projects on the filesystem → detects running processes → matches them → prompts the user to pick a project → infers entrypoints → returns a plan or `nil`.
 
-### 3. Project detection strategy per runtime
+**Note:** In the unified project list flow, `DetectJavaPlan` / `DetectNodePlan` / `DetectGoPlan` are still available as standalone entry points for direct `dtwiz install otel-java` etc. commands. The unified orchestrator in `otel.go` uses `createRuntimePlan()` which builds plans directly from the selected `detectedProject`, bypassing the per-runtime interactive menus.
 
+### 4. Unified project list replaces runtime menu
+
+Instead of a two-step flow (pick a runtime → pick a project), the orchestrator scans all GA runtimes at once and shows a single list:
+
+```
+  Detected projects:
+  ──────────────────────────────────────────────────
+  [1] Python   /home/user/projects/api  (pyproject.toml)
+  [2] Java     /home/user/projects/svc  (pom.xml)
+  [3] Node.js  /home/user/projects/web  (package.json)  ← PIDs: 1234
+  [4] Skip — collector only
+```
+
+The user picks one project directly. This reduces interaction to a single prompt and gives a complete overview of all detected projects regardless of runtime.
+
+### 5. Project detection strategy per runtime
+
+- **Python**: Scan for `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements.txt`, `Pipfile`, `poetry.lock`, `manage.py`. Detect running `python` processes and match by CWD.
 - **Java**: Scan for `pom.xml`, `build.gradle`, `build.gradle.kts`. Detect running `java` processes and match by CWD.
 - **Node.js**: Scan for `package.json` (excluding `node_modules`). Detect running `node` processes and match by CWD.
-- **Go**: Scan for `go.mod`. Detect running Go binaries by inspecting processes. Note: Go compiles to static binaries, so "auto-instrumentation" means providing OTel SDK integration guidance and env vars rather than attaching an agent.
+- **Go**: Scan for `go.mod`. Note: Go compiles to static binaries, so "auto-instrumentation" means providing OTel SDK integration guidance and env vars rather than attaching an agent.
 
-### 4. Confirmation preview layout
+### 6. Confirmation preview layout
 
-The preview shows `1) OTel Collector` and, if the user selected a runtime, `2) <Runtime> auto-instrumentation` with the plan's details. If the user chose "Skip", only the collector appears.
+The preview shows `1) OTel Collector` and, if the user selected a project, `2) <Runtime> auto-instrumentation` with the plan's details. If the user chose "Skip", only the collector appears.
 
-### 5. Execution
+### 7. Execution
 
 After collector installation completes, the single selected plan (if any) executes. It prints a separator header (`── <Runtime> auto-instrumentation ──`) before its block.
 
-### 6. "Coming soon" for unimplemented runtimes
+### 8. Coming-soon runtimes excluded from scanning
 
-Runtimes detected on PATH but whose installer is not yet implemented are still listed in the selection menu with a "coming soon" suffix (e.g., `[3] Go (coming soon)`). They are not selectable. This gives users visibility into planned support without hiding information.
+Only Python is GA. All other runtimes (Java, Node.js, Go) are "coming soon" by default — their projects are not scanned or shown. The `DTWIZ_ALL_RUNTIMES` environment variable (set to `"true"` or `"1"`) unlocks all runtimes for testing.
 
-**Alternative considered:** Hiding unimplemented runtimes entirely. Rejected because showing them communicates roadmap intent and avoids user confusion when a runtime is installed but not listed.
+**Alternative considered:** Showing coming-soon runtimes in a menu with labels. Rejected — the unified project list shows projects, not runtimes, so there's nothing to label. Coming-soon runtimes are simply excluded from scanning.
 
-### 7. `--dry-run` coverage
+### 9. `--dry-run` coverage
 
-All new flows — runtime detection, selection menu, combined preview — SHALL work under `--dry-run`. When `--dry-run` is set, the menu is printed, the combined plan is shown, but no collector or instrumentation is installed.
+All new flows — project scanning, project list, combined preview — SHALL work under `--dry-run`. When `--dry-run` is set, the project list is printed, the combined plan is shown, but no collector or instrumentation is installed.
 
-### 8. Non-regression: `InstallOtelCollectorOnly()`
+### 10. Non-regression: `InstallOtelCollectorOnly()`
 
-The existing `InstallOtelCollectorOnly()` code path is not modified by this change. It continues to install the collector without any runtime detection or selection menu. All new logic lives in `InstallOtelCollector()` only.
+The existing `InstallOtelCollectorOnly()` code path is not modified by this change. It continues to install the collector without any runtime detection or project list. All new logic lives in `InstallOtelCollector()` only.
 
 ## Risks / Trade-offs
 
-- **[Single runtime per invocation]** → Users who want to instrument multiple runtimes must run `dtwiz install otel` multiple times. Mitigation: this keeps the UX simple and each run focused; multi-runtime support can be added later if needed.
+- **[Single project per invocation]** → Users who want to instrument multiple projects must run `dtwiz install otel` multiple times. Mitigation: this keeps the UX simple and each run focused; multi-project support can be added later if needed.
 - **[Go is fundamentally different]** → Go has no runtime agent. `DetectGoPlan` can detect projects and provide env var configuration + SDK guidance but cannot auto-instrument a running binary. Mitigation: clearly label Go instrumentation as "manual SDK integration" in the preview and execution output.
 - **[Partial execution stubs]** → Java/Node/Go execution may initially be incomplete. Mitigation: the proposal scopes execution as non-goal; stubs print clear guidance on what the user needs to do manually.
 - **[Non-regression risk]** → Changes to `otel.go` could break `InstallOtelCollectorOnly()`. Mitigation: all new logic is scoped to `InstallOtelCollector()` only; existing tests must continue to pass.
+- **[Cross-platform process detection]** → Windows uses PowerShell `Get-CimInstance` which may be slower or unavailable in restricted environments. Mitigation: detection is best-effort; returns nil gracefully on failure.

--- a/openspec/changes/multi-runtime-detection/design.md
+++ b/openspec/changes/multi-runtime-detection/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`InstallOtelCollector` in `otel.go` orchestrates the Dynatrace OTel Collector installation and runtime auto-instrumentation. Today it only detects Python via `DetectPythonPlan`. The codebase already has a partial `otel_java.go` with `detectJava()` and `generateOtelJavaEnvVars()` but no plan struct or detection flow. Node.js and Go have no files at all.
+
+The Python implementation establishes a clear pattern: a `*InstrumentationPlan` struct captures all user choices upfront, detection happens before the confirmation prompt, and execution runs after the collector is installed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend the preparation phase of `InstallOtelCollector` to detect Java, Node.js, and Go runtimes alongside Python.
+- Follow the established pattern: `Detect<Lang>Plan()` → `*<Lang>InstrumentationPlan` with `PrintPlanSteps()` and `Execute()`.
+- Present a single runtime selection menu; the user picks one runtime (or skips). Only one runtime is instrumented per invocation.
+- Keep each runtime's detection and instrumentation logic in its own file (`otel_java.go`, `otel_nodejs.go`, `otel_go.go`).
+
+**Non-Goals:**
+- Full end-to-end execution of Java/Node/Go instrumentation is not required in this change — execution stubs that print TODO/guidance are acceptable. The priority is detection and plan creation.
+- Modifying the existing Python flow.
+- Support for additional runtimes beyond Java, Node.js, Go.
+- Changes to `dtwiz install otel-python` or `dtwiz install otel-java` standalone commands.
+
+## Decisions
+
+### 1. Common InstrumentationPlan interface
+
+Each runtime defines its own struct (`JavaInstrumentationPlan`, `NodeInstrumentationPlan`, `GoInstrumentationPlan`) with the same two methods:
+
+```go
+PrintPlanSteps()           // render preview lines for the combined plan
+Execute()                  // run the actual instrumentation after collector install
+```
+
+No formal Go interface is introduced — the orchestrator in `otel.go` calls the selected plan's methods directly via a nil-check, exactly as it does today for Python. Only one plan is active per invocation. This avoids unnecessary abstraction while keeping the pattern uniform.
+
+**Alternative considered:** A shared `InstrumentationPlan` interface. Rejected because it would require refactoring the existing Python code and the plans have different fields (virtualenv flags, JAR paths, etc.).
+
+**Alternative considered:** Supporting multiple runtime selections in a single invocation. Rejected for now — adds complexity to the confirmation preview, execution ordering, and error handling. Users can re-run `dtwiz install otel` to instrument additional runtimes.
+
+### 2. Detection functions per runtime
+
+Each file exports a single detection entry point matching the Python pattern:
+
+| File | Function | Guard |
+|------|----------|-------|
+| `otel_java.go` | `DetectJavaPlan(apiURL, token string) *JavaInstrumentationPlan` | `exec.LookPath("java")` |
+| `otel_nodejs.go` | `DetectNodePlan(apiURL, token string) *NodeInstrumentationPlan` | `exec.LookPath("node")` |
+| `otel_go.go` | `DetectGoPlan(apiURL, token string) *GoInstrumentationPlan` | `exec.LookPath("go")` |
+
+Each function: finds projects on the filesystem → detects running processes → matches them → prompts the user to pick a project → infers entrypoints → returns a plan or `nil`.
+
+### 3. Project detection strategy per runtime
+
+- **Java**: Scan for `pom.xml`, `build.gradle`, `build.gradle.kts`. Detect running `java` processes and match by CWD.
+- **Node.js**: Scan for `package.json` (excluding `node_modules`). Detect running `node` processes and match by CWD.
+- **Go**: Scan for `go.mod`. Detect running Go binaries by inspecting processes. Note: Go compiles to static binaries, so "auto-instrumentation" means providing OTel SDK integration guidance and env vars rather than attaching an agent.
+
+### 4. Confirmation preview layout
+
+The preview shows `1) OTel Collector` and, if the user selected a runtime, `2) <Runtime> auto-instrumentation` with the plan's details. If the user chose "Skip", only the collector appears.
+
+### 5. Execution
+
+After collector installation completes, the single selected plan (if any) executes. It prints a separator header (`── <Runtime> auto-instrumentation ──`) before its block.
+
+### 6. "Coming soon" for unimplemented runtimes
+
+Runtimes detected on PATH but whose installer is not yet implemented are still listed in the selection menu with a "coming soon" suffix (e.g., `[3] Go (coming soon)`). They are not selectable. This gives users visibility into planned support without hiding information.
+
+**Alternative considered:** Hiding unimplemented runtimes entirely. Rejected because showing them communicates roadmap intent and avoids user confusion when a runtime is installed but not listed.
+
+### 7. `--dry-run` coverage
+
+All new flows — runtime detection, selection menu, combined preview — SHALL work under `--dry-run`. When `--dry-run` is set, the menu is printed, the combined plan is shown, but no collector or instrumentation is installed.
+
+### 8. Non-regression: `InstallOtelCollectorOnly()`
+
+The existing `InstallOtelCollectorOnly()` code path is not modified by this change. It continues to install the collector without any runtime detection or selection menu. All new logic lives in `InstallOtelCollector()` only.
+
+## Risks / Trade-offs
+
+- **[Single runtime per invocation]** → Users who want to instrument multiple runtimes must run `dtwiz install otel` multiple times. Mitigation: this keeps the UX simple and each run focused; multi-runtime support can be added later if needed.
+- **[Go is fundamentally different]** → Go has no runtime agent. `DetectGoPlan` can detect projects and provide env var configuration + SDK guidance but cannot auto-instrument a running binary. Mitigation: clearly label Go instrumentation as "manual SDK integration" in the preview and execution output.
+- **[Partial execution stubs]** → Java/Node/Go execution may initially be incomplete. Mitigation: the proposal scopes execution as non-goal; stubs print clear guidance on what the user needs to do manually.
+- **[Non-regression risk]** → Changes to `otel.go` could break `InstallOtelCollectorOnly()`. Mitigation: all new logic is scoped to `InstallOtelCollector()` only; existing tests must continue to pass.

--- a/openspec/changes/multi-runtime-detection/design.md
+++ b/openspec/changes/multi-runtime-detection/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 `InstallOtelCollector` in `otel.go` orchestrates the Dynatrace OTel Collector installation and runtime auto-instrumentation. Today it only detects Python via `DetectPythonPlan`. The codebase already has a partial `otel_java.go` with `detectJava()` and `generateOtelJavaEnvVars()` but no plan struct or detection flow. Node.js and Go have no files at all.
@@ -7,12 +9,14 @@ The Python implementation establishes a clear pattern: a `*InstrumentationPlan` 
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Extend the preparation phase of `InstallOtelCollector` to detect Java, Node.js, and Go runtimes alongside Python.
 - Follow the established pattern: `Detect<Lang>Plan()` → `*<Lang>InstrumentationPlan` with `PrintPlanSteps()` and `Execute()`.
 - Present a single runtime selection menu; the user picks one runtime (or skips). Only one runtime is instrumented per invocation.
 - Keep each runtime's detection and instrumentation logic in its own file (`otel_java.go`, `otel_nodejs.go`, `otel_go.go`).
 
 **Non-Goals:**
+
 - Full end-to-end execution of Java/Node/Go instrumentation is not required in this change — execution stubs that print TODO/guidance are acceptable. The priority is detection and plan creation.
 - Modifying the existing Python flow.
 - Support for additional runtimes beyond Java, Node.js, Go.

--- a/openspec/changes/multi-runtime-detection/proposal.md
+++ b/openspec/changes/multi-runtime-detection/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 The `InstallOtelCollector` flow currently detects only Python projects during its preparation phase. Java, Node.js, and Go runtimes are ignored, meaning users must manually instrument those applications after the collector is installed. Extending detection to all supported runtimes makes the guided flow language-agnostic and delivers on the zero-config promise.
@@ -15,6 +17,7 @@ The `InstallOtelCollector` flow currently detects only Python projects during it
 ## Capabilities
 
 ### New Capabilities
+
 - `java-runtime-detection`: Detect Java projects/processes, build a `JavaInstrumentationPlan`, and execute auto-instrumentation via the OTel Java agent JAR.
 - `nodejs-runtime-detection`: Detect Node.js projects/processes, build a `NodeInstrumentationPlan`, and execute auto-instrumentation via `@opentelemetry/auto-instrumentations-node`.
 - `go-runtime-detection`: Detect Go projects/binaries, build a `GoInstrumentationPlan`, and provide compile-time instrumentation guidance (Go lacks a runtime agent).

--- a/openspec/changes/multi-runtime-detection/proposal.md
+++ b/openspec/changes/multi-runtime-detection/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `InstallOtelCollector` flow currently detects only Python projects during its preparation phase. Java, Node.js, and Go runtimes are ignored, meaning users must manually instrument those applications after the collector is installed. Extending detection to all supported runtimes makes the guided flow language-agnostic and delivers on the zero-config promise.
+
+## What Changes
+
+- Add `DetectJavaPlan` function and `JavaInstrumentationPlan` struct to `otel_java.go`, following the same pattern as `DetectPythonPlan` / `PythonInstrumentationPlan`.
+- Create `otel_nodejs.go` with `DetectNodePlan` / `NodeInstrumentationPlan` — project discovery via `package.json`, entrypoint detection, npm-based OTel SDK installation.
+- Create `otel_go.go` with `DetectGoPlan` / `GoInstrumentationPlan` — project discovery via `go.mod`, binary detection, guidance for compile-time instrumentation.
+- Update `InstallOtelCollector` in `otel.go` to detect available runtimes, present a single selection menu, and call the corresponding `Detect<Lang>Plan` for the user's choice. Only one runtime is instrumented per invocation.
+- Runtimes whose installer is not yet implemented are shown with a "coming soon" label instead of being hidden.
+- `--dry-run` covers all new flows (runtime selection menu, combined preview).
+- Existing `InstallOtelCollectorOnly()` flow remains unaffected (no regressions).
+
+## Capabilities
+
+### New Capabilities
+- `java-runtime-detection`: Detect Java projects/processes, build a `JavaInstrumentationPlan`, and execute auto-instrumentation via the OTel Java agent JAR.
+- `nodejs-runtime-detection`: Detect Node.js projects/processes, build a `NodeInstrumentationPlan`, and execute auto-instrumentation via `@opentelemetry/auto-instrumentations-node`.
+- `go-runtime-detection`: Detect Go projects/binaries, build a `GoInstrumentationPlan`, and provide compile-time instrumentation guidance (Go lacks a runtime agent).
+- `multi-runtime-orchestration`: Update the collector install flow to detect available runtimes, present a selection menu, and execute the chosen runtime's instrumentation plan alongside the collector install.
+
+### Modified Capabilities
+<!-- No existing specs to modify -->
+
+## Impact
+
+- **Code**: New files `otel_nodejs.go`, `otel_go.go`; extended `otel_java.go`; modified `otel.go` orchestration.
+- **Dependencies**: No new Go module dependencies. Runtime detection uses `exec.LookPath` and filesystem scanning already established by the Python implementation.
+- **UX**: A runtime selection menu lists detected runtimes (plus "Skip — collector only"). The user picks one; its plan is shown in the confirmation preview alongside the collector. Unimplemented runtimes appear with a "coming soon" label. The confirmation prompt remains a single `Proceed? [Y/n]`.
+- **Non-regression**: `InstallOtelCollectorOnly()` path must remain functional and unchanged.

--- a/openspec/changes/multi-runtime-detection/proposal.md
+++ b/openspec/changes/multi-runtime-detection/proposal.md
@@ -7,11 +7,13 @@ The `InstallOtelCollector` flow currently detects only Python projects during it
 ## What Changes
 
 - Add `DetectJavaPlan` function and `JavaInstrumentationPlan` struct to `otel_java.go`, following the same pattern as `DetectPythonPlan` / `PythonInstrumentationPlan`.
-- Create `otel_nodejs.go` with `DetectNodePlan` / `NodeInstrumentationPlan` — project discovery via `package.json`, entrypoint detection, npm-based OTel SDK installation.
-- Create `otel_go.go` with `DetectGoPlan` / `GoInstrumentationPlan` — project discovery via `go.mod`, binary detection, guidance for compile-time instrumentation.
-- Update `InstallOtelCollector` in `otel.go` to detect available runtimes, present a single selection menu, and call the corresponding `Detect<Lang>Plan` for the user's choice. Only one runtime is instrumented per invocation.
-- Runtimes whose installer is not yet implemented are shown with a "coming soon" label instead of being hidden.
-- `--dry-run` covers all new flows (runtime selection menu, combined preview).
+- Create `otel_nodejs.go` with `DetectNodePlan` / `NodeInstrumentationPlan` — project discovery via `package.json`, entrypoint detection (JS and TypeScript), npm-based OTel SDK installation.
+- Create `otel_go.go` with `DetectGoPlan` / `GoInstrumentationPlan` — project discovery via `go.mod`, module name extraction, guidance for compile-time instrumentation.
+- Create `otel_common.go` with shared utilities — `scanProjectDirs()`, `detectProcesses()`, `processMatchPIDs()`, `generateBaseOtelEnvVars()`, `getProcessCWD()` — eliminating duplication across runtime files.
+- Update `InstallOtelCollector` in `otel.go` to detect available runtimes, scan all GA runtimes for projects, and present a single unified project list. The user picks one project (or skips). Only one project is instrumented per invocation.
+- Only Python is GA by default. Java, Node.js, and Go are "coming soon" — their projects are excluded from scanning unless `DTWIZ_ALL_RUNTIMES=true` is set.
+- Process detection works cross-platform: Unix (`ps ax`, `lsof`) and Windows (PowerShell `Get-CimInstance`, `WMIC`).
+- `--dry-run` covers all new flows (project list, combined preview).
 - Existing `InstallOtelCollectorOnly()` flow remains unaffected (no regressions).
 
 ## Capabilities
@@ -19,25 +21,26 @@ The `InstallOtelCollector` flow currently detects only Python projects during it
 ### New Capabilities
 
 - `java-runtime-detection`: Detect Java projects/processes, build a `JavaInstrumentationPlan`, and execute auto-instrumentation via the OTel Java agent JAR.
-- `nodejs-runtime-detection`: Detect Node.js projects/processes, build a `NodeInstrumentationPlan`, and execute auto-instrumentation via `@opentelemetry/auto-instrumentations-node`.
-- `go-runtime-detection`: Detect Go projects/binaries, build a `GoInstrumentationPlan`, and provide compile-time instrumentation guidance (Go lacks a runtime agent).
-- `multi-runtime-orchestration`: Update the collector install flow to detect available runtimes, present a selection menu, and execute the chosen runtime's instrumentation plan alongside the collector install.
+- `nodejs-runtime-detection`: Detect Node.js projects/processes (including TypeScript entrypoints), build a `NodeInstrumentationPlan`, and execute auto-instrumentation via `@opentelemetry/auto-instrumentations-node`.
+- `go-runtime-detection`: Detect Go projects, extract module names, build a `GoInstrumentationPlan`, and provide compile-time instrumentation guidance (Go lacks a runtime agent).
+- `multi-runtime-orchestration`: Update the collector install flow to detect available runtimes, scan all GA runtimes for projects, present a unified project list, and execute the chosen project's instrumentation plan alongside the collector install.
 
 ### Modified Capabilities
 <!-- No existing specs to modify -->
 
 ## Impact
 
-- **Code**: New files `otel_nodejs.go`, `otel_go.go`; extended `otel_java.go`; modified `otel.go` orchestration.
+- **Code**: New files `otel_nodejs.go`, `otel_go.go`, `otel_common.go`; extended `otel_java.go`; rewritten `otel.go` orchestration.
 - **Dependencies**: No new Go module dependencies. Runtime detection uses `exec.LookPath` and filesystem scanning already established by the Python implementation.
-- **UX**: A runtime selection menu lists detected runtimes (plus "Skip — collector only"). The user picks one; its plan is shown in the confirmation preview alongside the collector. Unimplemented runtimes appear with a "coming soon" label. The confirmation prompt remains a single `Proceed? [Y/n]`.
+- **UX**: A unified project list shows all detected projects across GA runtimes (plus "Skip — collector only"). The user picks one project; its plan is shown in the confirmation preview alongside the collector. Coming-soon runtimes are excluded from scanning entirely. The confirmation prompt remains a single `Proceed? [Y/n]`.
 - **Non-regression**: `InstallOtelCollectorOnly()` path must remain functional and unchanged.
 
 ## Rollback Plan
 
-All new code lives in isolated files (`pkg/installer/otel_nodejs.go`, `pkg/installer/otel_go.go`) or additive changes to existing files (`pkg/installer/otel_java.go`, `pkg/installer/otel.go`). To roll back:
+All new code lives in isolated files (`pkg/installer/otel_nodejs.go`, `pkg/installer/otel_go.go`, `pkg/installer/otel_common.go`) or additive changes to existing files (`pkg/installer/otel_java.go`, `pkg/installer/otel.go`). To roll back:
 
-1. **Revert `pkg/installer/otel.go`** — remove the runtime detection menu and selection logic from `InstallOtelCollector()`, restoring the previous Python-only path.
-2. **Delete new files** — remove `pkg/installer/otel_nodejs.go` and `pkg/installer/otel_go.go`.
+1. **Revert `pkg/installer/otel.go`** — remove the unified project list and selection logic from `InstallOtelCollector()`, restoring the previous Python-only path.
+2. **Delete new files** — remove `pkg/installer/otel_nodejs.go`, `pkg/installer/otel_go.go`, and `pkg/installer/otel_common.go`.
 3. **Revert `pkg/installer/otel_java.go`** — remove the `JavaInstrumentationPlan`, `DetectJavaPlan`, and related additions; keep existing `detectJava()` and `generateOtelJavaEnvVars()` unchanged.
-4. No database, config, or external service changes are involved — rollback is purely code deletion and revert.
+4. **Revert `pkg/installer/otel_python.go`** — restore duplicated scanning/process detection code that was refactored into `otel_common.go`.
+5. No database, config, or external service changes are involved — rollback is purely code deletion and revert.

--- a/openspec/changes/multi-runtime-detection/proposal.md
+++ b/openspec/changes/multi-runtime-detection/proposal.md
@@ -20,9 +20,9 @@ The `InstallOtelCollector` flow currently detects only Python projects during it
 
 ### New Capabilities
 
-- `java-runtime-detection`: Detect Java projects/processes, build a `JavaInstrumentationPlan`, and execute auto-instrumentation via the OTel Java agent JAR.
-- `nodejs-runtime-detection`: Detect Node.js projects/processes (including TypeScript entrypoints), build a `NodeInstrumentationPlan`, and execute auto-instrumentation via `@opentelemetry/auto-instrumentations-node`.
-- `go-runtime-detection`: Detect Go projects, extract module names, build a `GoInstrumentationPlan`, and provide compile-time instrumentation guidance (Go lacks a runtime agent).
+- `java-runtime-detection`: Detect Java projects/processes, build a `JavaInstrumentationPlan`, and print instrumentation guidance (agent JAR download, `-javaagent` flag, env vars).
+- `nodejs-runtime-detection`: Detect Node.js projects/processes (including TypeScript entrypoints), build a `NodeInstrumentationPlan`, and print instrumentation guidance (`npm install` commands, env vars, `--require` flag).
+- `go-runtime-detection`: Detect Go projects, extract module names, build a `GoInstrumentationPlan`, and print compile-time instrumentation guidance (`go get` commands, env vars, SDK initialization).
 - `multi-runtime-orchestration`: Update the collector install flow to detect available runtimes, scan all GA runtimes for projects, present a unified project list, and execute the chosen project's instrumentation plan alongside the collector install.
 
 ### Modified Capabilities

--- a/openspec/changes/multi-runtime-detection/proposal.md
+++ b/openspec/changes/multi-runtime-detection/proposal.md
@@ -32,3 +32,12 @@ The `InstallOtelCollector` flow currently detects only Python projects during it
 - **Dependencies**: No new Go module dependencies. Runtime detection uses `exec.LookPath` and filesystem scanning already established by the Python implementation.
 - **UX**: A runtime selection menu lists detected runtimes (plus "Skip — collector only"). The user picks one; its plan is shown in the confirmation preview alongside the collector. Unimplemented runtimes appear with a "coming soon" label. The confirmation prompt remains a single `Proceed? [Y/n]`.
 - **Non-regression**: `InstallOtelCollectorOnly()` path must remain functional and unchanged.
+
+## Rollback Plan
+
+All new code lives in isolated files (`pkg/installer/otel_nodejs.go`, `pkg/installer/otel_go.go`) or additive changes to existing files (`pkg/installer/otel_java.go`, `pkg/installer/otel.go`). To roll back:
+
+1. **Revert `pkg/installer/otel.go`** — remove the runtime detection menu and selection logic from `InstallOtelCollector()`, restoring the previous Python-only path.
+2. **Delete new files** — remove `pkg/installer/otel_nodejs.go` and `pkg/installer/otel_go.go`.
+3. **Revert `pkg/installer/otel_java.go`** — remove the `JavaInstrumentationPlan`, `DetectJavaPlan`, and related additions; keep existing `detectJava()` and `generateOtelJavaEnvVars()` unchanged.
+4. No database, config, or external service changes are involved — rollback is purely code deletion and revert.

--- a/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
@@ -20,7 +20,7 @@ The system SHALL detect Go installations by looking up `go` on PATH and verifyin
 
 ### Requirement: Go project scanning
 
-The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
+The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations. SHALL use the shared `scanProjectDirs()` utility in `pkg/installer/otel_common.go` — NOT duplicate the scanning logic.
 
 #### Scenario: Go project detected
 
@@ -68,7 +68,7 @@ The system SHALL communicate that Go requires compile-time SDK integration and c
 
 ### Requirement: GoInstrumentationPlan struct
 
-The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
+The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`. OTel environment variables SHALL be generated via the shared `generateBaseOtelEnvVars()` in `pkg/installer/otel_common.go` to ensure consistent URL-encoded header values across all runtimes.
 
 #### Scenario: Struct fields populated
 

--- a/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
@@ -8,25 +8,29 @@ The system SHALL detect Go installations by looking up `go` on PATH and verifyin
 
 #### Scenario: Go is available
 
+- **GIVEN** the user selected Go from the runtime selection menu
 - **WHEN** `go` is found on PATH and `go version` succeeds
 - **THEN** the system reports the Go path and version and proceeds with project scanning
 
 #### Scenario: Go is not available
 
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `go` is not found on PATH
 - **THEN** the system silently skips Go detection and returns nil
 
 ### Requirement: Go project scanning
 
-The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations.
+The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: Go project detected
 
+- **GIVEN** Go is available on the system
 - **WHEN** a directory contains `go.mod`
 - **THEN** the system adds it to the list of detected Go projects with marker `go.mod` and extracts the module name from the `module` directive
 
 #### Scenario: No Go projects found
 
+- **GIVEN** Go is available on the system
 - **WHEN** no directories contain `go.mod`
 - **THEN** `DetectGoPlan` returns nil without prompting the user
 
@@ -36,11 +40,13 @@ The system SHALL present discovered Go projects and prompt the user to select on
 
 #### Scenario: User selects a project
 
+- **GIVEN** one or more Go projects are listed
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `GoInstrumentationPlan` for that project
 
 #### Scenario: User skips
 
+- **GIVEN** one or more Go projects are listed
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectGoPlan` returns nil
 
@@ -50,19 +56,22 @@ The system SHALL communicate that Go requires compile-time SDK integration and c
 
 #### Scenario: PrintPlanSteps shows SDK guidance
 
+- **GIVEN** a `GoInstrumentationPlan` was created for a selected project
 - **WHEN** `PrintPlanSteps()` is called on a `GoInstrumentationPlan`
 - **THEN** it prints the project path, required `go get` packages, and environment variables — and labels the step as "SDK integration (manual)"
 
 #### Scenario: Execute prints setup instructions
 
+- **GIVEN** the user confirmed the combined installation plan
 - **WHEN** `Execute()` is called on a `GoInstrumentationPlan`
 - **THEN** it prints the `go get` commands for the OTel Go SDK, generates the environment variable export statements, and clearly states the user must add SDK initialization code to their application
 
 ### Requirement: GoInstrumentationPlan struct
 
-The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: Struct fields populated
 
+- **GIVEN** the user selected a Go project and detection completed
 - **WHEN** `DetectGoPlan` returns a non-nil plan
 - **THEN** the plan contains the project path, module name from `go.mod`, and pre-generated OTel environment variables

--- a/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Go runtime detection
+The system SHALL detect Go installations by looking up `go` on PATH and verifying the version via `go version`.
+
+#### Scenario: Go is available
+- **WHEN** `go` is found on PATH and `go version` succeeds
+- **THEN** the system reports the Go path and version and proceeds with project scanning
+
+#### Scenario: Go is not available
+- **WHEN** `go` is not found on PATH
+- **THEN** the system silently skips Go detection and returns nil
+
+### Requirement: Go project scanning
+The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations.
+
+#### Scenario: Go project detected
+- **WHEN** a directory contains `go.mod`
+- **THEN** the system adds it to the list of detected Go projects with marker `go.mod` and extracts the module name from the `module` directive
+
+#### Scenario: No Go projects found
+- **WHEN** no directories contain `go.mod`
+- **THEN** `DetectGoPlan` returns nil without prompting the user
+
+### Requirement: Go project selection prompt
+The system SHALL present discovered Go projects and prompt the user to select one or skip.
+
+#### Scenario: User selects a project
+- **WHEN** the user enters a valid project number
+- **THEN** the system creates a `GoInstrumentationPlan` for that project
+
+#### Scenario: User skips
+- **WHEN** the user presses Enter without selecting
+- **THEN** `DetectGoPlan` returns nil
+
+### Requirement: Go instrumentation is SDK-based guidance
+The system SHALL communicate that Go requires compile-time SDK integration and cannot be auto-instrumented at runtime like Python or Java. The plan SHALL provide the necessary OTel environment variables and instructions for adding the OpenTelemetry Go SDK to the project.
+
+#### Scenario: PrintPlanSteps shows SDK guidance
+- **WHEN** `PrintPlanSteps()` is called on a `GoInstrumentationPlan`
+- **THEN** it prints the project path, required `go get` packages, and environment variables — and labels the step as "SDK integration (manual)"
+
+#### Scenario: Execute prints setup instructions
+- **WHEN** `Execute()` is called on a `GoInstrumentationPlan`
+- **THEN** it prints the `go get` commands for the OTel Go SDK, generates the environment variable export statements, and clearly states the user must add SDK initialization code to their application
+
+### Requirement: GoInstrumentationPlan struct
+The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+
+#### Scenario: Struct fields populated
+- **WHEN** `DetectGoPlan` returns a non-nil plan
+- **THEN** the plan contains the project path, module name from `go.mod`, and pre-generated OTel environment variables

--- a/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
@@ -8,7 +8,7 @@ The system SHALL detect Go installations by looking up `go` on PATH and verifyin
 
 #### Scenario: Go is available
 
-- **GIVEN** the user selected Go from the runtime selection menu
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `go` is found on PATH and `go version` succeeds
 - **THEN** the system reports the Go path and version and proceeds with project scanning
 
@@ -33,22 +33,6 @@ The system SHALL scan the filesystem for Go project markers (`go.mod`) starting 
 - **GIVEN** Go is available on the system
 - **WHEN** no directories contain `go.mod`
 - **THEN** `DetectGoPlan` returns nil without prompting the user
-
-### Requirement: Go project selection prompt
-
-The system SHALL present discovered Go projects and prompt the user to select one or skip.
-
-#### Scenario: User selects a project
-
-- **GIVEN** one or more Go projects are listed
-- **WHEN** the user enters a valid project number
-- **THEN** the system creates a `GoInstrumentationPlan` for that project
-
-#### Scenario: User skips
-
-- **GIVEN** one or more Go projects are listed
-- **WHEN** the user presses Enter without selecting
-- **THEN** `DetectGoPlan` returns nil
 
 ### Requirement: Go instrumentation is SDK-based guidance
 

--- a/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/go-runtime-detection/spec.md
@@ -1,52 +1,68 @@
+# Go Runtime Detection
+
 ## ADDED Requirements
 
 ### Requirement: Go runtime detection
+
 The system SHALL detect Go installations by looking up `go` on PATH and verifying the version via `go version`.
 
 #### Scenario: Go is available
+
 - **WHEN** `go` is found on PATH and `go version` succeeds
 - **THEN** the system reports the Go path and version and proceeds with project scanning
 
 #### Scenario: Go is not available
+
 - **WHEN** `go` is not found on PATH
 - **THEN** the system silently skips Go detection and returns nil
 
 ### Requirement: Go project scanning
+
 The system SHALL scan the filesystem for Go project markers (`go.mod`) starting from the current directory and common project locations.
 
 #### Scenario: Go project detected
+
 - **WHEN** a directory contains `go.mod`
 - **THEN** the system adds it to the list of detected Go projects with marker `go.mod` and extracts the module name from the `module` directive
 
 #### Scenario: No Go projects found
+
 - **WHEN** no directories contain `go.mod`
 - **THEN** `DetectGoPlan` returns nil without prompting the user
 
 ### Requirement: Go project selection prompt
+
 The system SHALL present discovered Go projects and prompt the user to select one or skip.
 
 #### Scenario: User selects a project
+
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `GoInstrumentationPlan` for that project
 
 #### Scenario: User skips
+
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectGoPlan` returns nil
 
 ### Requirement: Go instrumentation is SDK-based guidance
+
 The system SHALL communicate that Go requires compile-time SDK integration and cannot be auto-instrumented at runtime like Python or Java. The plan SHALL provide the necessary OTel environment variables and instructions for adding the OpenTelemetry Go SDK to the project.
 
 #### Scenario: PrintPlanSteps shows SDK guidance
+
 - **WHEN** `PrintPlanSteps()` is called on a `GoInstrumentationPlan`
 - **THEN** it prints the project path, required `go get` packages, and environment variables — and labels the step as "SDK integration (manual)"
 
 #### Scenario: Execute prints setup instructions
+
 - **WHEN** `Execute()` is called on a `GoInstrumentationPlan`
 - **THEN** it prints the `go get` commands for the OTel Go SDK, generates the environment variable export statements, and clearly states the user must add SDK initialization code to their application
 
 ### Requirement: GoInstrumentationPlan struct
+
 The system SHALL define a `GoInstrumentationPlan` struct with fields for the selected project, module name, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
 
 #### Scenario: Struct fields populated
+
 - **WHEN** `DetectGoPlan` returns a non-nil plan
 - **THEN** the plan contains the project path, module name from `go.mod`, and pre-generated OTel environment variables

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -1,56 +1,73 @@
+# Java Runtime Detection
+
 ## ADDED Requirements
 
 ### Requirement: Java runtime detection
+
 The system SHALL detect Java installations by looking up `java` on PATH and verifying the version via `java -version`.
 
 #### Scenario: Java is available
+
 - **WHEN** `java` is found on PATH and `java -version` succeeds
 - **THEN** the system reports the Java path and version and proceeds with project scanning
 
 #### Scenario: Java is not available
+
 - **WHEN** `java` is not found on PATH
 - **THEN** the system silently skips Java detection and returns nil
 
 ### Requirement: Java project scanning
+
 The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations.
 
 #### Scenario: Maven project detected
+
 - **WHEN** a directory contains `pom.xml`
 - **THEN** the system adds it to the list of detected Java projects with marker `pom.xml`
 
 #### Scenario: Gradle project detected
+
 - **WHEN** a directory contains `build.gradle` or `build.gradle.kts`
 - **THEN** the system adds it to the list of detected Java projects with the corresponding Gradle marker
 
 #### Scenario: No Java projects found
+
 - **WHEN** no directories contain recognized Java project markers
 - **THEN** `DetectJavaPlan` returns nil without prompting the user
 
 ### Requirement: Java process detection
+
 The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory.
 
 #### Scenario: Running Java process matched to project
+
 - **WHEN** a running `java` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
 ### Requirement: Java project selection prompt
+
 The system SHALL present discovered Java projects and prompt the user to select one or skip.
 
 #### Scenario: User selects a project
+
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `JavaInstrumentationPlan` for that project
 
 #### Scenario: User skips
+
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectJavaPlan` returns nil
 
 ### Requirement: JavaInstrumentationPlan struct
+
 The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, the Java agent JAR path, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
 
 #### Scenario: PrintPlanSteps displays plan
+
 - **WHEN** `PrintPlanSteps()` is called
 - **THEN** it prints the project path, agent JAR download URL, and environment variables to be set
 
 #### Scenario: Execute performs instrumentation
+
 - **WHEN** `Execute()` is called
 - **THEN** it downloads the OTel Java agent JAR, sets the required environment variables, and provides the `-javaagent` JVM flag to the user

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -8,30 +8,35 @@ The system SHALL detect Java installations by looking up `java` on PATH and veri
 
 #### Scenario: Java is available
 
+- **GIVEN** the user selected Java from the runtime selection menu
 - **WHEN** `java` is found on PATH and `java -version` succeeds
 - **THEN** the system reports the Java path and version and proceeds with project scanning
 
 #### Scenario: Java is not available
 
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `java` is not found on PATH
 - **THEN** the system silently skips Java detection and returns nil
 
 ### Requirement: Java project scanning
 
-The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations.
+The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: Maven project detected
 
+- **GIVEN** Java is available on the system
 - **WHEN** a directory contains `pom.xml`
 - **THEN** the system adds it to the list of detected Java projects with marker `pom.xml`
 
 #### Scenario: Gradle project detected
 
+- **GIVEN** Java is available on the system
 - **WHEN** a directory contains `build.gradle` or `build.gradle.kts`
 - **THEN** the system adds it to the list of detected Java projects with the corresponding Gradle marker
 
 #### Scenario: No Java projects found
 
+- **GIVEN** Java is available on the system
 - **WHEN** no directories contain recognized Java project markers
 - **THEN** `DetectJavaPlan` returns nil without prompting the user
 
@@ -41,6 +46,7 @@ The system SHALL detect running `java` processes and attempt to match them to di
 
 #### Scenario: Running Java process matched to project
 
+- **GIVEN** one or more Java projects have been detected on the filesystem
 - **WHEN** a running `java` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
@@ -50,24 +56,28 @@ The system SHALL present discovered Java projects and prompt the user to select 
 
 #### Scenario: User selects a project
 
+- **GIVEN** one or more Java projects are listed
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `JavaInstrumentationPlan` for that project
 
 #### Scenario: User skips
 
+- **GIVEN** one or more Java projects are listed
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectJavaPlan` returns nil
 
 ### Requirement: JavaInstrumentationPlan struct
 
-The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, the Java agent JAR path, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, the Java agent JAR path, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: PrintPlanSteps displays plan
 
+- **GIVEN** a `JavaInstrumentationPlan` was created for a selected project
 - **WHEN** `PrintPlanSteps()` is called
 - **THEN** it prints the project path, agent JAR download URL, and environment variables to be set
 
 #### Scenario: Execute performs instrumentation
 
+- **GIVEN** the user confirmed the combined installation plan
 - **WHEN** `Execute()` is called
 - **THEN** it downloads the OTel Java agent JAR, sets the required environment variables, and provides the `-javaagent` JVM flag to the user

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -20,7 +20,7 @@ The system SHALL detect Java installations by looking up `java` on PATH and veri
 
 ### Requirement: Java project scanning
 
-The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
+The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations. SHALL use the shared `scanProjectDirs()` utility in `pkg/installer/otel_common.go` — NOT duplicate the scanning logic.
 
 #### Scenario: Maven project detected
 
@@ -42,7 +42,7 @@ The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build
 
 ### Requirement: Java process detection
 
-The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory.
+The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses `powershell Get-Process` and `WMIC`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
 
 #### Scenario: Running Java process matched to project
 
@@ -68,16 +68,16 @@ The system SHALL present discovered Java projects and prompt the user to select 
 
 ### Requirement: JavaInstrumentationPlan struct
 
-The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, the Java agent JAR path, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
+The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`. OTel environment variables SHALL be generated via the shared `generateBaseOtelEnvVars()` in `pkg/installer/otel_common.go` to ensure consistent URL-encoded header values across all runtimes.
 
 #### Scenario: PrintPlanSteps displays plan
 
 - **GIVEN** a `JavaInstrumentationPlan` was created for a selected project
 - **WHEN** `PrintPlanSteps()` is called
-- **THEN** it prints the project path, agent JAR download URL, and environment variables to be set
+- **THEN** it prints the project path, agent JAR download URL, and the `-javaagent` JVM flag
 
-#### Scenario: Execute performs instrumentation
+#### Scenario: Execute prints instrumentation instructions
 
 - **GIVEN** the user confirmed the combined installation plan
 - **WHEN** `Execute()` is called
-- **THEN** it downloads the OTel Java agent JAR, sets the required environment variables, and provides the `-javaagent` JVM flag to the user
+- **THEN** it prints the agent JAR download URL, the required environment variable export statements, and the `-javaagent` JVM flag — the user downloads the JAR manually

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -8,7 +8,7 @@ The system SHALL detect Java installations by looking up `java` on PATH and veri
 
 #### Scenario: Java is available
 
-- **GIVEN** the user selected Java from the runtime selection menu
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `java` is found on PATH and `java -version` succeeds
 - **THEN** the system reports the Java path and version and proceeds with project scanning
 
@@ -42,7 +42,7 @@ The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build
 
 ### Requirement: Java process detection
 
-The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses `powershell Get-Process` and `WMIC`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
+The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses PowerShell `Get-CimInstance Win32_Process`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
 
 #### Scenario: Running Java process matched to project
 
@@ -50,21 +50,6 @@ The system SHALL detect running `java` processes and attempt to match them to di
 - **WHEN** a running `java` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
-### Requirement: Java project selection prompt
-
-The system SHALL present discovered Java projects and prompt the user to select one or skip.
-
-#### Scenario: User selects a project
-
-- **GIVEN** one or more Java projects are listed
-- **WHEN** the user enters a valid project number
-- **THEN** the system creates a `JavaInstrumentationPlan` for that project
-
-#### Scenario: User skips
-
-- **GIVEN** one or more Java projects are listed
-- **WHEN** the user presses Enter without selecting
-- **THEN** `DetectJavaPlan` returns nil
 
 ### Requirement: JavaInstrumentationPlan struct
 

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Java runtime detection
+The system SHALL detect Java installations by looking up `java` on PATH and verifying the version via `java -version`.
+
+#### Scenario: Java is available
+- **WHEN** `java` is found on PATH and `java -version` succeeds
+- **THEN** the system reports the Java path and version and proceeds with project scanning
+
+#### Scenario: Java is not available
+- **WHEN** `java` is not found on PATH
+- **THEN** the system silently skips Java detection and returns nil
+
+### Requirement: Java project scanning
+The system SHALL scan the filesystem for Java project markers (`pom.xml`, `build.gradle`, `build.gradle.kts`) starting from the current directory and common project locations.
+
+#### Scenario: Maven project detected
+- **WHEN** a directory contains `pom.xml`
+- **THEN** the system adds it to the list of detected Java projects with marker `pom.xml`
+
+#### Scenario: Gradle project detected
+- **WHEN** a directory contains `build.gradle` or `build.gradle.kts`
+- **THEN** the system adds it to the list of detected Java projects with the corresponding Gradle marker
+
+#### Scenario: No Java projects found
+- **WHEN** no directories contain recognized Java project markers
+- **THEN** `DetectJavaPlan` returns nil without prompting the user
+
+### Requirement: Java process detection
+The system SHALL detect running `java` processes and attempt to match them to discovered projects by working directory.
+
+#### Scenario: Running Java process matched to project
+- **WHEN** a running `java` process has a CWD matching a detected project directory
+- **THEN** the project listing shows the associated PIDs
+
+### Requirement: Java project selection prompt
+The system SHALL present discovered Java projects and prompt the user to select one or skip.
+
+#### Scenario: User selects a project
+- **WHEN** the user enters a valid project number
+- **THEN** the system creates a `JavaInstrumentationPlan` for that project
+
+#### Scenario: User skips
+- **WHEN** the user presses Enter without selecting
+- **THEN** `DetectJavaPlan` returns nil
+
+### Requirement: JavaInstrumentationPlan struct
+The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, the Java agent JAR path, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+
+#### Scenario: PrintPlanSteps displays plan
+- **WHEN** `PrintPlanSteps()` is called
+- **THEN** it prints the project path, agent JAR download URL, and environment variables to be set
+
+#### Scenario: Execute performs instrumentation
+- **WHEN** `Execute()` is called
+- **THEN** it downloads the OTel Java agent JAR, sets the required environment variables, and provides the `-javaagent` JVM flag to the user

--- a/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/java-runtime-detection/spec.md
@@ -50,7 +50,6 @@ The system SHALL detect running `java` processes and attempt to match them to di
 - **WHEN** a running `java` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
-
 ### Requirement: JavaInstrumentationPlan struct
 
 The system SHALL define a `JavaInstrumentationPlan` struct with fields for the selected project, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`. OTel environment variables SHALL be generated via the shared `generateBaseOtelEnvVars()` in `pkg/installer/otel_common.go` to ensure consistent URL-encoded header values across all runtimes.

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -1,100 +1,129 @@
+# Multi-Runtime Orchestration
+
 ## ADDED Requirements
 
 ### Requirement: Runtime selection menu
+
 The `InstallOtelCollector` function SHALL detect available runtimes via `exec.LookPath` and present them as a numbered selection menu. The menu SHALL include a "Skip — collector only" option. The user selects exactly one runtime to instrument (or skips). Only one runtime plan is created per invocation.
 
 #### Scenario: Multiple runtimes available
+
 - **WHEN** `python3`, `java`, and `node` are on PATH
 - **THEN** the menu shows `[1] Python`, `[2] Java`, `[3] Node.js`, `[4] Skip — collector only` and the user picks one
 
 #### Scenario: Only one runtime available
+
 - **WHEN** only `python3` is on PATH
 - **THEN** the menu shows `[1] Python`, `[2] Skip — collector only`
 
 #### Scenario: No runtimes available
+
 - **WHEN** no runtime binaries are found on PATH
 - **THEN** the system skips the menu and proceeds with collector-only installation
 
 ### Requirement: Project listing after runtime selection
+
 After the user selects a runtime from the menu, the system SHALL call the corresponding `Detect<Lang>Plan` function, which lists discovered projects and prompts the user to select one (exactly as the existing Python flow does).
 
 #### Scenario: User selects Python and projects exist
+
 - **WHEN** the user picks Python from the menu and Python projects are found
 - **THEN** the system lists Python projects with `Select a project to instrument [1-N] or press Enter to skip:`
 
 #### Scenario: User selects a runtime but no projects found
+
 - **WHEN** the user picks Java from the menu but no `pom.xml` or `build.gradle` files exist
 - **THEN** `DetectJavaPlan` returns nil and the system proceeds with collector-only installation
 
 ### Requirement: Confirmation preview
+
 After the user selects a project (or skips), the system SHALL show a confirmation preview. Step 1 is always the OTel Collector; if a runtime plan was created, it appears as step 2. This preview is followed by a single `Proceed with installation?` prompt.
 
 #### Scenario: User selected a Python project
+
 - **WHEN** the user picked a Python project in the selection phase
 - **THEN** the confirmation preview shows `1) OTel Collector` with directory/binary details, `2) Python auto-instrumentation` with plan steps, then `Proceed with installation? [Y/n]`
 
 #### Scenario: User skipped or no project found
+
 - **WHEN** the user chose "Skip" or the selected runtime had no projects
 - **THEN** the confirmation preview shows only `1) OTel Collector` and proceeds to confirmation
 
 ### Requirement: Single confirmation prompt
+
 The system SHALL show a single `Proceed with installation?` prompt that covers the collector and the selected runtime plan (if any). There SHALL NOT be separate confirmation prompts for collector and runtime.
 
 #### Scenario: User confirms
+
 - **WHEN** the user answers yes to the confirmation prompt
 - **THEN** the collector is installed first, followed by execution of the selected runtime plan (if any)
 
 #### Scenario: User cancels
+
 - **WHEN** the user answers no
 - **THEN** no collector or instrumentation is installed
 
 ### Requirement: Runtime plan execution
+
 After the collector is installed successfully, the system SHALL execute the selected runtime plan (if non-nil). The plan's execution block SHALL be preceded by a separator header identifying the runtime.
 
 #### Scenario: Plan executes after collector
+
 - **WHEN** the user selected Python and confirmed
 - **THEN** the collector installs, then `pythonPlan.Execute()` runs with header `── Python auto-instrumentation ──`
 
 #### Scenario: Collector only
+
 - **WHEN** no runtime was selected
 - **THEN** only the collector installs, no instrumentation execution occurs
 
 ### Requirement: Header text mentions runtime presence
+
 When a runtime plan is selected, the introductory message SHALL state that the collector and application instrumentation will be installed. When no runtime is selected, the message SHALL only mention the collector.
 
 #### Scenario: Runtime selected
+
 - **WHEN** the user selected a runtime and a plan was created
 - **THEN** the intro message reads "This will install the OTel Collector and auto-instrument your application."
 
 #### Scenario: No runtime selected
+
 - **WHEN** the user chose "Skip" or no plan was created
 - **THEN** the intro message is omitted or states collector-only installation
 
 ### Requirement: Unimplemented runtimes shown as "coming soon"
+
 Runtimes detected on PATH whose installer is not yet implemented SHALL appear in the selection menu with a "coming soon" label. They SHALL NOT be selectable.
 
 #### Scenario: Runtime detected but not implemented
+
 - **WHEN** `go` is found on PATH but `GoInstrumentationPlan` execution is not yet implemented
 - **THEN** the menu shows `[N] Go (coming soon)` and selecting it prints a message that it is not yet available
 
 #### Scenario: All runtimes implemented
+
 - **WHEN** all detected runtimes have full installer implementations
 - **THEN** no "coming soon" labels appear and all entries are selectable
 
 ### Requirement: Dry-run support for new flows
+
 When `--dry-run` is set, the runtime selection menu and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
 
 #### Scenario: Dry-run with runtimes detected
+
 - **WHEN** `--dry-run` is set and runtimes are detected
 - **THEN** the system prints the selection menu, shows the combined plan preview, and exits without installing anything
 
 #### Scenario: Dry-run without runtimes
+
 - **WHEN** `--dry-run` is set and no runtimes are detected
 - **THEN** the system prints the collector-only dry-run plan as before
 
 ### Requirement: InstallOtelCollectorOnly non-regression
+
 The existing `InstallOtelCollectorOnly()` function SHALL NOT be modified by this change. It SHALL continue to install the collector without runtime detection or selection.
 
 #### Scenario: InstallOtelCollectorOnly unchanged
+
 - **WHEN** a user invokes the collector-only install path
 - **THEN** the behavior is identical to before this change — no runtime menu, no selection prompt, no instrumentation

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -12,12 +12,6 @@ The `InstallOtelCollector` function in `pkg/installer/otel.go` SHALL detect avai
 - **WHEN** `java` and `node` are on PATH and Java/Node.js projects exist
 - **THEN** the list shows e.g. `[1] Java     /home/user/projects/api  (pom.xml)`, `[2] Node.js  /home/user/projects/web  (package.json)`, `[3] Skip — collector only` and the user picks one
 
-#### Scenario: Single project detected
-
-- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
-- **WHEN** only one Java project is found
-- **THEN** the list shows `[1] Java     /home/user/projects/api  (pom.xml)`, `[2] Skip — collector only`
-
 #### Scenario: No projects detected
 
 - **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Runtime selection menu
+The `InstallOtelCollector` function SHALL detect available runtimes via `exec.LookPath` and present them as a numbered selection menu. The menu SHALL include a "Skip — collector only" option. The user selects exactly one runtime to instrument (or skips). Only one runtime plan is created per invocation.
+
+#### Scenario: Multiple runtimes available
+- **WHEN** `python3`, `java`, and `node` are on PATH
+- **THEN** the menu shows `[1] Python`, `[2] Java`, `[3] Node.js`, `[4] Skip — collector only` and the user picks one
+
+#### Scenario: Only one runtime available
+- **WHEN** only `python3` is on PATH
+- **THEN** the menu shows `[1] Python`, `[2] Skip — collector only`
+
+#### Scenario: No runtimes available
+- **WHEN** no runtime binaries are found on PATH
+- **THEN** the system skips the menu and proceeds with collector-only installation
+
+### Requirement: Project listing after runtime selection
+After the user selects a runtime from the menu, the system SHALL call the corresponding `Detect<Lang>Plan` function, which lists discovered projects and prompts the user to select one (exactly as the existing Python flow does).
+
+#### Scenario: User selects Python and projects exist
+- **WHEN** the user picks Python from the menu and Python projects are found
+- **THEN** the system lists Python projects with `Select a project to instrument [1-N] or press Enter to skip:`
+
+#### Scenario: User selects a runtime but no projects found
+- **WHEN** the user picks Java from the menu but no `pom.xml` or `build.gradle` files exist
+- **THEN** `DetectJavaPlan` returns nil and the system proceeds with collector-only installation
+
+### Requirement: Confirmation preview
+After the user selects a project (or skips), the system SHALL show a confirmation preview. Step 1 is always the OTel Collector; if a runtime plan was created, it appears as step 2. This preview is followed by a single `Proceed with installation?` prompt.
+
+#### Scenario: User selected a Python project
+- **WHEN** the user picked a Python project in the selection phase
+- **THEN** the confirmation preview shows `1) OTel Collector` with directory/binary details, `2) Python auto-instrumentation` with plan steps, then `Proceed with installation? [Y/n]`
+
+#### Scenario: User skipped or no project found
+- **WHEN** the user chose "Skip" or the selected runtime had no projects
+- **THEN** the confirmation preview shows only `1) OTel Collector` and proceeds to confirmation
+
+### Requirement: Single confirmation prompt
+The system SHALL show a single `Proceed with installation?` prompt that covers the collector and the selected runtime plan (if any). There SHALL NOT be separate confirmation prompts for collector and runtime.
+
+#### Scenario: User confirms
+- **WHEN** the user answers yes to the confirmation prompt
+- **THEN** the collector is installed first, followed by execution of the selected runtime plan (if any)
+
+#### Scenario: User cancels
+- **WHEN** the user answers no
+- **THEN** no collector or instrumentation is installed
+
+### Requirement: Runtime plan execution
+After the collector is installed successfully, the system SHALL execute the selected runtime plan (if non-nil). The plan's execution block SHALL be preceded by a separator header identifying the runtime.
+
+#### Scenario: Plan executes after collector
+- **WHEN** the user selected Python and confirmed
+- **THEN** the collector installs, then `pythonPlan.Execute()` runs with header `── Python auto-instrumentation ──`
+
+#### Scenario: Collector only
+- **WHEN** no runtime was selected
+- **THEN** only the collector installs, no instrumentation execution occurs
+
+### Requirement: Header text mentions runtime presence
+When a runtime plan is selected, the introductory message SHALL state that the collector and application instrumentation will be installed. When no runtime is selected, the message SHALL only mention the collector.
+
+#### Scenario: Runtime selected
+- **WHEN** the user selected a runtime and a plan was created
+- **THEN** the intro message reads "This will install the OTel Collector and auto-instrument your application."
+
+#### Scenario: No runtime selected
+- **WHEN** the user chose "Skip" or no plan was created
+- **THEN** the intro message is omitted or states collector-only installation
+
+### Requirement: Unimplemented runtimes shown as "coming soon"
+Runtimes detected on PATH whose installer is not yet implemented SHALL appear in the selection menu with a "coming soon" label. They SHALL NOT be selectable.
+
+#### Scenario: Runtime detected but not implemented
+- **WHEN** `go` is found on PATH but `GoInstrumentationPlan` execution is not yet implemented
+- **THEN** the menu shows `[N] Go (coming soon)` and selecting it prints a message that it is not yet available
+
+#### Scenario: All runtimes implemented
+- **WHEN** all detected runtimes have full installer implementations
+- **THEN** no "coming soon" labels appear and all entries are selectable
+
+### Requirement: Dry-run support for new flows
+When `--dry-run` is set, the runtime selection menu and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
+
+#### Scenario: Dry-run with runtimes detected
+- **WHEN** `--dry-run` is set and runtimes are detected
+- **THEN** the system prints the selection menu, shows the combined plan preview, and exits without installing anything
+
+#### Scenario: Dry-run without runtimes
+- **WHEN** `--dry-run` is set and no runtimes are detected
+- **THEN** the system prints the collector-only dry-run plan as before
+
+### Requirement: InstallOtelCollectorOnly non-regression
+The existing `InstallOtelCollectorOnly()` function SHALL NOT be modified by this change. It SHALL continue to install the collector without runtime detection or selection.
+
+#### Scenario: InstallOtelCollectorOnly unchanged
+- **WHEN** a user invokes the collector-only install path
+- **THEN** the behavior is identical to before this change — no runtime menu, no selection prompt, no instrumentation

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -2,43 +2,49 @@
 
 ## ADDED Requirements
 
-### Requirement: Runtime selection menu
+### Requirement: Unified project listing
 
-The `InstallOtelCollector` function in `pkg/installer/otel.go` SHALL detect available runtimes via `exec.LookPath` and present them as a numbered selection menu. The menu SHALL include a "Skip — collector only" option. The user selects exactly one runtime to instrument (or skips). Only one runtime plan is created per invocation.
+The `InstallOtelCollector` function in `pkg/installer/otel.go` SHALL detect available runtimes via `exec.LookPath`, scan for projects across all GA runtimes, and present a single unified project list. Each entry shows the runtime name, project path, marker files, and any running PIDs. The list SHALL include a "Skip — collector only" option. The user selects exactly one project to instrument (or skips). There is no runtime selection menu — the user picks a project directly.
 
-#### Scenario: Multiple runtimes available
-
-- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
-- **WHEN** `python3`, `java`, and `node` are on PATH
-- **THEN** the menu shows `[1] Python`, `[2] Java`, `[3] Node.js`, `[4] Skip — collector only` and the user picks one
-
-#### Scenario: Only one runtime available
+#### Scenario: Multiple runtimes and projects detected
 
 - **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
-- **WHEN** only `python3` is on PATH
-- **THEN** the menu shows `[1] Python`, `[2] Skip — collector only`
+- **WHEN** `java` and `node` are on PATH and Java/Node.js projects exist
+- **THEN** the list shows e.g. `[1] Java     /home/user/projects/api  (pom.xml)`, `[2] Node.js  /home/user/projects/web  (package.json)`, `[3] Skip — collector only` and the user picks one
 
-#### Scenario: No runtimes available
+#### Scenario: Single project detected
 
 - **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
-- **WHEN** no runtime binaries are found on PATH
-- **THEN** the system skips the menu and proceeds with collector-only installation
+- **WHEN** only one Java project is found
+- **THEN** the list shows `[1] Java     /home/user/projects/api  (pom.xml)`, `[2] Skip — collector only`
 
-### Requirement: Project listing after runtime selection
+#### Scenario: No projects detected
 
-After the user selects a runtime from the menu, the system SHALL call the corresponding `Detect<Lang>Plan` function, which lists discovered projects and prompts the user to select one (exactly as the existing Python flow does in `pkg/installer/otel_python.go`).
+- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
+- **WHEN** no project directories are found for any GA runtime
+- **THEN** the system skips the project list and proceeds with collector-only installation
 
-#### Scenario: User selects Python and projects exist
+### Requirement: Runtime plan creation from selected project
 
-- **GIVEN** the runtime selection menu was shown
-- **WHEN** the user picks Python from the menu and Python projects are found
-- **THEN** the system lists Python projects with `Select a project to instrument [1-N] or press Enter to skip:`
+After the user selects a project, the system SHALL create the appropriate instrumentation plan based on the project's runtime. For runtimes that require entrypoint detection (Python, Node.js), the system detects entrypoints automatically and prompts only if none are found.
 
-#### Scenario: User selects a runtime but no projects found
+#### Scenario: User selects a Java project
 
-- **GIVEN** the runtime selection menu was shown
-- **WHEN** the user picks Java from the menu but no `pom.xml` or `build.gradle` files exist
-- **THEN** `DetectJavaPlan` returns nil and the system proceeds with collector-only installation
+- **GIVEN** the unified project list is displayed
+- **WHEN** the user picks a Java project
+- **THEN** the system creates a `JavaInstrumentationPlan` for that project
+
+#### Scenario: User selects a Node.js project with detected entrypoint
+
+- **GIVEN** the unified project list is displayed
+- **WHEN** the user picks a Node.js project that has a `package.json` with a `main` field
+- **THEN** the system creates a `NodeInstrumentationPlan` with the detected entrypoint — no extra prompt
+
+#### Scenario: User selects a Python project with no entrypoint
+
+- **GIVEN** the unified project list is displayed
+- **WHEN** the user picks a Python project and no entrypoint is auto-detected
+- **THEN** the system prompts `No entrypoint detected. Enter the Python file to run (e.g. app.py):`
 
 ### Requirement: Confirmation preview
 
@@ -46,13 +52,13 @@ After the user selects a project (or skips), the system SHALL show a confirmatio
 
 #### Scenario: User selected a Python project
 
-- **GIVEN** the user picked Python from the runtime menu and selected a project
+- **GIVEN** the user picked a Python project from the list and an entrypoint was determined
 - **WHEN** the confirmation preview is rendered
 - **THEN** it shows `1) OTel Collector` with directory/binary details, `2) Python auto-instrumentation` with plan steps, then `Proceed with installation? [Y/n]`
 
 #### Scenario: User skipped or no project found
 
-- **GIVEN** the user chose "Skip" or the selected runtime had no projects
+- **GIVEN** the user chose "Skip" or no projects were detected
 - **WHEN** the confirmation preview is rendered
 - **THEN** it shows only `1) OTel Collector` and proceeds to confirmation
 
@@ -78,13 +84,13 @@ After the collector is installed successfully, the system SHALL execute the sele
 
 #### Scenario: Plan executes after collector
 
-- **GIVEN** the user selected Python, confirmed, and the collector installed successfully
+- **GIVEN** the user selected a Python project, confirmed, and the collector installed successfully
 - **WHEN** the runtime plan execution phase begins
 - **THEN** `pythonPlan.Execute()` runs with header `── Python auto-instrumentation ──`
 
 #### Scenario: Collector only
 
-- **GIVEN** no runtime was selected or the plan was nil
+- **GIVEN** no project was selected or the plan was nil
 - **WHEN** the collector installation completes
 - **THEN** no instrumentation execution occurs
 
@@ -94,7 +100,7 @@ When a runtime plan is selected, the introductory message SHALL state that the c
 
 #### Scenario: Runtime selected
 
-- **GIVEN** the user selected a runtime and a plan was created
+- **GIVEN** the user selected a project and a plan was created
 - **WHEN** the intro message is printed
 - **THEN** it reads "This will install the OTel Collector and auto-instrument your application."
 
@@ -104,36 +110,36 @@ When a runtime plan is selected, the introductory message SHALL state that the c
 - **WHEN** the intro message is printed
 - **THEN** the message is omitted or states collector-only installation
 
-### Requirement: Unimplemented runtimes shown as "coming soon"
+### Requirement: Coming-soon runtimes excluded from project scanning
 
-Runtimes detected on PATH whose installer is not yet implemented SHALL appear in the selection menu with a "coming soon" label. They SHALL NOT be selectable.
+Only Python is considered GA for runtime instrumentation. All other runtimes (Java, Node.js, Go) are "coming soon" by default — their projects SHALL NOT be scanned or shown. The `comingSoon` flag is controlled by a package-level function that checks the `DTWIZ_ALL_RUNTIMES` environment variable. When `DTWIZ_ALL_RUNTIMES=true` is set, all runtimes are treated as GA, enabling end-to-end testing of unreleased runtimes.
 
-#### Scenario: Runtime detected but not implemented
+#### Scenario: Default behavior — only Python projects shown
 
-- **GIVEN** the runtime detection phase found `go` on PATH
-- **WHEN** `GoInstrumentationPlan` execution is not yet implemented
-- **THEN** the menu shows `[N] Go (coming soon)` and selecting it prints a message that it is not yet available
+- **GIVEN** the `DTWIZ_ALL_RUNTIMES` env var is not set
+- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
+- **THEN** only Python projects appear in the unified list (Java, Node.js, Go projects are not scanned)
 
-#### Scenario: All runtimes implemented
+#### Scenario: All runtimes unlocked for testing
 
-- **GIVEN** all detected runtimes have full installer implementations
-- **WHEN** the runtime selection menu is rendered
-- **THEN** no "coming soon" labels appear and all entries are selectable
+- **GIVEN** `DTWIZ_ALL_RUNTIMES=true` is set in the environment
+- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
+- **THEN** projects from all four runtimes appear in the unified list
 
-### Requirement: Dry-run support for new flows
+### Requirement: Dry-run support
 
-When `--dry-run` is set, the runtime selection menu and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
+When `--dry-run` is set, the unified project list and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
 
-#### Scenario: Dry-run with runtimes detected
-
-- **GIVEN** `--dry-run` is set on the `install otel` command
-- **WHEN** runtimes are detected on PATH
-- **THEN** the system prints the selection menu, shows the combined plan preview, and exits without installing anything
-
-#### Scenario: Dry-run without runtimes
+#### Scenario: Dry-run with projects detected
 
 - **GIVEN** `--dry-run` is set on the `install otel` command
-- **WHEN** no runtimes are detected
+- **WHEN** projects are detected across GA runtimes
+- **THEN** the system prints the unified project list, shows the collector dry-run plan, and exits without installing anything
+
+#### Scenario: Dry-run without projects
+
+- **GIVEN** `--dry-run` is set on the `install otel` command
+- **WHEN** no projects are detected
 - **THEN** the system prints the collector-only dry-run plan as before
 
 ### Requirement: InstallOtelCollectorOnly non-regression
@@ -144,4 +150,4 @@ The existing `InstallOtelCollectorOnly()` function in `pkg/installer/otel.go` SH
 
 - **GIVEN** a user invokes the collector-only install path via `InstallOtelCollectorOnly()`
 - **WHEN** the function executes
-- **THEN** the behavior is identical to before this change — no runtime menu, no selection prompt, no instrumentation
+- **THEN** the behavior is identical to before this change — no project list, no selection prompt, no instrumentation

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -4,34 +4,39 @@
 
 ### Requirement: Runtime selection menu
 
-The `InstallOtelCollector` function SHALL detect available runtimes via `exec.LookPath` and present them as a numbered selection menu. The menu SHALL include a "Skip — collector only" option. The user selects exactly one runtime to instrument (or skips). Only one runtime plan is created per invocation.
+The `InstallOtelCollector` function in `pkg/installer/otel.go` SHALL detect available runtimes via `exec.LookPath` and present them as a numbered selection menu. The menu SHALL include a "Skip — collector only" option. The user selects exactly one runtime to instrument (or skips). Only one runtime plan is created per invocation.
 
 #### Scenario: Multiple runtimes available
 
+- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
 - **WHEN** `python3`, `java`, and `node` are on PATH
 - **THEN** the menu shows `[1] Python`, `[2] Java`, `[3] Node.js`, `[4] Skip — collector only` and the user picks one
 
 #### Scenario: Only one runtime available
 
+- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
 - **WHEN** only `python3` is on PATH
 - **THEN** the menu shows `[1] Python`, `[2] Skip — collector only`
 
 #### Scenario: No runtimes available
 
+- **GIVEN** an OTel Collector installation is in progress via `InstallOtelCollector`
 - **WHEN** no runtime binaries are found on PATH
 - **THEN** the system skips the menu and proceeds with collector-only installation
 
 ### Requirement: Project listing after runtime selection
 
-After the user selects a runtime from the menu, the system SHALL call the corresponding `Detect<Lang>Plan` function, which lists discovered projects and prompts the user to select one (exactly as the existing Python flow does).
+After the user selects a runtime from the menu, the system SHALL call the corresponding `Detect<Lang>Plan` function, which lists discovered projects and prompts the user to select one (exactly as the existing Python flow does in `pkg/installer/otel_python.go`).
 
 #### Scenario: User selects Python and projects exist
 
+- **GIVEN** the runtime selection menu was shown
 - **WHEN** the user picks Python from the menu and Python projects are found
 - **THEN** the system lists Python projects with `Select a project to instrument [1-N] or press Enter to skip:`
 
 #### Scenario: User selects a runtime but no projects found
 
+- **GIVEN** the runtime selection menu was shown
 - **WHEN** the user picks Java from the menu but no `pom.xml` or `build.gradle` files exist
 - **THEN** `DetectJavaPlan` returns nil and the system proceeds with collector-only installation
 
@@ -41,13 +46,15 @@ After the user selects a project (or skips), the system SHALL show a confirmatio
 
 #### Scenario: User selected a Python project
 
-- **WHEN** the user picked a Python project in the selection phase
-- **THEN** the confirmation preview shows `1) OTel Collector` with directory/binary details, `2) Python auto-instrumentation` with plan steps, then `Proceed with installation? [Y/n]`
+- **GIVEN** the user picked Python from the runtime menu and selected a project
+- **WHEN** the confirmation preview is rendered
+- **THEN** it shows `1) OTel Collector` with directory/binary details, `2) Python auto-instrumentation` with plan steps, then `Proceed with installation? [Y/n]`
 
 #### Scenario: User skipped or no project found
 
-- **WHEN** the user chose "Skip" or the selected runtime had no projects
-- **THEN** the confirmation preview shows only `1) OTel Collector` and proceeds to confirmation
+- **GIVEN** the user chose "Skip" or the selected runtime had no projects
+- **WHEN** the confirmation preview is rendered
+- **THEN** it shows only `1) OTel Collector` and proceeds to confirmation
 
 ### Requirement: Single confirmation prompt
 
@@ -55,11 +62,13 @@ The system SHALL show a single `Proceed with installation?` prompt that covers t
 
 #### Scenario: User confirms
 
+- **GIVEN** the confirmation preview is displayed with collector and optional runtime plan
 - **WHEN** the user answers yes to the confirmation prompt
 - **THEN** the collector is installed first, followed by execution of the selected runtime plan (if any)
 
 #### Scenario: User cancels
 
+- **GIVEN** the confirmation preview is displayed
 - **WHEN** the user answers no
 - **THEN** no collector or instrumentation is installed
 
@@ -69,13 +78,15 @@ After the collector is installed successfully, the system SHALL execute the sele
 
 #### Scenario: Plan executes after collector
 
-- **WHEN** the user selected Python and confirmed
-- **THEN** the collector installs, then `pythonPlan.Execute()` runs with header `── Python auto-instrumentation ──`
+- **GIVEN** the user selected Python, confirmed, and the collector installed successfully
+- **WHEN** the runtime plan execution phase begins
+- **THEN** `pythonPlan.Execute()` runs with header `── Python auto-instrumentation ──`
 
 #### Scenario: Collector only
 
-- **WHEN** no runtime was selected
-- **THEN** only the collector installs, no instrumentation execution occurs
+- **GIVEN** no runtime was selected or the plan was nil
+- **WHEN** the collector installation completes
+- **THEN** no instrumentation execution occurs
 
 ### Requirement: Header text mentions runtime presence
 
@@ -83,13 +94,15 @@ When a runtime plan is selected, the introductory message SHALL state that the c
 
 #### Scenario: Runtime selected
 
-- **WHEN** the user selected a runtime and a plan was created
-- **THEN** the intro message reads "This will install the OTel Collector and auto-instrument your application."
+- **GIVEN** the user selected a runtime and a plan was created
+- **WHEN** the intro message is printed
+- **THEN** it reads "This will install the OTel Collector and auto-instrument your application."
 
 #### Scenario: No runtime selected
 
-- **WHEN** the user chose "Skip" or no plan was created
-- **THEN** the intro message is omitted or states collector-only installation
+- **GIVEN** the user chose "Skip" or no plan was created
+- **WHEN** the intro message is printed
+- **THEN** the message is omitted or states collector-only installation
 
 ### Requirement: Unimplemented runtimes shown as "coming soon"
 
@@ -97,12 +110,14 @@ Runtimes detected on PATH whose installer is not yet implemented SHALL appear in
 
 #### Scenario: Runtime detected but not implemented
 
-- **WHEN** `go` is found on PATH but `GoInstrumentationPlan` execution is not yet implemented
+- **GIVEN** the runtime detection phase found `go` on PATH
+- **WHEN** `GoInstrumentationPlan` execution is not yet implemented
 - **THEN** the menu shows `[N] Go (coming soon)` and selecting it prints a message that it is not yet available
 
 #### Scenario: All runtimes implemented
 
-- **WHEN** all detected runtimes have full installer implementations
+- **GIVEN** all detected runtimes have full installer implementations
+- **WHEN** the runtime selection menu is rendered
 - **THEN** no "coming soon" labels appear and all entries are selectable
 
 ### Requirement: Dry-run support for new flows
@@ -111,19 +126,22 @@ When `--dry-run` is set, the runtime selection menu and combined preview SHALL b
 
 #### Scenario: Dry-run with runtimes detected
 
-- **WHEN** `--dry-run` is set and runtimes are detected
+- **GIVEN** `--dry-run` is set on the `install otel` command
+- **WHEN** runtimes are detected on PATH
 - **THEN** the system prints the selection menu, shows the combined plan preview, and exits without installing anything
 
 #### Scenario: Dry-run without runtimes
 
-- **WHEN** `--dry-run` is set and no runtimes are detected
+- **GIVEN** `--dry-run` is set on the `install otel` command
+- **WHEN** no runtimes are detected
 - **THEN** the system prints the collector-only dry-run plan as before
 
 ### Requirement: InstallOtelCollectorOnly non-regression
 
-The existing `InstallOtelCollectorOnly()` function SHALL NOT be modified by this change. It SHALL continue to install the collector without runtime detection or selection.
+The existing `InstallOtelCollectorOnly()` function in `pkg/installer/otel.go` SHALL NOT be modified by this change. It SHALL continue to install the collector without runtime detection or selection.
 
 #### Scenario: InstallOtelCollectorOnly unchanged
 
-- **WHEN** a user invokes the collector-only install path
+- **GIVEN** a user invokes the collector-only install path via `InstallOtelCollectorOnly()`
+- **WHEN** the function executes
 - **THEN** the behavior is identical to before this change — no runtime menu, no selection prompt, no instrumentation

--- a/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/multi-runtime-orchestration/spec.md
@@ -98,50 +98,14 @@ When a runtime plan is selected, the introductory message SHALL state that the c
 - **WHEN** the intro message is printed
 - **THEN** it reads "This will install the OTel Collector and auto-instrument your application."
 
-#### Scenario: No runtime selected
+#### Scenario: User skipped runtime selection
 
-- **GIVEN** the user chose "Skip" or no plan was created
+- **GIVEN** the user chose "Skip" from the unified project list
 - **WHEN** the intro message is printed
-- **THEN** the message is omitted or states collector-only installation
+- **THEN** the message is omitted
 
-### Requirement: Coming-soon runtimes excluded from project scanning
+#### Scenario: No projects detected
 
-Only Python is considered GA for runtime instrumentation. All other runtimes (Java, Node.js, Go) are "coming soon" by default — their projects SHALL NOT be scanned or shown. The `comingSoon` flag is controlled by a package-level function that checks the `DTWIZ_ALL_RUNTIMES` environment variable. When `DTWIZ_ALL_RUNTIMES=true` is set, all runtimes are treated as GA, enabling end-to-end testing of unreleased runtimes.
-
-#### Scenario: Default behavior — only Python projects shown
-
-- **GIVEN** the `DTWIZ_ALL_RUNTIMES` env var is not set
-- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
-- **THEN** only Python projects appear in the unified list (Java, Node.js, Go projects are not scanned)
-
-#### Scenario: All runtimes unlocked for testing
-
-- **GIVEN** `DTWIZ_ALL_RUNTIMES=true` is set in the environment
-- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
-- **THEN** projects from all four runtimes appear in the unified list
-
-### Requirement: Dry-run support
-
-When `--dry-run` is set, the unified project list and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
-
-#### Scenario: Dry-run with projects detected
-
-- **GIVEN** `--dry-run` is set on the `install otel` command
-- **WHEN** projects are detected across GA runtimes
-- **THEN** the system prints the unified project list, shows the collector dry-run plan, and exits without installing anything
-
-#### Scenario: Dry-run without projects
-
-- **GIVEN** `--dry-run` is set on the `install otel` command
-- **WHEN** no projects are detected
-- **THEN** the system prints the collector-only dry-run plan as before
-
-### Requirement: InstallOtelCollectorOnly non-regression
-
-The existing `InstallOtelCollectorOnly()` function in `pkg/installer/otel.go` SHALL NOT be modified by this change. It SHALL continue to install the collector without runtime detection or selection.
-
-#### Scenario: InstallOtelCollectorOnly unchanged
-
-- **GIVEN** a user invokes the collector-only install path via `InstallOtelCollectorOnly()`
-- **WHEN** the function executes
-- **THEN** the behavior is identical to before this change — no project list, no selection prompt, no instrumentation
+- **GIVEN** no plan was created because no projects were found for any GA runtime
+- **WHEN** the intro message is printed
+- **THEN** the message states collector-only installation

--- a/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
@@ -8,7 +8,7 @@ The system SHALL detect Node.js installations by looking up `node` on PATH and v
 
 #### Scenario: Node.js is available
 
-- **GIVEN** the user selected Node.js from the runtime selection menu
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `node` is found on PATH and `node --version` succeeds
 - **THEN** the system reports the Node.js path and version and proceeds with project scanning
 
@@ -36,29 +36,13 @@ The system SHALL scan the filesystem for Node.js project markers (`package.json`
 
 ### Requirement: Node.js process detection
 
-The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses `powershell Get-Process` and `WMIC`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
+The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses PowerShell `Get-CimInstance Win32_Process`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
 
 #### Scenario: Running Node process matched to project
 
 - **GIVEN** one or more Node.js projects have been detected on the filesystem
 - **WHEN** a running `node` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
-
-### Requirement: Node.js project selection prompt
-
-The system SHALL present discovered Node.js projects and prompt the user to select one or skip.
-
-#### Scenario: User selects a project
-
-- **GIVEN** one or more Node.js projects are listed
-- **WHEN** the user enters a valid project number
-- **THEN** the system creates a `NodeInstrumentationPlan` for that project
-
-#### Scenario: User skips
-
-- **GIVEN** one or more Node.js projects are listed
-- **WHEN** the user presses Enter without selecting
-- **THEN** `DetectNodePlan` returns nil
 
 ### Requirement: Node.js entrypoint detection
 
@@ -96,4 +80,4 @@ The system SHALL define a `NodeInstrumentationPlan` struct with fields for the s
 
 - **GIVEN** the user confirmed the combined installation plan
 - **WHEN** `Execute()` is called
-- **THEN** it installs `@opentelemetry/auto-instrumentations-node` and related packages via npm, configures environment variables, and launches the entrypoint with `--require @opentelemetry/auto-instrumentations-node/register`
+- **THEN** it prints the `npm install` command for `@opentelemetry/auto-instrumentations-node` and related packages, the required environment variable export statements, and the instrumented run command with `--require @opentelemetry/auto-instrumentations-node/register` — the user runs these commands manually

--- a/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
@@ -1,67 +1,87 @@
+# Node.js Runtime Detection
+
 ## ADDED Requirements
 
 ### Requirement: Node.js runtime detection
+
 The system SHALL detect Node.js installations by looking up `node` on PATH and verifying the version via `node --version`.
 
 #### Scenario: Node.js is available
+
 - **WHEN** `node` is found on PATH and `node --version` succeeds
 - **THEN** the system reports the Node.js path and version and proceeds with project scanning
 
 #### Scenario: Node.js is not available
+
 - **WHEN** `node` is not found on PATH
 - **THEN** the system silently skips Node.js detection and returns nil
 
 ### Requirement: Node.js project scanning
+
 The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories.
 
 #### Scenario: Node.js project detected
+
 - **WHEN** a directory contains `package.json` and is not inside a `node_modules` directory
 - **THEN** the system adds it to the list of detected Node.js projects with marker `package.json`
 
 #### Scenario: No Node.js projects found
+
 - **WHEN** no directories contain `package.json` outside of `node_modules`
 - **THEN** `DetectNodePlan` returns nil without prompting the user
 
 ### Requirement: Node.js process detection
+
 The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory.
 
 #### Scenario: Running Node process matched to project
+
 - **WHEN** a running `node` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
 ### Requirement: Node.js project selection prompt
+
 The system SHALL present discovered Node.js projects and prompt the user to select one or skip.
 
 #### Scenario: User selects a project
+
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `NodeInstrumentationPlan` for that project
 
 #### Scenario: User skips
+
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectNodePlan` returns nil
 
 ### Requirement: Node.js entrypoint detection
+
 The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.start`) or common filenames (`index.js`, `app.js`, `server.js`).
 
 #### Scenario: Entrypoint found in package.json
+
 - **WHEN** `package.json` has a `main` field or `scripts.start` field
 - **THEN** the system uses that as the entrypoint
 
 #### Scenario: Entrypoint found by convention
+
 - **WHEN** `package.json` does not specify an entrypoint but `index.js`, `app.js`, or `server.js` exists in the project root
 - **THEN** the system uses the first matching file as the entrypoint
 
 #### Scenario: No entrypoint detected
+
 - **WHEN** no entrypoint can be inferred
 - **THEN** the system prompts the user to enter the entrypoint file manually
 
 ### Requirement: NodeInstrumentationPlan struct
+
 The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
 
 #### Scenario: PrintPlanSteps displays plan
+
 - **WHEN** `PrintPlanSteps()` is called
 - **THEN** it prints the project path, npm packages to install, and the instrumented run command
 
 #### Scenario: Execute performs instrumentation
+
 - **WHEN** `Execute()` is called
 - **THEN** it installs `@opentelemetry/auto-instrumentations-node` and related packages via npm, configures environment variables, and launches the entrypoint with `--require @opentelemetry/auto-instrumentations-node/register`

--- a/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
@@ -20,7 +20,7 @@ The system SHALL detect Node.js installations by looking up `node` on PATH and v
 
 ### Requirement: Node.js project scanning
 
-The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
+The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories. SHALL use the shared `scanProjectDirs()` utility in `pkg/installer/otel_common.go` with `excludeNames: ["node_modules"]` — NOT duplicate the scanning logic.
 
 #### Scenario: Node.js project detected
 
@@ -36,7 +36,7 @@ The system SHALL scan the filesystem for Node.js project markers (`package.json`
 
 ### Requirement: Node.js process detection
 
-The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory.
+The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory. SHALL use the shared `detectProcesses()` and `processMatchPIDs()` utilities in `pkg/installer/otel_common.go`. On Unix, process detection uses `ps ax` and `lsof`. On Windows, it uses `powershell Get-Process` and `WMIC`. Both are best-effort — they may fail on processes owned by other users or on systems with restricted permissions.
 
 #### Scenario: Running Node process matched to project
 
@@ -62,7 +62,7 @@ The system SHALL present discovered Node.js projects and prompt the user to sele
 
 ### Requirement: Node.js entrypoint detection
 
-The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.start`) or common filenames (`index.js`, `app.js`, `server.js`).
+The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.start`) or common filenames. Recognized file extensions include `.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, and `.cts`. Convention fallbacks SHALL check both `.js` and `.ts` variants for each base name (`index`, `app`, `server`).
 
 #### Scenario: Entrypoint found in package.json
 
@@ -73,7 +73,7 @@ The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.
 #### Scenario: Entrypoint found by convention
 
 - **GIVEN** the user selected a Node.js project
-- **WHEN** `package.json` does not specify an entrypoint but `index.js`, `app.js`, or `server.js` exists in the project root
+- **WHEN** `package.json` does not specify an entrypoint but `index.js`, `index.ts`, `app.js`, `app.ts`, `server.js`, or `server.ts` exists in the project root
 - **THEN** the system uses the first matching file as the entrypoint
 
 #### Scenario: No entrypoint detected
@@ -84,7 +84,7 @@ The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.
 
 ### Requirement: NodeInstrumentationPlan struct
 
-The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
+The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`. OTel environment variables SHALL be generated via the shared `generateBaseOtelEnvVars()` in `pkg/installer/otel_common.go` to ensure consistent URL-encoded header values across all runtimes.
 
 #### Scenario: PrintPlanSteps displays plan
 

--- a/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Node.js runtime detection
+The system SHALL detect Node.js installations by looking up `node` on PATH and verifying the version via `node --version`.
+
+#### Scenario: Node.js is available
+- **WHEN** `node` is found on PATH and `node --version` succeeds
+- **THEN** the system reports the Node.js path and version and proceeds with project scanning
+
+#### Scenario: Node.js is not available
+- **WHEN** `node` is not found on PATH
+- **THEN** the system silently skips Node.js detection and returns nil
+
+### Requirement: Node.js project scanning
+The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories.
+
+#### Scenario: Node.js project detected
+- **WHEN** a directory contains `package.json` and is not inside a `node_modules` directory
+- **THEN** the system adds it to the list of detected Node.js projects with marker `package.json`
+
+#### Scenario: No Node.js projects found
+- **WHEN** no directories contain `package.json` outside of `node_modules`
+- **THEN** `DetectNodePlan` returns nil without prompting the user
+
+### Requirement: Node.js process detection
+The system SHALL detect running `node` processes and attempt to match them to discovered projects by working directory.
+
+#### Scenario: Running Node process matched to project
+- **WHEN** a running `node` process has a CWD matching a detected project directory
+- **THEN** the project listing shows the associated PIDs
+
+### Requirement: Node.js project selection prompt
+The system SHALL present discovered Node.js projects and prompt the user to select one or skip.
+
+#### Scenario: User selects a project
+- **WHEN** the user enters a valid project number
+- **THEN** the system creates a `NodeInstrumentationPlan` for that project
+
+#### Scenario: User skips
+- **WHEN** the user presses Enter without selecting
+- **THEN** `DetectNodePlan` returns nil
+
+### Requirement: Node.js entrypoint detection
+The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.start`) or common filenames (`index.js`, `app.js`, `server.js`).
+
+#### Scenario: Entrypoint found in package.json
+- **WHEN** `package.json` has a `main` field or `scripts.start` field
+- **THEN** the system uses that as the entrypoint
+
+#### Scenario: Entrypoint found by convention
+- **WHEN** `package.json` does not specify an entrypoint but `index.js`, `app.js`, or `server.js` exists in the project root
+- **THEN** the system uses the first matching file as the entrypoint
+
+#### Scenario: No entrypoint detected
+- **WHEN** no entrypoint can be inferred
+- **THEN** the system prompts the user to enter the entrypoint file manually
+
+### Requirement: NodeInstrumentationPlan struct
+The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+
+#### Scenario: PrintPlanSteps displays plan
+- **WHEN** `PrintPlanSteps()` is called
+- **THEN** it prints the project path, npm packages to install, and the instrumented run command
+
+#### Scenario: Execute performs instrumentation
+- **WHEN** `Execute()` is called
+- **THEN** it installs `@opentelemetry/auto-instrumentations-node` and related packages via npm, configures environment variables, and launches the entrypoint with `--require @opentelemetry/auto-instrumentations-node/register`

--- a/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/nodejs-runtime-detection/spec.md
@@ -8,25 +8,29 @@ The system SHALL detect Node.js installations by looking up `node` on PATH and v
 
 #### Scenario: Node.js is available
 
+- **GIVEN** the user selected Node.js from the runtime selection menu
 - **WHEN** `node` is found on PATH and `node --version` succeeds
 - **THEN** the system reports the Node.js path and version and proceeds with project scanning
 
 #### Scenario: Node.js is not available
 
+- **GIVEN** the system is checking for available runtimes
 - **WHEN** `node` is not found on PATH
 - **THEN** the system silently skips Node.js detection and returns nil
 
 ### Requirement: Node.js project scanning
 
-The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories.
+The system SHALL scan the filesystem for Node.js project markers (`package.json`) starting from the current directory and common project locations, excluding `node_modules` directories. Follows the same scanning pattern established by `DetectPythonPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: Node.js project detected
 
+- **GIVEN** Node.js is available on the system
 - **WHEN** a directory contains `package.json` and is not inside a `node_modules` directory
 - **THEN** the system adds it to the list of detected Node.js projects with marker `package.json`
 
 #### Scenario: No Node.js projects found
 
+- **GIVEN** Node.js is available on the system
 - **WHEN** no directories contain `package.json` outside of `node_modules`
 - **THEN** `DetectNodePlan` returns nil without prompting the user
 
@@ -36,6 +40,7 @@ The system SHALL detect running `node` processes and attempt to match them to di
 
 #### Scenario: Running Node process matched to project
 
+- **GIVEN** one or more Node.js projects have been detected on the filesystem
 - **WHEN** a running `node` process has a CWD matching a detected project directory
 - **THEN** the project listing shows the associated PIDs
 
@@ -45,11 +50,13 @@ The system SHALL present discovered Node.js projects and prompt the user to sele
 
 #### Scenario: User selects a project
 
+- **GIVEN** one or more Node.js projects are listed
 - **WHEN** the user enters a valid project number
 - **THEN** the system creates a `NodeInstrumentationPlan` for that project
 
 #### Scenario: User skips
 
+- **GIVEN** one or more Node.js projects are listed
 - **WHEN** the user presses Enter without selecting
 - **THEN** `DetectNodePlan` returns nil
 
@@ -59,29 +66,34 @@ The system SHALL infer entrypoints from `package.json` fields (`main`, `scripts.
 
 #### Scenario: Entrypoint found in package.json
 
+- **GIVEN** the user selected a Node.js project
 - **WHEN** `package.json` has a `main` field or `scripts.start` field
 - **THEN** the system uses that as the entrypoint
 
 #### Scenario: Entrypoint found by convention
 
+- **GIVEN** the user selected a Node.js project
 - **WHEN** `package.json` does not specify an entrypoint but `index.js`, `app.js`, or `server.js` exists in the project root
 - **THEN** the system uses the first matching file as the entrypoint
 
 #### Scenario: No entrypoint detected
 
-- **WHEN** no entrypoint can be inferred
+- **GIVEN** the user selected a Node.js project
+- **WHEN** no entrypoint can be inferred from `package.json` or conventional filenames
 - **THEN** the system prompts the user to enter the entrypoint file manually
 
 ### Requirement: NodeInstrumentationPlan struct
 
-The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods.
+The system SHALL define a `NodeInstrumentationPlan` struct with fields for the selected project, entrypoints, OTel environment variables, `EnvURL`, and `PlatformToken`. It SHALL implement `PrintPlanSteps()` and `Execute()` methods. Follows the pattern established by `PythonInstrumentationPlan` in `pkg/installer/otel_python.go`.
 
 #### Scenario: PrintPlanSteps displays plan
 
+- **GIVEN** a `NodeInstrumentationPlan` was created for a selected project
 - **WHEN** `PrintPlanSteps()` is called
 - **THEN** it prints the project path, npm packages to install, and the instrumented run command
 
 #### Scenario: Execute performs instrumentation
 
+- **GIVEN** the user confirmed the combined installation plan
 - **WHEN** `Execute()` is called
 - **THEN** it installs `@opentelemetry/auto-instrumentations-node` and related packages via npm, configures environment variables, and launches the entrypoint with `--require @opentelemetry/auto-instrumentations-node/register`

--- a/openspec/changes/multi-runtime-detection/specs/runtime-gating/spec.md
+++ b/openspec/changes/multi-runtime-detection/specs/runtime-gating/spec.md
@@ -1,0 +1,45 @@
+# Runtime Gating
+
+## ADDED Requirements
+
+### Requirement: Coming-soon runtimes excluded from project scanning
+
+Only Python is considered GA for runtime instrumentation. All other runtimes (Java, Node.js, Go) are "coming soon" by default — their projects SHALL NOT be scanned or shown. The `enabled` flag is controlled by a package-level function that checks the `DTWIZ_ALL_RUNTIMES` environment variable. When `DTWIZ_ALL_RUNTIMES=true` is set, all runtimes are treated as GA, enabling end-to-end testing of unreleased runtimes.
+
+#### Scenario: Default behavior — only Python projects shown
+
+- **GIVEN** the `DTWIZ_ALL_RUNTIMES` env var is not set
+- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
+- **THEN** only Python projects appear in the unified list (Java, Node.js, Go projects are not scanned)
+
+#### Scenario: All runtimes unlocked for testing
+
+- **GIVEN** `DTWIZ_ALL_RUNTIMES=true` is set in the environment
+- **WHEN** `python3`, `java`, `node`, and `go` are on PATH
+- **THEN** projects from all four runtimes appear in the unified list
+
+### Requirement: Dry-run support
+
+When `--dry-run` is set, the unified project list and combined preview SHALL be printed but no collector or instrumentation SHALL be installed.
+
+#### Scenario: Dry-run with projects detected
+
+- **GIVEN** `--dry-run` is set on the `install otel` command
+- **WHEN** projects are detected across GA runtimes
+- **THEN** the system prints the unified project list, shows the collector dry-run plan, and exits without installing anything
+
+#### Scenario: Dry-run without projects
+
+- **GIVEN** `--dry-run` is set on the `install otel` command
+- **WHEN** no projects are detected
+- **THEN** the system prints the collector-only dry-run plan as before
+
+### Requirement: Collector-only path unaffected by runtime detection
+
+The collector-only installation path SHALL install the OTel Collector without presenting a project list, prompting for runtime selection, or performing any instrumentation.
+
+#### Scenario: Collector-only install skips runtime detection
+
+- **GIVEN** a collector-only installation is initiated
+- **WHEN** the installation runs
+- **THEN** no project list is shown, no runtime is selected, and only the collector is installed

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -37,7 +37,7 @@ Add project scanning, process detection, entrypoint detection (JS + TypeScript),
 - [ ] 3.3 Add `detectNodeEntrypoints()` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js` (including TypeScript variants `.ts`/`.mts`/`.cts`)
 - [ ] 3.4 Define `NodeInstrumentationPlan` struct and `generateOtelNodeEnvVars()`
 - [ ] 3.5 Implement `DetectNodePlan(apiURL, token)` — project listing, user prompt, entrypoint detection, plan assembly
-- [ ] 3.6 Implement `PrintPlanSteps()` and `Execute()` — npm install OTel packages, launch with `--require` flag
+- [ ] 3.6 Implement `PrintPlanSteps()` and `Execute()` — print `npm install` commands for OTel packages, env vars, and instrumented run command with `--require` flag
 - [ ] 3.7 Add tests: project detected, `node_modules` excluded, entrypoint from `main`/`scripts.start`/fallback, TypeScript variants, no entrypoint returns empty
 
 ## 4. Go runtime detection and plan

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -1,0 +1,53 @@
+## 1. Java Detection & Plan
+
+- [ ] 1.1 Add `JavaProject` struct and `detectJavaProjects()` scanner (scan for `pom.xml`, `build.gradle`, `build.gradle.kts`) in `otel_java.go`
+- [ ] 1.2 Add `detectJavaProcesses()` and `matchJavaProcessesToProjects()` in `otel_java.go`
+- [ ] 1.3 Define `JavaInstrumentationPlan` struct with project, agent JAR path, env vars, `EnvURL`, `PlatformToken`
+- [ ] 1.4 Implement `DetectJavaPlan(apiURL, token string) *JavaInstrumentationPlan` — project listing, user prompt, plan assembly
+- [ ] 1.5 Implement `PrintPlanSteps()` on `JavaInstrumentationPlan`
+- [ ] 1.6 Implement `Execute()` on `JavaInstrumentationPlan` — download agent JAR, print `-javaagent` flag and env vars
+
+## 2. Node.js Detection & Plan
+
+- [ ] 2.1 Create `otel_nodejs.go` with `NodeProject` struct and `detectNodeProjects()` scanner (scan for `package.json`, exclude `node_modules`)
+- [ ] 2.2 Add `detectNodeProcesses()` and `matchNodeProcessesToProjects()` in `otel_nodejs.go`
+- [ ] 2.3 Add `detectNodeEntrypoints()` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js`
+- [ ] 2.4 Define `NodeInstrumentationPlan` struct with project, entrypoints, env vars, `EnvURL`, `PlatformToken`
+- [ ] 2.5 Implement `DetectNodePlan(apiURL, token string) *NodeInstrumentationPlan` — project listing, user prompt, entrypoint detection, plan assembly
+- [ ] 2.6 Implement `PrintPlanSteps()` on `NodeInstrumentationPlan`
+- [ ] 2.7 Implement `Execute()` on `NodeInstrumentationPlan` — npm install OTel packages, launch with `--require` flag
+- [ ] 2.8 Add `generateOtelNodeEnvVars()` function
+
+## 3. Go Detection & Plan
+
+- [ ] 3.1 Create `otel_go.go` with `GoProject` struct and `detectGoProjects()` scanner (scan for `go.mod`, extract module name)
+- [ ] 3.2 Define `GoInstrumentationPlan` struct with project, module name, env vars, `EnvURL`, `PlatformToken`
+- [ ] 3.3 Implement `DetectGoPlan(apiURL, token string) *GoInstrumentationPlan` — project listing, user prompt, plan assembly
+- [ ] 3.4 Implement `PrintPlanSteps()` on `GoInstrumentationPlan` — label as "SDK integration (manual)"
+- [ ] 3.5 Implement `Execute()` on `GoInstrumentationPlan` — print `go get` commands, env vars, and SDK initialization guidance
+- [ ] 3.6 Add `generateOtelGoEnvVars()` function
+
+## 4. Orchestration in otel.go
+
+- [ ] 4.1 Add `detectAvailableRuntimes()` that uses `exec.LookPath` for each runtime and returns the list of available ones
+- [ ] 4.2 Add runtime selection menu with "Skip — collector only" option and "coming soon" labels
+- [ ] 4.3 Call the selected runtime's `Detect<Lang>Plan` after menu selection
+- [ ] 4.4 Update confirmation preview to show collector + at most one runtime plan
+- [ ] 4.5 Update intro message to reflect whether a runtime was selected
+- [ ] 4.6 Add execution block for the selected plan after collector install, with separator header
+- [ ] 4.7 Pass `EnvURL`, `PlatformToken`, and generated env vars to the selected plan before execution
+
+## 5. Coming Soon & Dry-Run
+
+- [ ] 5.1 Add "coming soon" label rendering for unimplemented runtimes in the selection menu
+- [ ] 5.2 Ensure unimplemented runtime entries are not selectable (print "not yet available" on selection)
+- [ ] 5.3 Ensure `--dry-run` prints the runtime selection menu and combined preview without installing
+- [ ] 5.4 Verify `InstallOtelCollectorOnly()` is not modified and existing tests pass
+
+## 6. Testing
+
+- [ ] 6.1 Add unit tests for `detectJavaProjects()` with temp directory fixtures
+- [ ] 6.2 Add unit tests for `detectNodeProjects()` with temp directory fixtures (including `node_modules` exclusion)
+- [ ] 6.3 Add unit tests for `detectGoProjects()` and module name extraction
+- [ ] 6.4 Add unit tests for "coming soon" label logic
+- [ ] 6.5 Run `make test` and `make lint` to verify no regressions

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -59,12 +59,12 @@ Replace the runtime selection menu with a unified project list across all GA run
 **Files:** `pkg/installer/otel.go` (modify), `pkg/installer/otel_test.go` (modify)
 
 - [ ] 5.1 Add `allRuntimesEnabled()` checking `DTWIZ_ALL_RUNTIMES` env var (`"true"` or `"1"`)
-- [ ] 5.2 Update `detectAvailableRuntimes()` — Python `comingSoon: false`, Java/Node.js/Go `comingSoon: !unlockAll`
-- [ ] 5.3 Add `detectedProject` struct and `detectAllProjects(runtimes)` — scan all GA runtimes, skip coming-soon, return unified list
+- [ ] 5.2 Update `detectAvailableRuntimes()` — Python `enabled: true`, Java/Node.js/Go `enabled: allEnabled`
+- [ ] 5.3 Add `detectedProject` struct and `detectAllProjects(runtimes)` — scan all enabled runtimes, skip disabled, return unified list
 - [ ] 5.4 Add `printProjectList()` and `selectProject()` for unified project selection UX
 - [ ] 5.5 Add `createRuntimePlan()` to dispatch plan creation based on selected project's runtime
 - [ ] 5.6 Rewrite `InstallOtelCollector()` — scan projects, show unified list, create plan, show combined preview, execute after collector install
 - [ ] 5.7 Ensure `--dry-run` prints the project list and combined preview without installing
 - [ ] 5.8 Verify `InstallOtelCollectorOnly()` is not modified
-- [ ] 5.9 Add tests: `detectAvailableRuntimes` coming-soon defaults (Python GA), `DTWIZ_ALL_RUNTIMES=true` unlocks all, `printProjectList` formatting, `detectAllProjects` skips coming-soon / includes all when unlocked
+- [ ] 5.9 Add tests: `detectAvailableRuntimes` enabled defaults (Python enabled), `DTWIZ_ALL_RUNTIMES=true` enables all, `printProjectList` formatting, `detectAllProjects` skips disabled / includes all when unlocked
 - [ ] 5.10 Run `make test` and `make lint` to verify no regressions

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -1,59 +1,70 @@
 # Tasks
 
-## 1. Java Detection & Plan
+## 1. Shared utilities and Python refactor
 
-- [ ] 1.1 Add `JavaProject` struct and `detectJavaProjects()` scanner (scan for `pom.xml`, `build.gradle`, `build.gradle.kts`) in `pkg/installer/otel_java.go`
-- [ ] 1.2 Add `detectJavaProcesses()` and `matchJavaProcessesToProjects()` in `pkg/installer/otel_java.go`
-- [ ] 1.3 Define `JavaInstrumentationPlan` struct with project, agent JAR path, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_java.go`
-- [ ] 1.4 Implement `DetectJavaPlan(apiURL, token string) *JavaInstrumentationPlan` — project listing, user prompt, plan assembly in `pkg/installer/otel_java.go`
-- [ ] 1.5 Implement `PrintPlanSteps()` on `JavaInstrumentationPlan`
-- [ ] 1.6 Implement `Execute()` on `JavaInstrumentationPlan` — download agent JAR, print `-javaagent` flag and env vars
+Extract duplicated scanning, process detection, and env var generation from `otel_python.go` into a new shared module. Refactor Python to use the shared code. This is the foundation all subsequent tasks depend on.
 
-## 2. Node.js Detection & Plan
+**Files:** `pkg/installer/otel_common.go` (create), `pkg/installer/otel_python.go` (modify)
 
-- [ ] 2.1 Create `pkg/installer/otel_nodejs.go` with `NodeProject` struct and `detectNodeProjects()` scanner (scan for `package.json`, exclude `node_modules`)
-- [ ] 2.2 Add `detectNodeProcesses()` and `matchNodeProcessesToProjects()` in `pkg/installer/otel_nodejs.go`
-- [ ] 2.3 Add `detectNodeEntrypoints()` in `pkg/installer/otel_nodejs.go` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js`
-- [ ] 2.4 Define `NodeInstrumentationPlan` struct with project, entrypoints, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_nodejs.go`
-- [ ] 2.5 Implement `DetectNodePlan(apiURL, token string) *NodeInstrumentationPlan` — project listing, user prompt, entrypoint detection, plan assembly in `pkg/installer/otel_nodejs.go`
-- [ ] 2.6 Implement `PrintPlanSteps()` on `NodeInstrumentationPlan`
-- [ ] 2.7 Implement `Execute()` on `NodeInstrumentationPlan` — npm install OTel packages, launch with `--require` flag
-- [ ] 2.8 Add `generateOtelNodeEnvVars()` function in `pkg/installer/otel_nodejs.go`
+- [ ] 1.1 Create `otel_common.go` with `scanProjectDirs(markers, excludeNames)` — scans CWD + home-directory project locations for directories containing marker files
+- [ ] 1.2 Add `detectProcesses(filterTerm, excludeTerms)` — Unix: `ps ax`/`lsof`; Windows: PowerShell `Get-CimInstance Win32_Process`
+- [ ] 1.3 Add `getProcessCWD(pid)` — Unix: `lsof`; Windows: `Get-CimInstance` executable path fallback
+- [ ] 1.4 Add `processMatchPIDs(dirPath, procs)` — match processes to project directories by CWD or command line
+- [ ] 1.5 Add `generateBaseOtelEnvVars(apiURL, token, serviceName)` — common OTEL_* env vars shared by all runtimes
+- [ ] 1.6 Refactor `otel_python.go` to call shared `scanProjectDirs`, `detectProcesses`, `processMatchPIDs`, and `generateBaseOtelEnvVars` instead of its own duplicated implementations
 
-## 3. Go Detection & Plan
+## 2. Java runtime detection and plan
 
-- [ ] 3.1 Create `pkg/installer/otel_go.go` with `GoProject` struct and `detectGoProjects()` scanner (scan for `go.mod`, extract module name)
-- [ ] 3.2 Define `GoInstrumentationPlan` struct with project, module name, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_go.go`
-- [ ] 3.3 Implement `DetectGoPlan(apiURL, token string) *GoInstrumentationPlan` — project listing, user prompt, plan assembly in `pkg/installer/otel_go.go`
-- [ ] 3.4 Implement `PrintPlanSteps()` on `GoInstrumentationPlan` — label as "SDK integration (manual)"
-- [ ] 3.5 Implement `Execute()` on `GoInstrumentationPlan` — print `go get` commands, env vars, and SDK initialization guidance
-- [ ] 3.6 Add `generateOtelGoEnvVars()` function in `pkg/installer/otel_go.go`
+Add project scanning, process detection, and instrumentation plan for Java. Depends on task 1 (shared utilities).
 
-## 4. Orchestration in `pkg/installer/otel.go`
+**Files:** `pkg/installer/otel_java.go` (modify), `pkg/installer/otel_java_test.go` (create)
 
-- [ ] 4.1 Add `detectAvailableRuntimes()` in `pkg/installer/otel.go` that uses `exec.LookPath` for each runtime and returns the list of available ones
-- [ ] 4.2 Add runtime selection menu with "Skip — collector only" option and "coming soon" labels in `pkg/installer/otel.go`
-- [ ] 4.3 Call the selected runtime's `Detect<Lang>Plan` after menu selection in `InstallOtelCollector()`
-- [ ] 4.4 Update confirmation preview to show collector + at most one runtime plan in `InstallOtelCollector()`
-- [ ] 4.5 Update intro message to reflect whether a runtime was selected
-- [ ] 4.6 Add execution block for the selected plan after collector install, with separator header
-- [ ] 4.7 Pass `EnvURL`, `PlatformToken`, and generated env vars to the selected plan before execution
+- [ ] 2.1 Add `JavaProject` struct and `detectJavaProjects()` using `scanProjectDirs` for `pom.xml`, `build.gradle`, `build.gradle.kts`
+- [ ] 2.2 Add `detectJavaProcesses()` and `matchJavaProcessesToProjects()` using shared `detectProcesses`/`processMatchPIDs`
+- [ ] 2.3 Define `JavaInstrumentationPlan` struct with project, env vars, `EnvURL`, `PlatformToken`
+- [ ] 2.4 Implement `DetectJavaPlan(apiURL, token)` — project listing, user prompt, plan assembly
+- [ ] 2.5 Implement `PrintPlanSteps()` and `Execute()` on `JavaInstrumentationPlan`
+- [ ] 2.6 Add tests: Maven project detected, Gradle project detected, no projects returns nil
 
-## 5. Coming Soon & Dry-Run
+## 3. Node.js runtime detection and plan
 
-- [ ] 5.1 Add "coming soon" label rendering for unimplemented runtimes in the selection menu
-- [ ] 5.2 Ensure unimplemented runtime entries are not selectable (print "not yet available" on selection)
-- [ ] 5.3 Ensure `--dry-run` prints the runtime selection menu and combined preview without installing
-- [ ] 5.4 Verify `InstallOtelCollectorOnly()` in `pkg/installer/otel.go` is not modified and existing tests pass
+Add project scanning, process detection, entrypoint detection (JS + TypeScript), and instrumentation plan for Node.js. Depends on task 1 (shared utilities).
 
-## 6. Testing
+**Files:** `pkg/installer/otel_nodejs.go` (create), `pkg/installer/otel_nodejs_test.go` (create)
 
-Tests derived from spec scenarios to ensure coverage of new behavior and edge cases:
+- [ ] 3.1 Add `NodeProject` struct and `detectNodeProjects()` using `scanProjectDirs` for `package.json`, excluding `node_modules`
+- [ ] 3.2 Add `detectNodeProcesses()` and `matchNodeProcessesToProjects()` using shared utilities
+- [ ] 3.3 Add `detectNodeEntrypoints()` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js` (including TypeScript variants `.ts`/`.mts`/`.cts`)
+- [ ] 3.4 Define `NodeInstrumentationPlan` struct and `generateOtelNodeEnvVars()`
+- [ ] 3.5 Implement `DetectNodePlan(apiURL, token)` — project listing, user prompt, entrypoint detection, plan assembly
+- [ ] 3.6 Implement `PrintPlanSteps()` and `Execute()` — npm install OTel packages, launch with `--require` flag
+- [ ] 3.7 Add tests: project detected, `node_modules` excluded, entrypoint from `main`/`scripts.start`/fallback, TypeScript variants, no entrypoint returns empty
 
-- [ ] 6.1 `pkg/installer/otel_java_test.go`: test `detectJavaProjects()` — Maven project detected (dir with `pom.xml`), Gradle project detected (`build.gradle`/`build.gradle.kts`), no projects found returns nil (spec: Java project scanning)
-- [ ] 6.2 `pkg/installer/otel_nodejs_test.go`: test `detectNodeProjects()` — project detected (dir with `package.json`), `node_modules` excluded, no projects found returns nil (spec: Node.js project scanning)
-- [ ] 6.3 `pkg/installer/otel_nodejs_test.go`: test `detectNodeEntrypoints()` — entrypoint from `main` field, from `scripts.start`, fallback to `index.js`/`app.js`/`server.js`, no entrypoint returns empty (spec: Node.js entrypoint detection)
-- [ ] 6.4 `pkg/installer/otel_go_test.go`: test `detectGoProjects()` — project detected with module name extraction from `go.mod`, no projects found returns nil (spec: Go project scanning)
-- [ ] 6.5 `pkg/installer/otel_test.go`: test `detectAvailableRuntimes()` — multiple runtimes on PATH, single runtime, no runtimes (spec: Runtime selection menu)
-- [ ] 6.6 `pkg/installer/otel_test.go`: test "coming soon" label logic — unimplemented runtime shown with label, all implemented hides label (spec: Unimplemented runtimes shown as "coming soon")
-- [ ] 6.7 Run `make test` and `make lint` to verify no regressions (spec: InstallOtelCollectorOnly non-regression)
+## 4. Go runtime detection and plan
+
+Add project scanning, module name extraction, and SDK integration guidance for Go. Depends on task 1 (shared utilities).
+
+**Files:** `pkg/installer/otel_go.go` (create), `pkg/installer/otel_go_test.go` (create)
+
+- [ ] 4.1 Add `GoProject` struct (with `ModuleName`) and `detectGoProjects()` using `scanProjectDirs` for `go.mod`, extracting module name
+- [ ] 4.2 Define `GoInstrumentationPlan` struct and `generateOtelGoEnvVars()`
+- [ ] 4.3 Implement `DetectGoPlan(apiURL, token)` — project listing, user prompt, plan assembly
+- [ ] 4.4 Implement `PrintPlanSteps()` (label as "SDK integration (manual)") and `Execute()` — print `go get` commands, env vars, SDK initialization guidance
+- [ ] 4.5 Add tests: project detected with module name extraction, no projects returns nil
+
+## 5. Orchestration, coming-soon filtering, and dry-run
+
+Replace the runtime selection menu with a unified project list across all GA runtimes. Only Python is GA by default; `DTWIZ_ALL_RUNTIMES=true` unlocks all. Depends on tasks 1–4 (all runtime detectors must exist).
+
+**Files:** `pkg/installer/otel.go` (modify), `pkg/installer/otel_test.go` (modify)
+
+- [ ] 5.1 Add `allRuntimesEnabled()` checking `DTWIZ_ALL_RUNTIMES` env var (`"true"` or `"1"`)
+- [ ] 5.2 Update `detectAvailableRuntimes()` — Python `comingSoon: false`, Java/Node.js/Go `comingSoon: !unlockAll`
+- [ ] 5.3 Add `detectedProject` struct and `detectAllProjects(runtimes)` — scan all GA runtimes, skip coming-soon, return unified list
+- [ ] 5.4 Add `printProjectList()` and `selectProject()` for unified project selection UX
+- [ ] 5.5 Add `createRuntimePlan()` to dispatch plan creation based on selected project's runtime
+- [ ] 5.6 Rewrite `InstallOtelCollector()` — scan projects, show unified list, create plan, show combined preview, execute after collector install
+- [ ] 5.7 Ensure `--dry-run` prints the project list and combined preview without installing
+- [ ] 5.8 Verify `InstallOtelCollectorOnly()` is not modified
+- [ ] 5.9 Add tests: `detectAvailableRuntimes` coming-soon defaults (Python GA), `DTWIZ_ALL_RUNTIMES=true` unlocks all, `printProjectList` formatting, `detectAllProjects` skips coming-soon / includes all when unlocked
+- [ ] 5.10 Run `make test` and `make lint` to verify no regressions

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -2,39 +2,39 @@
 
 ## 1. Java Detection & Plan
 
-- [ ] 1.1 Add `JavaProject` struct and `detectJavaProjects()` scanner (scan for `pom.xml`, `build.gradle`, `build.gradle.kts`) in `otel_java.go`
-- [ ] 1.2 Add `detectJavaProcesses()` and `matchJavaProcessesToProjects()` in `otel_java.go`
-- [ ] 1.3 Define `JavaInstrumentationPlan` struct with project, agent JAR path, env vars, `EnvURL`, `PlatformToken`
-- [ ] 1.4 Implement `DetectJavaPlan(apiURL, token string) *JavaInstrumentationPlan` — project listing, user prompt, plan assembly
+- [ ] 1.1 Add `JavaProject` struct and `detectJavaProjects()` scanner (scan for `pom.xml`, `build.gradle`, `build.gradle.kts`) in `pkg/installer/otel_java.go`
+- [ ] 1.2 Add `detectJavaProcesses()` and `matchJavaProcessesToProjects()` in `pkg/installer/otel_java.go`
+- [ ] 1.3 Define `JavaInstrumentationPlan` struct with project, agent JAR path, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_java.go`
+- [ ] 1.4 Implement `DetectJavaPlan(apiURL, token string) *JavaInstrumentationPlan` — project listing, user prompt, plan assembly in `pkg/installer/otel_java.go`
 - [ ] 1.5 Implement `PrintPlanSteps()` on `JavaInstrumentationPlan`
 - [ ] 1.6 Implement `Execute()` on `JavaInstrumentationPlan` — download agent JAR, print `-javaagent` flag and env vars
 
 ## 2. Node.js Detection & Plan
 
-- [ ] 2.1 Create `otel_nodejs.go` with `NodeProject` struct and `detectNodeProjects()` scanner (scan for `package.json`, exclude `node_modules`)
-- [ ] 2.2 Add `detectNodeProcesses()` and `matchNodeProcessesToProjects()` in `otel_nodejs.go`
-- [ ] 2.3 Add `detectNodeEntrypoints()` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js`
-- [ ] 2.4 Define `NodeInstrumentationPlan` struct with project, entrypoints, env vars, `EnvURL`, `PlatformToken`
-- [ ] 2.5 Implement `DetectNodePlan(apiURL, token string) *NodeInstrumentationPlan` — project listing, user prompt, entrypoint detection, plan assembly
+- [ ] 2.1 Create `pkg/installer/otel_nodejs.go` with `NodeProject` struct and `detectNodeProjects()` scanner (scan for `package.json`, exclude `node_modules`)
+- [ ] 2.2 Add `detectNodeProcesses()` and `matchNodeProcessesToProjects()` in `pkg/installer/otel_nodejs.go`
+- [ ] 2.3 Add `detectNodeEntrypoints()` in `pkg/installer/otel_nodejs.go` — parse `package.json` `main`/`scripts.start`, fall back to `index.js`/`app.js`/`server.js`
+- [ ] 2.4 Define `NodeInstrumentationPlan` struct with project, entrypoints, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_nodejs.go`
+- [ ] 2.5 Implement `DetectNodePlan(apiURL, token string) *NodeInstrumentationPlan` — project listing, user prompt, entrypoint detection, plan assembly in `pkg/installer/otel_nodejs.go`
 - [ ] 2.6 Implement `PrintPlanSteps()` on `NodeInstrumentationPlan`
 - [ ] 2.7 Implement `Execute()` on `NodeInstrumentationPlan` — npm install OTel packages, launch with `--require` flag
-- [ ] 2.8 Add `generateOtelNodeEnvVars()` function
+- [ ] 2.8 Add `generateOtelNodeEnvVars()` function in `pkg/installer/otel_nodejs.go`
 
 ## 3. Go Detection & Plan
 
-- [ ] 3.1 Create `otel_go.go` with `GoProject` struct and `detectGoProjects()` scanner (scan for `go.mod`, extract module name)
-- [ ] 3.2 Define `GoInstrumentationPlan` struct with project, module name, env vars, `EnvURL`, `PlatformToken`
-- [ ] 3.3 Implement `DetectGoPlan(apiURL, token string) *GoInstrumentationPlan` — project listing, user prompt, plan assembly
+- [ ] 3.1 Create `pkg/installer/otel_go.go` with `GoProject` struct and `detectGoProjects()` scanner (scan for `go.mod`, extract module name)
+- [ ] 3.2 Define `GoInstrumentationPlan` struct with project, module name, env vars, `EnvURL`, `PlatformToken` in `pkg/installer/otel_go.go`
+- [ ] 3.3 Implement `DetectGoPlan(apiURL, token string) *GoInstrumentationPlan` — project listing, user prompt, plan assembly in `pkg/installer/otel_go.go`
 - [ ] 3.4 Implement `PrintPlanSteps()` on `GoInstrumentationPlan` — label as "SDK integration (manual)"
 - [ ] 3.5 Implement `Execute()` on `GoInstrumentationPlan` — print `go get` commands, env vars, and SDK initialization guidance
-- [ ] 3.6 Add `generateOtelGoEnvVars()` function
+- [ ] 3.6 Add `generateOtelGoEnvVars()` function in `pkg/installer/otel_go.go`
 
-## 4. Orchestration in otel.go
+## 4. Orchestration in `pkg/installer/otel.go`
 
-- [ ] 4.1 Add `detectAvailableRuntimes()` that uses `exec.LookPath` for each runtime and returns the list of available ones
-- [ ] 4.2 Add runtime selection menu with "Skip — collector only" option and "coming soon" labels
-- [ ] 4.3 Call the selected runtime's `Detect<Lang>Plan` after menu selection
-- [ ] 4.4 Update confirmation preview to show collector + at most one runtime plan
+- [ ] 4.1 Add `detectAvailableRuntimes()` in `pkg/installer/otel.go` that uses `exec.LookPath` for each runtime and returns the list of available ones
+- [ ] 4.2 Add runtime selection menu with "Skip — collector only" option and "coming soon" labels in `pkg/installer/otel.go`
+- [ ] 4.3 Call the selected runtime's `Detect<Lang>Plan` after menu selection in `InstallOtelCollector()`
+- [ ] 4.4 Update confirmation preview to show collector + at most one runtime plan in `InstallOtelCollector()`
 - [ ] 4.5 Update intro message to reflect whether a runtime was selected
 - [ ] 4.6 Add execution block for the selected plan after collector install, with separator header
 - [ ] 4.7 Pass `EnvURL`, `PlatformToken`, and generated env vars to the selected plan before execution
@@ -44,12 +44,16 @@
 - [ ] 5.1 Add "coming soon" label rendering for unimplemented runtimes in the selection menu
 - [ ] 5.2 Ensure unimplemented runtime entries are not selectable (print "not yet available" on selection)
 - [ ] 5.3 Ensure `--dry-run` prints the runtime selection menu and combined preview without installing
-- [ ] 5.4 Verify `InstallOtelCollectorOnly()` is not modified and existing tests pass
+- [ ] 5.4 Verify `InstallOtelCollectorOnly()` in `pkg/installer/otel.go` is not modified and existing tests pass
 
 ## 6. Testing
 
-- [ ] 6.1 Add unit tests for `detectJavaProjects()` with temp directory fixtures
-- [ ] 6.2 Add unit tests for `detectNodeProjects()` with temp directory fixtures (including `node_modules` exclusion)
-- [ ] 6.3 Add unit tests for `detectGoProjects()` and module name extraction
-- [ ] 6.4 Add unit tests for "coming soon" label logic
-- [ ] 6.5 Run `make test` and `make lint` to verify no regressions
+Tests derived from spec scenarios to ensure coverage of new behavior and edge cases:
+
+- [ ] 6.1 `pkg/installer/otel_java_test.go`: test `detectJavaProjects()` — Maven project detected (dir with `pom.xml`), Gradle project detected (`build.gradle`/`build.gradle.kts`), no projects found returns nil (spec: Java project scanning)
+- [ ] 6.2 `pkg/installer/otel_nodejs_test.go`: test `detectNodeProjects()` — project detected (dir with `package.json`), `node_modules` excluded, no projects found returns nil (spec: Node.js project scanning)
+- [ ] 6.3 `pkg/installer/otel_nodejs_test.go`: test `detectNodeEntrypoints()` — entrypoint from `main` field, from `scripts.start`, fallback to `index.js`/`app.js`/`server.js`, no entrypoint returns empty (spec: Node.js entrypoint detection)
+- [ ] 6.4 `pkg/installer/otel_go_test.go`: test `detectGoProjects()` — project detected with module name extraction from `go.mod`, no projects found returns nil (spec: Go project scanning)
+- [ ] 6.5 `pkg/installer/otel_test.go`: test `detectAvailableRuntimes()` — multiple runtimes on PATH, single runtime, no runtimes (spec: Runtime selection menu)
+- [ ] 6.6 `pkg/installer/otel_test.go`: test "coming soon" label logic — unimplemented runtime shown with label, all implemented hides label (spec: Unimplemented runtimes shown as "coming soon")
+- [ ] 6.7 Run `make test` and `make lint` to verify no regressions (spec: InstallOtelCollectorOnly non-regression)

--- a/openspec/changes/multi-runtime-detection/tasks.md
+++ b/openspec/changes/multi-runtime-detection/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. Java Detection & Plan
 
 - [ ] 1.1 Add `JavaProject` struct and `detectJavaProjects()` scanner (scan for `pom.xml`, `build.gradle`, `build.gradle.kts`) in `otel_java.go`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,20 +1,44 @@
 schema: spec-driven
 
-# Project context (optional)
-# This is shown to AI when creating artifacts.
-# Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  Tech stack: Go, Cobra CLI framework, Go templates (text/template)
+  Build: `make build` (go build with ldflags), `make test`, `make lint` (golangci-lint)
+  Release: goreleaser, archives per OS/arch
+  Domain: Dynatrace observability CLI — analyzes systems and deploys the best monitoring method automatically
 
-# Per-artifact rules (optional)
-# Add custom rules for specific artifacts.
-# Example:
-#   rules:
-#     proposal:
-#       - Keep proposals under 500 words
-#       - Always include a "Non-goals" section
-#     tasks:
-#       - Break tasks into chunks of max 2 hours
+  Project structure:
+    - main.go → cmd.Execute()
+    - cmd/ — Cobra commands (root, analyze, recommend, setup, install, update, uninstall, status, version, auth)
+    - pkg/analyzer/ — system detection (platform, Docker, K8s, OneAgent, OTel, AWS, Azure, services)
+    - pkg/recommender/ — priority-ranked ingestion recommendations
+    - pkg/installer/ — per-method installers + shared utilities + embedded Go templates
+    - scripts/ — curl|sh installer scripts
+
+  CLI conventions:
+    - Verb-noun command tree: top-level verbs (install, update, uninstall), methods as subcommands
+    - All leaf commands set Args: cobra.NoArgs; parent commands use cobra.MinimumNArgs(1)
+    - --dry-run as PersistentFlags().BoolVar() on parent, shared by subcommands
+    - Zero-config defaults: OneAgent full-stack, K8s cloudNativeFullStack, AWS all services + all regions
+
+  UX rules:
+    - Before executing, show compact preview of commands/actions, print generated config inline
+    - Single confirmation prompt: "Apply? [Y/n]" (default yes)
+    - Reduce to the max: every output line must earn its place
+
+  Auth:
+    - Two URL families: Classic (no .apps.) with Api-Token, Platform (with .apps.) with Bearer
+    - Token prefixes: dt0c01.* = API token, dt0s16.* = Platform token
+    - Credentials from flags → env vars (DT_ENVIRONMENT, DT_ACCESS_TOKEN, DT_PLATFORM_TOKEN)
+
+rules:
+  proposal:
+    - Include rollback plan for risky or architecture-level changes
+    - Reference relevant feature flag names when new behavior is gated
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Reference existing patterns before introducing new ones
+    - Document feature flag dependencies directly in scenarios
+  tasks:
+    - Reference concrete file paths from the key paths above
+    - Always include relevant test layers
+    - Define test cases derived from the spec to ensure coverage of new behavior and edge cases


### PR DESCRIPTION
Add multi-runtime detection spec for OTel Collector install flow

Unified project list — InstallOtelCollector scans all GA runtimes at once and presents a single list. User picks one project or skips.

Shared utilities — New otel_common.go with project scanning, process detection, and OTel env var generation. Python refactored to use it.

Java detection — Scan for Maven/Gradle projects, match running processes. Plan prints agent JAR URL, -javaagent flag, and env vars.

Node.js detection — Scan for package.json, infer entrypoints from main/scripts.start or convention (JS + TypeScript). Plan prints npm install and --require flag.

Go detection — Scan for `go.mod`, extract module names. Plan prints SDK go get commands and env vars; labeled "manual" since Go has no runtime agent.

Coming-soon gates — Java, Node.js, and Go are hidden by default. DTWIZ_ALL_RUNTIMES=true unlocks all for testing.