### PR TITLE
feat: add --debug flag infrastructure for verbose logging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Description
+
+<!-- What is the purpose of this PR? Briefly describe what you changed and why. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+## Changes
+
+<!-- List the main changes in this PR. -->
+
+- ...
+- ...
+
+## How to test
+
+<!-- Steps for reviewers to test this PR. -->
+
+1. ...
+2. ...
+3. ...
+
+## Checklist
+
+- [ ] I have tested these changes locally.
+- [ ] I updated documentation where necessary.
+- [ ] I added or updated tests where appropriate.
+- [ ] I followed the existing code style and conventions.

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,22 @@
+name: PR Checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  checklist:
+    name: Checklist complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any checklist items are unchecked
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          section=$(echo "$BODY" | awk '/^## Checklist/,0')
+          if echo "$section" | grep -q '^- \[ \]'; then
+            echo "The following checklist items are not completed:"
+            echo "$section" | grep '^- \[ \]'
+            exit 1
+          fi
+          echo "All checklist items are checked."

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,7 @@ import (
 // Version is set at build time via -ldflags.
 var Version = "dev"
 
+var debugFlag bool
 var environmentFlag string
 var accessTokenFlag string
 var platformTokenFlag string
@@ -27,6 +29,11 @@ Set your Dynatrace credentials via environment variables:
   export DT_PLATFORM_TOKEN=dt0s16.****
 
 Then use dtwiz commands to analyze and instrument your system.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		debug := debugFlag || os.Getenv("DT_DEBUG") == "true"
+		logger.Init(debug)
+		logger.Debug("Debug mode enabled")
+	},
 }
 
 func printBanner() {
@@ -60,6 +67,7 @@ func init() {
 		cmd.Help()
 	}
 
+	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "enable debug logging (also read from DT_DEBUG=true)")
 	rootCmd.PersistentFlags().StringVar(&environmentFlag, "environment", "", "Dynatrace environment URL (also read from DT_ENVIRONMENT)")
 	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token (also read from DT_ACCESS_TOKEN)")
 	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token (dt0s16.*) for AWS installer (also read from DT_PLATFORM_TOKEN)")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,13 +7,10 @@ import (
 
 var enabled bool
 
-// Init configures the default slog logger based on the debug flag.
-// When debug is true the log level is set to Debug; otherwise it is set
-// to Warn so that only warnings and errors are emitted.
-// Output is written to stderr to keep stdout clean for program output.
+// Init configures structured logging. Writes to stderr; all output is suppressed unless debug=true.
 func Init(debug bool) {
 	enabled = debug
-	level := slog.LevelWarn
+	level := slog.Level(100) // above Error — silences all output
 	if debug {
 		level = slog.LevelDebug
 	}
@@ -21,13 +18,11 @@ func Init(debug bool) {
 	slog.SetDefault(slog.New(handler))
 }
 
-// Enabled returns true when debug logging is active.
 func Enabled() bool {
 	return enabled
 }
 
-// Debug logs a message at debug level. Additional key-value pairs can be
-// passed as structured context (e.g. logger.Debug("loaded config", "path", p)).
+// Debug logs at debug level with optional key-value pairs (e.g. logger.Debug("loaded", "path", p)).
 func Debug(msg string, args ...any) {
 	slog.Debug(msg, args...)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,33 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+)
+
+var enabled bool
+
+// Init configures the default slog logger based on the debug flag.
+// When debug is true the log level is set to Debug; otherwise it is set
+// to Warn so that only warnings and errors are emitted.
+// Output is written to stderr to keep stdout clean for program output.
+func Init(debug bool) {
+	enabled = debug
+	level := slog.LevelWarn
+	if debug {
+		level = slog.LevelDebug
+	}
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
+}
+
+// Enabled returns true when debug logging is active.
+func Enabled() bool {
+	return enabled
+}
+
+// Debug logs a message at debug level. Additional key-value pairs can be
+// passed as structured context (e.g. logger.Debug("loaded config", "path", p)).
+func Debug(msg string, args ...any) {
+	slog.Debug(msg, args...)
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,46 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+)
+
+func TestInitDebugEnabled(t *testing.T) {
+	Init(true)
+	if !Enabled() {
+		t.Fatal("expected Enabled() to return true after Init(true)")
+	}
+
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	Debug("test message", "key", "value")
+
+	if buf.Len() == 0 {
+		t.Fatal("expected debug message to be written when debug is enabled")
+	}
+}
+
+func TestInitDebugDisabled(t *testing.T) {
+	Init(false)
+	if Enabled() {
+		t.Fatal("expected Enabled() to return false after Init(false)")
+	}
+
+	// The default level is Warn, so Debug calls should be suppressed.
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	Debug("should not appear")
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when debug is disabled, got: %s", buf.String())
+	}
+}


### PR DESCRIPTION
Introduces a lightweight debug logger backed by log/slog (stdlib).
- pkg/logger: Init(), Debug(), Enabled() functions
- cmd/root.go: --debug persistent flag with DT_DEBUG env var fallback
- PersistentPreRun initializes the logger for all commands
- PoC debug line: "Debug mode enabled"

Add PR template for Open Source projects