### PR TITLE
feat: add AWS Lambda instrumentation (install/uninstall)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -145,6 +145,22 @@ var installAWSCmd = &cobra.Command{
 	},
 }
 
+var installAWSLambdaCmd = &cobra.Command{
+	Use:   "aws-lambda",
+	Short: "Install Dynatrace Lambda Layer on all functions",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		envURL, accessTok, platformTok, err := getDtEnvironment()
+		if err != nil {
+			return err
+		}
+		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+			return err
+		}
+		return installer.InstallAWSLambda(envURL, accessTok, platformTok, installDryRun, true)
+	},
+}
+
 var installAzureCmd = &cobra.Command{
 	Use:   "azure",
 	Short: "Set up Dynatrace Azure Monitor integration",
@@ -179,6 +195,7 @@ func init() {
 	installCmd.AddCommand(installOtelPythonCmd)
 	installCmd.AddCommand(installOtelJavaCmd)
 	installCmd.AddCommand(installAWSCmd)
+	installCmd.AddCommand(installAWSLambdaCmd)
 	installCmd.AddCommand(installAzureCmd)
 	installCmd.AddCommand(installGCPCmd)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,6 +47,15 @@ var uninstallAWSCmd = &cobra.Command{
 	},
 }
 
+var uninstallAWSLambdaCmd = &cobra.Command{
+	Use:   "aws-lambda",
+	Short: "Remove Dynatrace Lambda Layer from all functions",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return installer.UninstallAWSLambda(uninstallDryRun)
+	},
+}
+
 var uninstallOtelCmd = &cobra.Command{
 	Use:   "otel",
 	Short: "Kill running OTel Collector processes and remove installation files",
@@ -74,6 +83,7 @@ func init() {
 	uninstallCmd.AddCommand(uninstallKubernetesCmd)
 	uninstallCmd.AddCommand(uninstallOneAgentCmd)
 	uninstallCmd.AddCommand(uninstallAWSCmd)
+	uninstallCmd.AddCommand(uninstallAWSLambdaCmd)
 	uninstallCmd.AddCommand(uninstallOtelCmd)
 	uninstallCmd.AddCommand(uninstallSelfCmd)
 }

--- a/openspec/changes/add-aws-lambda-instrumentation/.openspec.yaml
+++ b/openspec/changes/add-aws-lambda-instrumentation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/openspec/changes/add-aws-lambda-instrumentation/design.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/design.md
@@ -1,0 +1,185 @@
+# Design
+
+## Context
+
+`dtwiz install aws` in `pkg/installer/aws.go` deploys a CloudFormation stack for AWS platform monitoring. It already detects the AWS account via `aws sts get-caller-identity`, creates a Dynatrace monitoring configuration via the Classic API, and deploys a CloudFormation template. The analyzer (`pkg/analyzer/detect_aws.go`) already detects Lambda functions and counts them. The codebase has no Lambda-specific installer.
+
+The Dynatrace Lambda Layer is a per-function extension that provides distributed tracing and code-level visibility. It requires: (1) the correct layer ARN (varies by region, runtime, architecture), (2) environment variables on the function (`DT_TENANT`, `DT_CLUSTER`, `DT_CONNECTION_BASE_URL`, `DT_CONNECTION_AUTH_TOKEN`, `AWS_LAMBDA_EXEC_WRAPPER`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement `InstallAWSLambda()` that instruments all Lambda functions in the current AWS region with the Dynatrace Lambda Layer — zero manual configuration.
+- Implement `UninstallAWSLambda()` that cleanly removes instrumentation from all functions.
+- Run `InstallAWSLambda` concurrently from `InstallAWS` so users get platform + function-level monitoring in one command.
+- Register `install aws-lambda` and `uninstall aws-lambda` as Cobra subcommands following existing patterns.
+- Support `--dry-run` for both install and uninstall.
+- Handle idempotency: re-running updates already-instrumented functions to the latest layer version.
+
+**Non-Goals:**
+
+- Multi-region instrumentation (only the current AWS CLI region).
+- Adding `aws-lambda` as a separate recommendation in the `setup` menu or recommender.
+- Creating/managing DT API tokens — reuses the existing `DT_ACCESS_TOKEN`.
+- Supporting Lambda functions deployed as container images (layer attachment doesn't apply).
+
+## Decisions
+
+### 1. All logic in a single file: `aws_lambda.go`
+
+All Lambda instrumentation code lives in `pkg/installer/aws_lambda.go`. This follows the project convention where each method has its own file (`aws.go`, `otel.go`, `kubernetes.go`, etc.). Exported functions: `InstallAWSLambda()` and `UninstallAWSLambda()`.
+
+### 2. Layer ARN resolution via Dynatrace API
+
+The correct layer ARN is resolved dynamically by calling:
+
+```
+GET /api/v1/deployment/lambda/layer?arch={arm|x86}&techtype={runtime}&region={region}&withCollector=included
+```
+
+This endpoint requires the `InstallerDownload` token scope and returns:
+
+```json
+{
+  "arns": [
+    {
+      "arch": "arm",
+      "arn": "arn:aws:lambda:eu-central-1:657959507023:layer:Dynatrace_OneAgent_..._nodejs_arm:1",
+      "region": "eu-central-1",
+      "techType": "nodejs",
+      "withCollector": "included"
+    }
+  ]
+}
+```
+
+The installer caches layer ARNs by `(runtime, arch)` tuple during a single invocation to avoid redundant API calls.
+
+**Alternative considered:** Hardcoding the Dynatrace AWS account ID and using `aws lambda list-layers` to discover layers. Rejected because the version/date component in the ARN changes with each Dynatrace release and listing would return all versions, not just the latest.
+
+### 3. Connection info from Dynatrace API
+
+The installer calls `/api/v1/deployment/installer/agent/connectioninfo` to obtain:
+
+- `tenantUUID` → used as `DT_TENANT` env var
+- Cluster ID → used as `DT_CLUSTER` env var (exact field to be determined at implementation time; may be embedded in communication endpoints or require parsing)
+
+The `DT_CONNECTION_BASE_URL` is derived from the environment URL using the existing `ClassicAPIURL()` helper (strip `.apps.` if present).
+
+The `DT_CONNECTION_AUTH_TOKEN` is the user's access token (reused as-is).
+
+### 4. Runtime-to-techtype mapping
+
+Each Lambda function's `Runtime` field (e.g., `nodejs18.x`, `python3.11`, `java17`) is mapped to the DT API's `techtype` parameter:
+
+| AWS Runtime prefix | DT techtype |
+|---------------------|-------------|
+| `nodejs` | `nodejs` |
+| `python` | `python` |
+| `java` | `java` |
+| `go` | `go` |
+| `dotnet` | *skip with warning* |
+| `provided` | *skip with warning* |
+
+Functions with unsupported or custom runtimes are skipped with a warning message.
+
+**Alternative considered:** Supporting `.NET` via the log-collection-only layer. Deferred — .NET Lambda support in Dynatrace is limited and the `techtype` parameter doesn't include `dotnet` for the layer endpoint.
+
+### 5. Environment variable merging
+
+`aws lambda update-function-configuration` replaces the entire `Environment.Variables` map. To avoid destroying existing env vars:
+
+1. Call `aws lambda get-function-configuration` to read the current config.
+2. Merge DT_* env vars into the existing map (add new keys, overwrite DT_* keys).
+3. Replace the Dynatrace layer in the `Layers` list (identified by ARN containing `Dynatrace_OneAgent`), or append if not present.
+4. Call `aws lambda update-function-configuration` with the merged config.
+
+This is implemented using the AWS CLI with `--environment` and `--layers` flags, passing the full merged values.
+
+### 6. Idempotency: update to latest layer
+
+When a function already has a Dynatrace layer attached (detected by checking if any layer ARN contains `Dynatrace_OneAgent`):
+
+- The existing layer is replaced with the latest version from the DT API.
+- DT_* env vars are updated to current values.
+- The preview table marks these functions as "update" vs "new".
+
+### 7. Sequential processing
+
+Functions are processed one at a time. This provides:
+
+- Clear, sequential output (function name + status per line)
+- No risk of hitting AWS API rate limits
+- Simpler error handling (fail on one function, continue with the rest)
+
+Each function's update is independent — a failure on one function logs an error and continues to the next.
+
+### 8. Parallel execution from `install aws`
+
+`InstallAWS()` spawns `InstallAWSLambda()` in a goroutine at the start of its flow. Both run concurrently:
+
+```
+InstallAWS()
+├─ go InstallAWSLambda(...)    ← concurrent
+├─ Create DT monitoring config  ← existing flow
+├─ Deploy CloudFormation stack   ← existing flow
+└─ Wait for Lambda goroutine    ← sync.WaitGroup
+```
+
+Both the CloudFormation deployment and Lambda instrumentation have their own confirmation prompts and previews. Since they run concurrently, the Lambda flow runs independently — it performs its own validation, preview, confirmation, and execution. Error from the Lambda goroutine is logged but does not block the CloudFormation deployment.
+
+**Note:** The parallel execution uses a separate goroutine with its own output. The terminal output may interleave. This is acceptable for the first iteration; output synchronization can be refined later if needed.
+
+### 9. Uninstall flow
+
+`UninstallAWSLambda()`:
+
+1. Lists all Lambda functions in the current region.
+2. Filters to functions that have a Dynatrace layer (ARN contains `Dynatrace_OneAgent`).
+3. Shows a preview of functions to be cleaned up.
+4. For each function: removes the Dynatrace layer from the layers list, removes DT_* env vars (`DT_TENANT`, `DT_CLUSTER`, `DT_CONNECTION_BASE_URL`, `DT_CONNECTION_AUTH_TOKEN`, `AWS_LAMBDA_EXEC_WRAPPER`), preserves everything else.
+5. Calls `aws lambda update-function-configuration` with the cleaned config.
+
+### 10. Preview and dry-run
+
+The preview shows a table:
+
+```text
+  Lambda functions to instrument:
+  ──────────────────────────────────────────────────────────────────
+  Function                Runtime      Arch    Action
+  ──────────────────────────────────────────────────────────────────
+  my-api-handler          nodejs18.x   arm64   new
+  data-processor          python3.11   x86_64  new
+  auth-service            java17       arm64   update
+  legacy-func             dotnet6      x86_64  skip (unsupported)
+  ──────────────────────────────────────────────────────────────────
+  3 functions to instrument, 1 skipped
+```
+
+Under `--dry-run`, the preview is printed but no changes are applied and no confirmation prompt is shown.
+
+### 11. Cobra command registration
+
+Following existing patterns in `cmd/install.go` and `cmd/uninstall.go`:
+
+- `installAWSLambdaCmd` registered under `installCmd` with `Use: "aws-lambda"` and `Args: cobra.NoArgs`.
+- `uninstallAWSLambdaCmd` registered under `uninstallCmd` with the same pattern.
+- Both use the parent's `--dry-run` persistent flag.
+
+### 12. No recommender changes
+
+`MethodAWSLambda` is NOT added to the recommender. The `setup` flow does not show it as a separate option. Lambda instrumentation is either:
+
+- Triggered automatically by `install aws` (parallel).
+- Run manually via `install aws-lambda`.
+
+## Risks / Trade-offs
+
+- **[Interleaved terminal output]** → Running Lambda instrumentation concurrently with CloudFormation deployment may produce interleaved output. Mitigation: acceptable for first iteration; can add output buffering later.
+- **[DT_CLUSTER resolution uncertainty]** → The exact source of the numeric cluster ID in the connection info API response is unclear from docs. Mitigation: inspect the actual API response at implementation time; fall back to parsing communication endpoints if needed.
+- **[Token scope requirement]** → The access token needs `InstallerDownload` scope for the layer ARN API, which may not be present on all user tokens. Mitigation: clear error message if the API returns 403.
+- **[AWS API rate limits]** → Sequential processing of many functions (hundreds) could be slow. Mitigation: sequential processing avoids rate limit issues; concurrent processing can be added later if performance is a concern.
+- **[Container image Lambda functions]** → Functions deployed as container images cannot have layers attached. Mitigation: detect `PackageType: Image` and skip with a warning.
+- **[Function update conflicts]** → `update-function-configuration` may fail if the function is being updated by another process or is in a pending state. Mitigation: log the error and continue to the next function.

--- a/openspec/changes/add-aws-lambda-instrumentation/design.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/design.md
@@ -34,8 +34,8 @@ All Lambda instrumentation code lives in `pkg/installer/aws_lambda.go`. This fol
 
 The correct layer ARN is resolved dynamically by calling:
 
-```
-GET /api/v1/deployment/lambda/layer?arch={arm|x86}&techtype={runtime}&region={region}&withCollector=included
+```text
+GET /api/v1/deployment/lambda/layer?arch={arm|x86}&techtype={runtime}&region={region}&withCollector=excluded
 ```
 
 This endpoint requires the `InstallerDownload` token scope and returns:
@@ -119,7 +119,7 @@ Each function's update is independent — a failure on one function logs an erro
 
 `InstallAWS()` spawns `InstallAWSLambda()` in a goroutine at the start of its flow. Both run concurrently:
 
-```
+```text
 InstallAWS()
 ├─ go InstallAWSLambda(...)    ← concurrent
 ├─ Create DT monitoring config  ← existing flow

--- a/openspec/changes/add-aws-lambda-instrumentation/proposal.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/proposal.md
@@ -1,0 +1,44 @@
+# Proposal
+
+## Why
+
+`dtwiz install aws` deploys AWS platform monitoring (CloudFormation stack for logs, events, metrics) and includes `Lambda_essential` in the Dynatrace extension feature sets. This gives metric-level visibility into Lambda functions but provides no function-level instrumentation — no distributed traces, no code-level insights. Users must manually attach the Dynatrace Lambda Layer to each function, set environment variables, and resolve the correct layer ARN per runtime/architecture/region. This is error-prone and violates the project's "if we detect it, we enable it" philosophy.
+
+## What Changes
+
+- Add `dtwiz install aws-lambda` command that automatically instruments all Lambda functions in the current AWS region with the Dynatrace Lambda Layer.
+- Add `dtwiz uninstall aws-lambda` command that removes the Dynatrace Lambda Layer and associated env vars from all instrumented functions.
+- Modify `dtwiz install aws` to run `InstallAWSLambda` concurrently alongside the existing CloudFormation deployment — zero additional user interaction.
+- The installer lists all Lambda functions, auto-detects each function's runtime and architecture, queries the Dynatrace API (`/api/v1/deployment/lambda/layer`) for the matching layer ARN, and attaches the layer with the required DT_* environment variables.
+- Already-instrumented functions get their layer updated to the latest version.
+- `aws-lambda` does NOT appear as a separate recommendation in the `setup` menu — it is only accessible via `dtwiz install aws-lambda` directly or triggered automatically from `dtwiz install aws`.
+
+## Capabilities
+
+### New Capabilities
+
+- `lambda-instrumentation`: Attach the Dynatrace Lambda Layer to all Lambda functions in the current AWS region. Auto-detect runtime and architecture per function, resolve the correct layer ARN from the DT API, set required environment variables, and handle already-instrumented functions by updating to the latest layer version.
+- `lambda-uninstrumentation`: Remove the Dynatrace Lambda Layer and DT_* environment variables from all instrumented functions, preserving all other function configuration.
+- `aws-lambda-parallel-execution`: Run Lambda instrumentation concurrently when `install aws` is invoked, without requiring additional user interaction.
+
+### Modified Capabilities
+
+- `aws-platform-monitoring` (existing `install aws`): Modified to spawn `InstallAWSLambda` as a concurrent goroutine alongside the CloudFormation deployment.
+
+## Impact
+
+- **Code**: New file `pkg/installer/aws_lambda.go`; modified `pkg/installer/aws.go`, `cmd/install.go`, `cmd/uninstall.go`.
+- **Dependencies**: No new Go module dependencies. Uses `aws lambda` CLI commands (already a prerequisite for `install aws`) and existing Dynatrace API client patterns from `aws.go`.
+- **UX**: `install aws` now instruments Lambda functions automatically in parallel. Users see a combined summary. `install aws-lambda` is available standalone for users who only want Lambda instrumentation. Both support `--dry-run`.
+- **Token scope**: The access token (`DT_ACCESS_TOKEN`) needs `InstallerDownload` scope for the layer ARN API. This is in addition to the scopes already required by `install aws`.
+- **Non-regression**: Existing `install aws` CloudFormation flow must remain functional and unchanged. The Lambda instrumentation runs alongside it, not as a replacement.
+
+## Rollback Plan
+
+All new code lives in a single new file (`pkg/installer/aws_lambda.go`) and additive changes to existing files. To roll back:
+
+1. **Revert `pkg/installer/aws.go`** — remove the goroutine that calls `InstallAWSLambda` from `InstallAWS`.
+2. **Revert `cmd/install.go`** — remove the `installAWSLambdaCmd` subcommand registration.
+3. **Revert `cmd/uninstall.go`** — remove the `uninstallAWSLambdaCmd` subcommand registration.
+4. **Delete `pkg/installer/aws_lambda.go`** — all Lambda-specific logic is contained here.
+5. No database, config, or external service changes are involved — rollback is purely code deletion and revert.

--- a/openspec/changes/add-aws-lambda-instrumentation/specs/aws-lambda-parallel-execution/spec.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/specs/aws-lambda-parallel-execution/spec.md
@@ -1,0 +1,37 @@
+# AWS Lambda Parallel Execution
+
+## ADDED Requirements
+
+### Requirement: Concurrent Lambda instrumentation from `install aws`
+
+When `InstallAWS` is invoked, it SHALL spawn `InstallAWSLambda` in a separate goroutine at the start of its flow. The CloudFormation deployment and Lambda instrumentation run concurrently. `InstallAWS` waits for both to complete before returning.
+
+#### Scenario: Both succeed
+
+- **GIVEN** the user runs `dtwiz install aws`
+- **WHEN** both the CloudFormation deployment and Lambda instrumentation complete successfully
+- **THEN** the user sees output from both, and the command exits with success
+
+#### Scenario: Lambda instrumentation fails, CloudFormation succeeds
+
+- **GIVEN** the user runs `dtwiz install aws`
+- **WHEN** the CloudFormation deployment succeeds but Lambda instrumentation fails
+- **THEN** the CloudFormation result is not affected, the Lambda error is logged, and the command exits with success (platform monitoring is more important)
+
+#### Scenario: Dry-run applies to both
+
+- **GIVEN** the user runs `dtwiz install aws --dry-run`
+- **WHEN** both flows run concurrently
+- **THEN** both show their preview without applying any changes
+
+## MODIFIED Requirements
+
+### Requirement: `InstallAWS` spawns Lambda instrumentation
+
+The existing `InstallAWS()` function in `pkg/installer/aws.go` SHALL be modified to start `InstallAWSLambda()` as a concurrent goroutine. The Lambda goroutine receives the same credentials (envURL, token, platformToken, dryRun). A `sync.WaitGroup` ensures `InstallAWS` does not return until both flows are complete. Errors from the Lambda goroutine are logged but do not cause `InstallAWS` to fail.
+
+#### Scenario: Lambda goroutine error is non-fatal
+
+- **GIVEN** `InstallAWSLambda` returns an error
+- **WHEN** `InstallAWS` collects the result
+- **THEN** the error is logged with a warning prefix, and `InstallAWS` returns nil (not the Lambda error)

--- a/openspec/changes/add-aws-lambda-instrumentation/specs/lambda-instrumentation/spec.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/specs/lambda-instrumentation/spec.md
@@ -1,0 +1,131 @@
+# Lambda Instrumentation
+
+## ADDED Requirements
+
+### Requirement: Lambda function discovery
+
+The system SHALL list all Lambda functions in the current AWS region using `aws lambda list-functions` with pagination support. Functions with `PackageType: Image` (container images) SHALL be excluded since layers cannot be attached to them.
+
+#### Scenario: Functions found in current region
+
+- **GIVEN** the AWS CLI is configured with valid credentials and a default region
+- **WHEN** `InstallAWSLambda` lists Lambda functions
+- **THEN** all functions in the current region are returned with their runtime, architecture, and existing layers
+
+#### Scenario: No functions found
+
+- **GIVEN** the AWS CLI is configured with valid credentials
+- **WHEN** no Lambda functions exist in the current region
+- **THEN** the system prints "No Lambda functions found in region {region}" and exits without error
+
+#### Scenario: Container image functions excluded
+
+- **GIVEN** some Lambda functions use `PackageType: Image`
+- **WHEN** the function list is built
+- **THEN** container image functions are excluded from instrumentation and noted in the summary
+
+### Requirement: Runtime-to-techtype mapping
+
+The system SHALL map each function's AWS runtime to a Dynatrace `techtype` parameter: `nodejs*` -> `nodejs`, `python*` -> `python`, `java*` -> `java`, `go*` -> `go`. Functions with unsupported runtimes (`dotnet*`, `provided*`, or unknown) SHALL be skipped with a warning.
+
+#### Scenario: Supported runtime mapped
+
+- **GIVEN** a Lambda function has runtime `nodejs18.x`
+- **WHEN** the system resolves the techtype
+- **THEN** it maps to `nodejs` for the DT layer ARN API call
+
+#### Scenario: Unsupported runtime skipped
+
+- **GIVEN** a Lambda function has runtime `dotnet6`
+- **WHEN** the system attempts to resolve the techtype
+- **THEN** the function is skipped and a warning is printed: "Skipping {function-name}: unsupported runtime dotnet6"
+
+### Requirement: Layer ARN resolution via Dynatrace API
+
+The system SHALL resolve the correct Lambda layer ARN by calling `GET /api/v1/deployment/lambda/layer` on the Classic API URL with query parameters `arch`, `techtype`, `region`, and `withCollector=included`. Requires `InstallerDownload` token scope. Layer ARNs SHALL be cached by `(runtime, arch)` tuple within a single invocation to avoid redundant API calls.
+
+#### Scenario: Layer ARN resolved successfully
+
+- **GIVEN** a function with runtime `python3.11` and architecture `arm64` in region `eu-central-1`
+- **WHEN** the system queries the DT layer API with `techtype=python&arch=arm&region=eu-central-1&withCollector=included`
+- **THEN** it receives a valid ARN and caches it for subsequent functions with the same runtime and architecture
+
+#### Scenario: Layer ARN cached for same runtime/arch
+
+- **GIVEN** two functions both have runtime `nodejs18.x` and architecture `x86_64`
+- **WHEN** the second function's layer ARN is resolved
+- **THEN** the cached ARN from the first resolution is used without an additional API call
+
+#### Scenario: API returns 403 (insufficient scope)
+
+- **GIVEN** the access token does not have `InstallerDownload` scope
+- **WHEN** the layer ARN API is called
+- **THEN** the system prints a clear error: "Access token needs InstallerDownload scope for Lambda layer resolution" and exits
+
+### Requirement: DT connection info retrieval
+
+The system SHALL call `GET /api/v1/deployment/installer/agent/connectioninfo` to obtain the `tenantUUID` (used as `DT_TENANT`) and the cluster ID (used as `DT_CLUSTER`). The `DT_CONNECTION_BASE_URL` is derived from the environment URL using `ClassicAPIURL()`. The `DT_CONNECTION_AUTH_TOKEN` is the user's access token.
+
+#### Scenario: Connection info retrieved
+
+- **GIVEN** a valid access token with `InstallerDownload` scope
+- **WHEN** the connection info API is called
+- **THEN** `tenantUUID` and cluster ID are extracted and used for the function environment variables
+
+### Requirement: Environment variable merging
+
+The system SHALL read each function's current configuration via `aws lambda get-function-configuration`, merge DT_* env vars into the existing environment variables (preserving all non-DT vars), and write the merged config back. The following env vars SHALL be set: `AWS_LAMBDA_EXEC_WRAPPER=/opt/dynatrace`, `DT_TENANT`, `DT_CLUSTER`, `DT_CONNECTION_BASE_URL`, `DT_CONNECTION_AUTH_TOKEN`.
+
+#### Scenario: Function with existing env vars
+
+- **GIVEN** a Lambda function has existing environment variables `DATABASE_URL=postgres://...` and `LOG_LEVEL=info`
+- **WHEN** the system instruments the function
+- **THEN** the updated configuration contains `DATABASE_URL`, `LOG_LEVEL`, AND the five DT_* env vars
+
+#### Scenario: Function with no existing env vars
+
+- **GIVEN** a Lambda function has no environment variables
+- **WHEN** the system instruments the function
+- **THEN** the updated configuration contains only the five DT_* env vars
+
+### Requirement: Layer attachment
+
+The system SHALL add the Dynatrace Lambda Layer to the function's layer list. If a Dynatrace layer is already present (ARN contains `Dynatrace_OneAgent`), it SHALL be replaced with the latest version. Other layers SHALL be preserved.
+
+#### Scenario: New instrumentation
+
+- **GIVEN** a function has layers `[arn:aws:lambda:...:layer:my-custom-layer:3]`
+- **WHEN** the system instruments the function
+- **THEN** the updated layers list is `[arn:aws:lambda:...:layer:my-custom-layer:3, arn:aws:lambda:...:layer:Dynatrace_OneAgent_...:1]`
+
+#### Scenario: Update existing instrumentation
+
+- **GIVEN** a function already has a layer with ARN containing `Dynatrace_OneAgent` (older version)
+- **WHEN** the system instruments the function
+- **THEN** the old Dynatrace layer is replaced with the latest version; other layers are unchanged
+
+### Requirement: Sequential processing with error resilience
+
+The system SHALL process functions one at a time. If instrumentation fails for a single function (e.g., function is in a pending state), the error is logged and processing continues with the next function. The final summary reports successes and failures.
+
+#### Scenario: One function fails, others succeed
+
+- **GIVEN** 5 Lambda functions to instrument
+- **WHEN** function 3 fails with "ResourceConflictException" (function being updated)
+- **THEN** functions 1, 2, 4, 5 are instrumented successfully, function 3's error is logged, and the summary shows "4 succeeded, 1 failed"
+
+### Requirement: Preview and dry-run
+
+The system SHALL display a preview table showing: function name, runtime, architecture, and action (new/update/skip). Under `--dry-run`, the preview is displayed but no changes are applied and no confirmation prompt is shown.
+
+#### Scenario: Dry run preview
+
+- **GIVEN** `--dry-run` is set
+- **WHEN** `InstallAWSLambda` runs
+- **THEN** the preview table is printed, no functions are modified, and no confirmation prompt appears
+
+#### Scenario: Normal run with confirmation
+
+- **GIVEN** `--dry-run` is NOT set
+- **WHEN** `InstallAWSLambda` displays the preview
+- **THEN** it prompts "Apply? [Y/n]" and proceeds only on confirmation

--- a/openspec/changes/add-aws-lambda-instrumentation/specs/lambda-uninstrumentation/spec.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/specs/lambda-uninstrumentation/spec.md
@@ -1,0 +1,51 @@
+# Lambda Uninstrumentation
+
+## ADDED Requirements
+
+### Requirement: Detect instrumented functions
+
+The system SHALL list all Lambda functions in the current AWS region and filter to those that have a Dynatrace Lambda Layer attached (identified by any layer ARN containing `Dynatrace_OneAgent`).
+
+#### Scenario: Instrumented functions found
+
+- **GIVEN** 10 Lambda functions exist in the current region
+- **WHEN** 3 of them have a layer ARN containing `Dynatrace_OneAgent`
+- **THEN** the uninstall preview shows only those 3 functions
+
+#### Scenario: No instrumented functions found
+
+- **GIVEN** no Lambda functions in the current region have a Dynatrace layer
+- **WHEN** `UninstallAWSLambda` runs
+- **THEN** it prints "No Lambda functions with Dynatrace instrumentation found" and exits without error
+
+### Requirement: Clean removal of instrumentation
+
+The system SHALL remove the Dynatrace Lambda Layer from the function's layers list and remove the DT_* environment variables (`DT_TENANT`, `DT_CLUSTER`, `DT_CONNECTION_BASE_URL`, `DT_CONNECTION_AUTH_TOKEN`, `AWS_LAMBDA_EXEC_WRAPPER`). All other layers and environment variables SHALL be preserved.
+
+#### Scenario: Remove layer and env vars
+
+- **GIVEN** a function has layers `[custom-layer, Dynatrace_OneAgent_...]` and env vars `DATABASE_URL`, `DT_TENANT`, `DT_CONNECTION_BASE_URL`, `LOG_LEVEL`
+- **WHEN** the system uninstruments the function
+- **THEN** the updated layers are `[custom-layer]` and env vars are `DATABASE_URL`, `LOG_LEVEL`
+
+#### Scenario: Function with only DT env vars
+
+- **GIVEN** a function's only env vars are the DT_* variables
+- **WHEN** the system uninstruments the function
+- **THEN** the environment variables map is empty (not null — to avoid AWS API errors)
+
+### Requirement: Uninstall preview and dry-run
+
+The system SHALL show a preview of functions to be cleaned up before applying changes. Under `--dry-run`, the preview is shown but no changes are applied.
+
+#### Scenario: Uninstall dry run
+
+- **GIVEN** `--dry-run` is set
+- **WHEN** `UninstallAWSLambda` runs
+- **THEN** the preview is printed, no functions are modified, and no confirmation prompt appears
+
+#### Scenario: Uninstall with confirmation
+
+- **GIVEN** `--dry-run` is NOT set
+- **WHEN** `UninstallAWSLambda` displays the preview
+- **THEN** it prompts "Apply? [Y/n]" and proceeds only on confirmation

--- a/openspec/changes/add-aws-lambda-instrumentation/tasks.md
+++ b/openspec/changes/add-aws-lambda-instrumentation/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+## 1. Core Lambda instrumentation installer
+
+Implement the main `InstallAWSLambda()` function and all supporting helpers in a new file. This is the bulk of the work.
+
+**Files:** `pkg/installer/aws_lambda.go` (create)
+
+- [x] 1.1 Create `aws_lambda.go` with `InstallAWSLambda(envURL, token, platformToken string, dryRun bool) error` entry point
+- [x] 1.2 Implement `getAWSRegion()` — run `aws configure get region` to get the current AWS region
+- [x] 1.3 Implement `listLambdaFunctions(region string)` — call `aws lambda list-functions` with pagination (`--no-paginate` or manual `--starting-token`), parse JSON output, return slice of `lambdaFunction` structs (name, runtime, architecture, layers, env vars, packageType). Exclude `PackageType: Image` functions.
+- [x] 1.4 Implement `mapRuntimeToTechtype(runtime string) (string, bool)` — map AWS runtime prefix to DT techtype (`nodejs` -> `nodejs`, `python` -> `python`, `java` -> `java`, `go` -> `go`). Return false for unsupported runtimes.
+- [x] 1.5 Implement `getDTConnectionInfo(envURL, token string)` — call `GET /api/v1/deployment/installer/agent/connectioninfo` on the Classic API URL with `Api-Token` auth. Parse response for `tenantUUID` and cluster ID. Return a `dtConnectionInfo` struct.
+- [x] 1.6 Implement `getLambdaLayerARN(envURL, token, techtype, arch, region string)` — call `GET /api/v1/deployment/lambda/layer` with query params. Parse response. Return the ARN string. Handle 403 with clear error about `InstallerDownload` scope.
+- [x] 1.7 Add layer ARN cache: `map[string]string` keyed by `"{techtype}-{arch}"` to avoid redundant API calls
+- [x] 1.8 Implement `classifyFunction(fn lambdaFunction)` — return action: `"new"`, `"update"`, or `"skip"` based on whether a Dynatrace layer is already present and whether the runtime is supported
+- [x] 1.9 Implement `printPreviewTable(functions []lambdaFunction, actions []string)` — render the preview table showing function name, runtime, arch, and action
+- [x] 1.10 Implement `instrumentFunction(fn lambdaFunction, layerARN string, connInfo dtConnectionInfo, envURL, token string)` — read current config via `aws lambda get-function-configuration`, merge DT_* env vars, update layers list (replace existing DT layer or append), call `aws lambda update-function-configuration`
+- [x] 1.11 Wire the full `InstallAWSLambda` flow: validate -> list functions -> resolve layer ARNs -> preview -> confirm -> instrument sequentially -> summary
+- [x] 1.12 Add tests: `mapRuntimeToTechtype` mapping, `classifyFunction` logic (new/update/skip), env var merging preserves existing vars, layer replacement logic
+
+## 2. Lambda uninstrumentation
+
+Implement `UninstallAWSLambda()` in the same file. Depends on task 1 (reuses helpers).
+
+**Files:** `pkg/installer/aws_lambda.go` (modify)
+
+- [x] 2.1 Implement `UninstallAWSLambda(dryRun bool) error` — list functions, filter to instrumented ones, preview, confirm, remove layer + DT_* env vars
+- [x] 2.2 Implement `isInstrumented(fn lambdaFunction) bool` — check if any layer ARN contains `Dynatrace_OneAgent`
+- [x] 2.3 Implement `uninstrumentFunction(fn lambdaFunction)` — remove DT layer from layers list, remove DT_* env vars from env map, call `aws lambda update-function-configuration`
+- [x] 2.4 Add tests: `isInstrumented` detection, env var removal preserves non-DT vars, empty env map after removal
+
+## 3. Cobra command registration
+
+Register `install aws-lambda` and `uninstall aws-lambda` subcommands following existing patterns.
+
+**Files:** `cmd/install.go` (modify), `cmd/uninstall.go` (modify)
+
+- [x] 3.1 Add `installAWSLambdaCmd` in `cmd/install.go` — `Use: "aws-lambda"`, `Short: "Install Dynatrace Lambda Layer on all functions"`, `Args: cobra.NoArgs`. RunE: resolve creds via `getDtEnvironment()`, call `validateCredentials()`, call `installer.InstallAWSLambda(envURL, token, platformToken, installDryRun)`
+- [x] 3.2 Register `installAWSLambdaCmd` under `installCmd` in `init()`
+- [x] 3.3 Add `uninstallAWSLambdaCmd` in `cmd/uninstall.go` — `Use: "aws-lambda"`, `Short: "Remove Dynatrace Lambda Layer from all functions"`, `Args: cobra.NoArgs`. RunE: call `installer.UninstallAWSLambda(uninstallDryRun)`
+- [x] 3.4 Register `uninstallAWSLambdaCmd` under `uninstallCmd` in `init()`
+
+## 4. Parallel execution from `install aws`
+
+Modify `InstallAWS` to spawn `InstallAWSLambda` concurrently. Depends on task 1.
+
+**Files:** `pkg/installer/aws.go` (modify)
+
+- [x] 4.1 Add `sync.WaitGroup` and error channel to `InstallAWS()`
+- [x] 4.2 Spawn `InstallAWSLambda()` in a goroutine before the CloudFormation deployment
+- [x] 4.3 After CloudFormation completes, wait for the Lambda goroutine via `wg.Wait()`
+- [x] 4.4 Log Lambda goroutine errors as warnings (non-fatal to the overall `install aws` flow)
+- [x] 4.5 Ensure `--dry-run` is passed through to the Lambda goroutine
+
+## 5. Integration testing and verification
+
+End-to-end verification of all flows.
+
+**Files:** `pkg/installer/aws_lambda_test.go` (create or extend)
+
+- [x] 5.1 Run `make test` — all existing tests must pass
+- [x] 5.2 Run `make lint` — no new lint issues
+- [ ] 5.3 Manual verification: `dtwiz install aws-lambda --dry-run` shows preview without changes
+- [ ] 5.4 Manual verification: `dtwiz install aws --dry-run` shows both CloudFormation and Lambda previews
+- [ ] 5.5 Manual verification: `dtwiz uninstall aws-lambda --dry-run` shows cleanup preview

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -10,14 +10,13 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 )
 
 // awsTemplateURL is the pinned Dynatrace CloudFormation template.
 const awsTemplateURL = "https://dynatrace-data-acquisition.s3.amazonaws.com/aws/deployment/cfn/v1.0.0/da-aws-activation.yaml"
-
-
 
 // awsStackConfig holds all values required to render aws.tmpl and drive the
 // CloudFormation deployment.
@@ -232,18 +231,18 @@ func createDTMonitoringConfig(apiURL, token, accountID, region string) (string, 
 							"accountId":    accountID,
 						},
 					},
-					"regionFiltering": []string{region},
-					"tagFiltering":    []interface{}{},
-					"tagEnrichment":   []interface{}{},
-					"smartscapeConfiguration":        map[string]interface{}{"enabled": true},
-					"metricsConfiguration":           map[string]interface{}{"enabled": true, "regions": []string{region}},
-					"cloudWatchLogsConfiguration":    map[string]interface{}{"enabled": false, "regions": []string{region}},
-					"namespaces":                     []interface{}{},
-					"configurationMode":              "QUICK_START",
-					"deploymentMode":                 "AUTOMATED",
-					"deploymentScope":                "SINGLE_ACCOUNT",
-					"manualDeploymentStatus":         "NA",
-					"automatedDeploymentStatus":      "NA",
+					"regionFiltering":             []string{region},
+					"tagFiltering":                []interface{}{},
+					"tagEnrichment":               []interface{}{},
+					"smartscapeConfiguration":     map[string]interface{}{"enabled": true},
+					"metricsConfiguration":        map[string]interface{}{"enabled": true, "regions": []string{region}},
+					"cloudWatchLogsConfiguration": map[string]interface{}{"enabled": false, "regions": []string{region}},
+					"namespaces":                  []interface{}{},
+					"configurationMode":           "QUICK_START",
+					"deploymentMode":              "AUTOMATED",
+					"deploymentScope":             "SINGLE_ACCOUNT",
+					"manualDeploymentStatus":      "NA",
+					"automatedDeploymentStatus":   "NA",
 				},
 			},
 		},
@@ -524,9 +523,22 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool) error {
 
 	// ── Deploy ────────────────────────────────────────────────────────────────
 
+	// Start Lambda instrumentation concurrently. Only when actually deploying
+	// — dry-run skips this to avoid interleaved output and unnecessary API calls.
+	var wg sync.WaitGroup
+	var lambdaErr error
+	if !dryRun {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lambdaErr = InstallAWSLambda(envURL, token, platformToken, false, false)
+		}()
+	}
+
 	fmt.Printf("  Downloading CloudFormation template...\n")
 	tmplFile, err := downloadAWSTemplate()
 	if err != nil {
+		wg.Wait()
 		return err
 	}
 	defer os.Remove(tmplFile)
@@ -538,11 +550,19 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool) error {
 	fmt.Println()
 
 	if err := RunCommand("aws", realArgs...); err != nil {
+		wg.Wait()
 		return fmt.Errorf("CloudFormation deployment failed: %w", err)
 	}
 
 	fmt.Println()
 	fmt.Printf("  Stack %q deployed successfully.\n", cfg.StackName)
 	fmt.Printf("  View in the AWS Console: https://console.aws.amazon.com/cloudformation/home#/stacks\n")
+
+	// Wait for Lambda instrumentation to finish.
+	wg.Wait()
+	if lambdaErr != nil {
+		fmt.Printf("\n  Warning: Lambda instrumentation encountered an error: %s\n", lambdaErr)
+		fmt.Println("  You can retry with: dtwiz install aws-lambda")
+	}
 	return nil
 }

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -1,0 +1,864 @@
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// ── Data types ───────────────────────────────────────────────────────────────
+
+// lambdaFunction represents a discovered AWS Lambda function.
+type lambdaFunction struct {
+	Name         string
+	Runtime      string
+	Architecture string // "x86_64" or "arm64"
+	Layers       []string
+	EnvVars      map[string]string
+	PackageType  string // "Zip" or "Image"
+}
+
+// dtConnectionInfo holds Dynatrace connection details for Lambda env vars.
+type dtConnectionInfo struct {
+	TenantUUID string
+	ClusterID  string // numeric cluster ID from /api/v1/config/clusterid
+	BaseURL    string // classic API URL (no .apps.)
+	Token      string // agent connection token (dt0a01.* from /api/v2/tokens/agentConnectionToken)
+}
+
+// dtEnvVarKeys lists the env var keys managed by the Dynatrace Lambda layer.
+var dtEnvVarKeys = []string{
+	"AWS_LAMBDA_EXEC_WRAPPER",
+	"DT_TENANT",
+	"DT_CLUSTER",
+	"DT_CONNECTION_BASE_URL",
+	"DT_CONNECTION_AUTH_TOKEN",
+}
+
+// ── Runtime mapping ──────────────────────────────────────────────────────────
+
+// mapRuntimeToTechtype maps an AWS Lambda runtime string (e.g. "nodejs18.x")
+// to the Dynatrace layer API techtype parameter. Returns false for unsupported
+// runtimes.
+func mapRuntimeToTechtype(runtime string) (string, bool) {
+	prefixes := []struct {
+		prefix   string
+		techtype string
+	}{
+		{"nodejs", "nodejs"},
+		{"python", "python"},
+		{"java", "java"},
+		{"go", "go"},
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(runtime, p.prefix) {
+			return p.techtype, true
+		}
+	}
+	return "", false
+}
+
+// archToDTArch maps the AWS architecture value to the DT API parameter.
+func archToDTArch(arch string) string {
+	if arch == "arm64" {
+		return "arm"
+	}
+	return "x86"
+}
+
+// ── AWS helpers ──────────────────────────────────────────────────────────────
+
+// getLambdaRegion returns the current AWS region from env vars or aws configure.
+func getLambdaRegion() (string, error) {
+	_, region, err := getAWSCallerInfo()
+	if err != nil {
+		return "", err
+	}
+	return region, nil
+}
+
+// listLambdaFunctions lists all Lambda functions in the given region, handling
+// pagination. Functions with PackageType "Image" are excluded.
+func listLambdaFunctions() ([]lambdaFunction, error) {
+	var all []lambdaFunction
+	var marker string
+
+	for {
+		args := []string{"lambda", "list-functions", "--output", "json"}
+		if marker != "" {
+			args = append(args, "--marker", marker)
+		}
+
+		cmd := exec.Command("aws", args...)
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			msg := strings.TrimSpace(stderr.String())
+			if msg != "" {
+				return nil, fmt.Errorf("aws lambda list-functions: %s", msg)
+			}
+			return nil, fmt.Errorf("aws lambda list-functions: %w", err)
+		}
+
+		var resp struct {
+			Functions []struct {
+				FunctionName  string   `json:"FunctionName"`
+				Runtime       string   `json:"Runtime"`
+				PackageType   string   `json:"PackageType"`
+				Architectures []string `json:"Architectures"`
+				Layers        []struct {
+					Arn string `json:"Arn"`
+				} `json:"Layers"`
+				Environment struct {
+					Variables map[string]string `json:"Variables"`
+				} `json:"Environment"`
+			} `json:"Functions"`
+			NextMarker string `json:"NextMarker"`
+		}
+		if err := json.Unmarshal(out, &resp); err != nil {
+			return nil, fmt.Errorf("parsing lambda list-functions: %w", err)
+		}
+
+		for _, f := range resp.Functions {
+			// Skip container image functions — layers cannot be attached.
+			if f.PackageType == "Image" {
+				continue
+			}
+
+			arch := "x86_64"
+			if len(f.Architectures) > 0 {
+				arch = f.Architectures[0]
+			}
+
+			layers := make([]string, 0, len(f.Layers))
+			for _, l := range f.Layers {
+				layers = append(layers, l.Arn)
+			}
+
+			envVars := f.Environment.Variables
+			if envVars == nil {
+				envVars = make(map[string]string)
+			}
+
+			all = append(all, lambdaFunction{
+				Name:         f.FunctionName,
+				Runtime:      f.Runtime,
+				Architecture: arch,
+				Layers:       layers,
+				EnvVars:      envVars,
+				PackageType:  f.PackageType,
+			})
+		}
+
+		if resp.NextMarker == "" {
+			break
+		}
+		marker = resp.NextMarker
+	}
+
+	return all, nil
+}
+
+// ── Dynatrace API helpers ────────────────────────────────────────────────────
+
+// getDTConnectionInfo calls the Dynatrace connection info API to obtain tenant
+// UUID and cluster ID for Lambda env vars.
+func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
+	apiURL := classicAPIURL(envURL)
+	endpoint := apiURL + "/api/v1/deployment/installer/agent/connectioninfo"
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building connection info request: %w", err)
+	}
+	req.Header.Set("Authorization", dtAuthHeader(token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching connection info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == 403 {
+		return nil, fmt.Errorf("access token needs InstallerDownload scope for connection info API (HTTP 403)")
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("connection info API returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var info struct {
+		TenantUUID string `json:"tenantUUID"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("parsing connection info: %w", err)
+	}
+
+	// Fetch the numeric cluster ID from a dedicated endpoint.
+	clusterID, err := getClusterID(envURL, token)
+	if err != nil {
+		return nil, fmt.Errorf("resolving cluster ID: %w", err)
+	}
+
+	// Fetch the agent connection token (dt0a01.*) from the v2 API.
+	// This is the token the Lambda extension uses for trace ingest auth.
+	connToken, err := getAgentConnectionToken(envURL, token)
+	if err != nil {
+		return nil, fmt.Errorf("resolving agent connection token: %w", err)
+	}
+
+	return &dtConnectionInfo{
+		TenantUUID: info.TenantUUID,
+		ClusterID:  clusterID,
+		BaseURL:    classicAPIURL(envURL),
+		Token:      connToken,
+	}, nil
+}
+
+// getClusterID fetches the numeric cluster ID from the Dynatrace Classic API.
+// Endpoint: GET /api/v1/config/clusterid → { "clusterId": 997993252 }
+func getClusterID(envURL, token string) (string, error) {
+	apiURL := classicAPIURL(envURL)
+	endpoint := apiURL + "/api/v1/config/clusterid"
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("building cluster ID request: %w", err)
+	}
+	req.Header.Set("Authorization", dtAuthHeader(token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching cluster ID: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == 403 {
+		return "", fmt.Errorf("access token lacks permission to read cluster ID (HTTP 403)")
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("cluster ID API returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var result struct {
+		ClusterID json.Number `json:"clusterId"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing cluster ID response: %w", err)
+	}
+
+	clusterID := result.ClusterID.String()
+	if clusterID == "" {
+		return "", fmt.Errorf("cluster ID API returned empty clusterId")
+	}
+	return clusterID, nil
+}
+
+// getAgentConnectionToken fetches the agent connection token from the
+// Dynatrace v2 API. This is the dt0a01.* token that the Lambda extension uses
+// to authenticate when sending traces back to Dynatrace.
+// Endpoint: GET /api/v2/tokens/agentConnectionToken
+// Required scope: environment-api:agent-connection-tokens:read
+func getAgentConnectionToken(envURL, token string) (string, error) {
+	apiURL := classicAPIURL(envURL)
+	endpoint := apiURL + "/api/v2/agentConnectionToken"
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("building agent connection token request: %w", err)
+	}
+	req.Header.Set("Authorization", dtAuthHeader(token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching agent connection token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == 403 {
+		return "", fmt.Errorf("access token needs environment-api:agent-connection-tokens:read scope (HTTP 403)")
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("agent connection token API returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing agent connection token response: %w", err)
+	}
+
+	if result.Token == "" {
+		return "", fmt.Errorf("agent connection token API returned empty token")
+	}
+	return result.Token, nil
+}
+
+// truncate returns s truncated to maxLen characters.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// layerARNCache caches resolved layer ARNs by "techtype-arch" key.
+type layerARNCache map[string]string
+
+// getLambdaLayerARN resolves the latest Dynatrace Lambda layer ARN from the DT
+// API for the given techtype, architecture, and region. Results are cached in
+// the provided cache to avoid redundant API calls.
+func getLambdaLayerARN(cache layerARNCache, envURL, token, techtype, arch, region string) (string, error) {
+	cacheKey := techtype + "-" + arch
+	if arn, ok := cache[cacheKey]; ok {
+		return arn, nil
+	}
+
+	apiURL := classicAPIURL(envURL)
+	endpoint := fmt.Sprintf("%s/api/v1/deployment/lambda/layer?arch=%s&techtype=%s&region=%s&withCollector=excluded",
+		apiURL, archToDTArch(arch), techtype, region)
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("building layer ARN request: %w", err)
+	}
+	req.Header.Set("Authorization", dtAuthHeader(token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching layer ARN: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == 403 {
+		return "", fmt.Errorf("access token needs InstallerDownload scope for Lambda layer resolution (HTTP 403)")
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("lambda layer API returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var result struct {
+		ARNs []struct {
+			Arch          string `json:"arch"`
+			ARN           string `json:"arn"`
+			Region        string `json:"region"`
+			TechType      string `json:"techType"`
+			WithCollector string `json:"withCollector"`
+		} `json:"arns"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing layer ARN response: %w", err)
+	}
+
+	if len(result.ARNs) == 0 {
+		return "", fmt.Errorf("no Lambda layer ARN found for techtype=%s arch=%s region=%s", techtype, arch, region)
+	}
+
+	arn := result.ARNs[0].ARN
+	cache[cacheKey] = arn
+	return arn, nil
+}
+
+// ── Classification ───────────────────────────────────────────────────────────
+
+// isDynatraceInternal returns true if the function is a Dynatrace-managed
+// Lambda function that should never be instrumented.
+func isDynatraceInternal(fn lambdaFunction) bool {
+	return strings.Contains(fn.Name, "DynatraceApiClientFunction")
+}
+
+// classifyFunction determines what action to take for a Lambda function.
+// Returns "new", "update", or "skip".
+func classifyFunction(fn lambdaFunction) string {
+	// Skip Dynatrace-internal functions.
+	if isDynatraceInternal(fn) {
+		return "skip"
+	}
+	// Check if the runtime is supported first.
+	if _, ok := mapRuntimeToTechtype(fn.Runtime); !ok {
+		return "skip"
+	}
+	// Check if already instrumented with Dynatrace.
+	if hasDynatraceLayer(fn.Layers) {
+		return "update"
+	}
+	return "new"
+}
+
+// hasDynatraceLayer returns true if any layer ARN contains "Dynatrace_OneAgent".
+func hasDynatraceLayer(layers []string) bool {
+	for _, arn := range layers {
+		if strings.Contains(arn, "Dynatrace_OneAgent") {
+			return true
+		}
+	}
+	return false
+}
+
+// isInstrumented returns true if the function has a Dynatrace Lambda layer.
+func isInstrumented(fn lambdaFunction) bool {
+	return hasDynatraceLayer(fn.Layers)
+}
+
+// ── Preview ──────────────────────────────────────────────────────────────────
+
+// printLambdaPreviewTable renders the preview table of Lambda functions.
+func printLambdaPreviewTable(functions []lambdaFunction, actions []string) (actionable, skipped int) {
+	cyan := color.New(color.FgMagenta)
+	sep := strings.Repeat("─", 70)
+
+	fmt.Println()
+	cyan.Println("  Lambda functions to instrument:")
+	fmt.Printf("  %s\n", sep)
+	fmt.Printf("  %-30s %-14s %-8s %s\n", "Function", "Runtime", "Arch", "Action")
+	fmt.Printf("  %s\n", sep)
+
+	for i, fn := range functions {
+		action := actions[i]
+		actionStr := action
+		if action == "skip" {
+			actionStr = fmt.Sprintf("skip (%s)", skipReason(fn))
+			skipped++
+		} else {
+			actionable++
+		}
+		name := fn.Name
+		if len(name) > 30 {
+			name = name[:27] + "..."
+		}
+		fmt.Printf("  %-30s %-14s %-8s %s\n", name, fn.Runtime, fn.Architecture, actionStr)
+	}
+
+	fmt.Printf("  %s\n", sep)
+	fmt.Printf("  %d to instrument, %d skipped\n", actionable, skipped)
+	return actionable, skipped
+}
+
+// printLambdaUninstallPreview renders the preview for uninstallation.
+func printLambdaUninstallPreview(functions []lambdaFunction) {
+	cyan := color.New(color.FgMagenta)
+	sep := strings.Repeat("─", 55)
+
+	fmt.Println()
+	cyan.Println("  Lambda functions to uninstrument:")
+	fmt.Printf("  %s\n", sep)
+	fmt.Printf("  %-30s %-14s %s\n", "Function", "Runtime", "Arch")
+	fmt.Printf("  %s\n", sep)
+
+	for _, fn := range functions {
+		name := fn.Name
+		if len(name) > 30 {
+			name = name[:27] + "..."
+		}
+		fmt.Printf("  %-30s %-14s %s\n", name, fn.Runtime, fn.Architecture)
+	}
+
+	fmt.Printf("  %s\n", sep)
+	fmt.Printf("  %d functions to uninstrument\n", len(functions))
+}
+
+// skipReason returns a human-readable reason for skipping a function.
+func skipReason(fn lambdaFunction) string {
+	if isDynatraceInternal(fn) {
+		return "Dynatrace internal"
+	}
+	if _, ok := mapRuntimeToTechtype(fn.Runtime); !ok {
+		return "unsupported runtime"
+	}
+	return "unknown"
+}
+
+// ── Instrumentation ──────────────────────────────────────────────────────────
+
+// mergeDTEnvVars adds the Dynatrace env vars to the function's existing env
+// vars, preserving all non-DT values.
+func mergeDTEnvVars(existing map[string]string, conn *dtConnectionInfo) map[string]string {
+	merged := make(map[string]string, len(existing)+5)
+	for k, v := range existing {
+		merged[k] = v
+	}
+	merged["AWS_LAMBDA_EXEC_WRAPPER"] = "/opt/dynatrace"
+	merged["DT_TENANT"] = conn.TenantUUID
+	merged["DT_CLUSTER"] = conn.ClusterID
+	merged["DT_CONNECTION_BASE_URL"] = conn.BaseURL
+	merged["DT_CONNECTION_AUTH_TOKEN"] = conn.Token
+	return merged
+}
+
+// removeDTEnvVars removes all Dynatrace-managed env vars from the map.
+func removeDTEnvVars(existing map[string]string) map[string]string {
+	cleaned := make(map[string]string, len(existing))
+	for k, v := range existing {
+		isDT := false
+		for _, dtKey := range dtEnvVarKeys {
+			if k == dtKey {
+				isDT = true
+				break
+			}
+		}
+		if !isDT {
+			cleaned[k] = v
+		}
+	}
+	return cleaned
+}
+
+// updateLayers replaces any existing Dynatrace layer with the new ARN, or
+// appends it if not present.
+func updateLayers(existing []string, newARN string) []string {
+	var updated []string
+	replaced := false
+	for _, arn := range existing {
+		if strings.Contains(arn, "Dynatrace_OneAgent") {
+			updated = append(updated, newARN)
+			replaced = true
+		} else {
+			updated = append(updated, arn)
+		}
+	}
+	if !replaced {
+		updated = append(updated, newARN)
+	}
+	return updated
+}
+
+// removeDynatraceLayers removes all Dynatrace layers from the list.
+func removeDynatraceLayers(layers []string) []string {
+	var cleaned []string
+	for _, arn := range layers {
+		if !strings.Contains(arn, "Dynatrace_OneAgent") {
+			cleaned = append(cleaned, arn)
+		}
+	}
+	return cleaned
+}
+
+// instrumentFunction attaches the Dynatrace Lambda layer and sets env vars on
+// a single function. It reads the current config first to merge env vars.
+func instrumentFunction(fn lambdaFunction, layerARN string, conn *dtConnectionInfo) error {
+	// Read current configuration to get fresh env vars and layers.
+	currentEnv, currentLayers, err := getFunctionConfig(fn.Name)
+	if err != nil {
+		return fmt.Errorf("reading config for %s: %w", fn.Name, err)
+	}
+
+	// Merge env vars and layers.
+	mergedEnv := mergeDTEnvVars(currentEnv, conn)
+	mergedLayers := updateLayers(currentLayers, layerARN)
+
+	return updateFunctionConfig(fn.Name, mergedEnv, mergedLayers)
+}
+
+// uninstrumentFunction removes the Dynatrace layer and DT_* env vars from a
+// single function.
+func uninstrumentFunction(fn lambdaFunction) error {
+	currentEnv, currentLayers, err := getFunctionConfig(fn.Name)
+	if err != nil {
+		return fmt.Errorf("reading config for %s: %w", fn.Name, err)
+	}
+
+	cleanedEnv := removeDTEnvVars(currentEnv)
+	cleanedLayers := removeDynatraceLayers(currentLayers)
+
+	return updateFunctionConfig(fn.Name, cleanedEnv, cleanedLayers)
+}
+
+// getFunctionConfig retrieves the current environment variables and layers for
+// a Lambda function via the AWS CLI.
+func getFunctionConfig(functionName string) (envVars map[string]string, layers []string, err error) {
+	cmd := exec.Command("aws", "lambda", "get-function-configuration",
+		"--function-name", functionName, "--output", "json")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, runErr := cmd.Output()
+	if runErr != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, nil, fmt.Errorf("%s", msg)
+		}
+		return nil, nil, runErr
+	}
+
+	var config struct {
+		Environment struct {
+			Variables map[string]string `json:"Variables"`
+		} `json:"Environment"`
+		Layers []struct {
+			Arn string `json:"Arn"`
+		} `json:"Layers"`
+	}
+	if err := json.Unmarshal(out, &config); err != nil {
+		return nil, nil, fmt.Errorf("parsing function config: %w", err)
+	}
+
+	envVars = config.Environment.Variables
+	if envVars == nil {
+		envVars = make(map[string]string)
+	}
+
+	layers = make([]string, 0, len(config.Layers))
+	for _, l := range config.Layers {
+		layers = append(layers, l.Arn)
+	}
+
+	return envVars, layers, nil
+}
+
+// updateFunctionConfig updates a Lambda function's environment variables and
+// layers via the AWS CLI.
+func updateFunctionConfig(functionName string, envVars map[string]string, layers []string) error {
+	// Build the --environment argument as JSON.
+	envJSON, err := json.Marshal(map[string]interface{}{
+		"Variables": envVars,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling environment: %w", err)
+	}
+
+	args := []string{
+		"lambda", "update-function-configuration",
+		"--function-name", functionName,
+		"--environment", string(envJSON),
+	}
+
+	// Add layers (empty list to clear all layers if needed).
+	if len(layers) > 0 {
+		args = append(args, "--layers")
+		args = append(args, layers...)
+	} else {
+		args = append(args, "--layers")
+	}
+
+	return RunCommandQuiet("aws", args...)
+}
+
+// ── Main entry points ────────────────────────────────────────────────────────
+
+// InstallAWSLambda instruments all Lambda functions in the current AWS region
+// with the Dynatrace Lambda Layer. When confirm is true, the user is prompted
+// before applying changes; when false, changes are applied immediately after
+// the preview (used when called from install aws).
+func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool) error {
+	cyan := color.New(color.FgMagenta)
+
+	fmt.Println()
+	cyan.Println("  Dynatrace AWS Lambda Instrumentation")
+	fmt.Println()
+
+	// ── Validate ─────────────────────────────────────────────────────────────
+
+	if envURL == "" {
+		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)")
+	}
+	if token == "" {
+		return fmt.Errorf("access token is required (--access-token or DT_ACCESS_TOKEN)")
+	}
+
+	if !isAWSCLIInstalled() {
+		return fmt.Errorf("AWS CLI not found — install it from https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html")
+	}
+
+	// ── Get region ───────────────────────────────────────────────────────────
+
+	fmt.Printf("  Fetching AWS region...\n")
+	region, err := getLambdaRegion()
+	if err != nil {
+		return fmt.Errorf("getting AWS region: %w", err)
+	}
+	fmt.Printf("  Region: %s\n", region)
+
+	// ── Get DT connection info ───────────────────────────────────────────────
+
+	fmt.Printf("  Fetching Dynatrace connection info...\n")
+	connInfo, err := getDTConnectionInfo(envURL, token)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  Tenant: %s\n", connInfo.TenantUUID)
+
+	// ── List Lambda functions ────────────────────────────────────────────────
+
+	fmt.Printf("  Listing Lambda functions...\n")
+	functions, err := listLambdaFunctions()
+	if err != nil {
+		return err
+	}
+
+	if len(functions) == 0 {
+		fmt.Printf("  No Lambda functions found in region %s\n", region)
+		return nil
+	}
+
+	// ── Classify and resolve layer ARNs ──────────────────────────────────────
+
+	actions := make([]string, len(functions))
+	layerARNs := make([]string, len(functions))
+	cache := make(layerARNCache)
+
+	for i, fn := range functions {
+		action := classifyFunction(fn)
+		actions[i] = action
+
+		if action == "skip" {
+			continue
+		}
+
+		techtype, _ := mapRuntimeToTechtype(fn.Runtime)
+		arn, err := getLambdaLayerARN(cache, envURL, token, techtype, fn.Architecture, region)
+		if err != nil {
+			return fmt.Errorf("resolving layer ARN for %s: %w", fn.Name, err)
+		}
+		layerARNs[i] = arn
+	}
+
+	// ── Preview ──────────────────────────────────────────────────────────────
+
+	actionable, _ := printLambdaPreviewTable(functions, actions)
+	fmt.Println()
+
+	if actionable == 0 {
+		fmt.Println("  No functions to instrument.")
+		return nil
+	}
+
+	if dryRun {
+		fmt.Println("  [dry-run] No changes were made.")
+		return nil
+	}
+
+	// ── Confirm ──────────────────────────────────────────────────────────────
+
+	if confirm {
+		ok, err := confirmProceed("  Apply?")
+		if err != nil {
+			return fmt.Errorf("reading confirmation: %w", err)
+		}
+		if !ok {
+			fmt.Println("  Cancelled.")
+			return nil
+		}
+	}
+	fmt.Println()
+
+	// ── Instrument ───────────────────────────────────────────────────────────
+
+	succeeded := 0
+	failed := 0
+
+	for i, fn := range functions {
+		if actions[i] == "skip" {
+			continue
+		}
+
+		fmt.Printf("  %s %s...", actions[i], fn.Name)
+		if err := instrumentFunction(fn, layerARNs[i], connInfo); err != nil {
+			fmt.Printf(" failed: %s\n", err)
+			failed++
+			continue
+		}
+		fmt.Printf(" done\n")
+		succeeded++
+	}
+
+	// ── Summary ──────────────────────────────────────────────────────────────
+
+	fmt.Println()
+	if failed > 0 {
+		fmt.Printf("  %d succeeded, %d failed\n", succeeded, failed)
+	} else {
+		fmt.Printf("  %d functions instrumented successfully\n", succeeded)
+	}
+	return nil
+}
+
+// UninstallAWSLambda removes the Dynatrace Lambda Layer and DT_* environment
+// variables from all instrumented functions in the current AWS region.
+func UninstallAWSLambda(dryRun bool) error {
+	cyan := color.New(color.FgMagenta)
+
+	fmt.Println()
+	cyan.Println("  Dynatrace AWS Lambda — Remove Instrumentation")
+	fmt.Println()
+
+	if !isAWSCLIInstalled() {
+		return fmt.Errorf("AWS CLI not found — install it from https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html")
+	}
+
+	// ── List and filter ──────────────────────────────────────────────────────
+
+	fmt.Printf("  Listing Lambda functions...\n")
+	functions, err := listLambdaFunctions()
+	if err != nil {
+		return err
+	}
+
+	var instrumented []lambdaFunction
+	for _, fn := range functions {
+		if isInstrumented(fn) && !isDynatraceInternal(fn) {
+			instrumented = append(instrumented, fn)
+		}
+	}
+
+	if len(instrumented) == 0 {
+		fmt.Println("  No Lambda functions with Dynatrace instrumentation found")
+		return nil
+	}
+
+	// ── Preview ──────────────────────────────────────────────────────────────
+
+	printLambdaUninstallPreview(instrumented)
+	fmt.Println()
+
+	if dryRun {
+		fmt.Println("  [dry-run] No changes were made.")
+		return nil
+	}
+
+	// ── Confirm ──────────────────────────────────────────────────────────────
+
+	ok, err := confirmProceed("  Apply?")
+	if err != nil {
+		return fmt.Errorf("reading confirmation: %w", err)
+	}
+	if !ok {
+		fmt.Println("  Cancelled.")
+		return nil
+	}
+	fmt.Println()
+
+	// ── Uninstrument ─────────────────────────────────────────────────────────
+
+	succeeded := 0
+	failed := 0
+
+	for _, fn := range instrumented {
+		fmt.Printf("  removing %s...", fn.Name)
+		if err := uninstrumentFunction(fn); err != nil {
+			fmt.Printf(" failed: %s\n", err)
+			failed++
+			continue
+		}
+		fmt.Printf(" done\n")
+		succeeded++
+	}
+
+	// ── Summary ──────────────────────────────────────────────────────────────
+
+	fmt.Println()
+	if failed > 0 {
+		fmt.Printf("  %d succeeded, %d failed\n", succeeded, failed)
+	} else {
+		fmt.Printf("  %d functions uninstrumented successfully\n", succeeded)
+	}
+	return nil
+}

--- a/pkg/installer/aws_lambda_test.go
+++ b/pkg/installer/aws_lambda_test.go
@@ -1,0 +1,426 @@
+package installer
+
+import (
+	"testing"
+)
+
+func TestMapRuntimeToTechtype(t *testing.T) {
+	tests := []struct {
+		runtime  string
+		wantType string
+		wantOK   bool
+	}{
+		{"nodejs18.x", "nodejs", true},
+		{"nodejs20.x", "nodejs", true},
+		{"python3.12", "python", true},
+		{"python3.9", "python", true},
+		{"java21", "java", true},
+		{"java17", "java", true},
+		{"go1.x", "go", true},
+		{"dotnet8", "", false},
+		{"ruby3.3", "", false},
+		{"provided.al2023", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		gotType, gotOK := mapRuntimeToTechtype(tt.runtime)
+		if gotType != tt.wantType || gotOK != tt.wantOK {
+			t.Errorf("mapRuntimeToTechtype(%q) = (%q, %v), want (%q, %v)",
+				tt.runtime, gotType, gotOK, tt.wantType, tt.wantOK)
+		}
+	}
+}
+
+func TestArchToDTArch(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"arm64", "arm"},
+		{"x86_64", "x86"},
+		{"", "x86"},
+	}
+	for _, tt := range tests {
+		got := archToDTArch(tt.input)
+		if got != tt.want {
+			t.Errorf("archToDTArch(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestClassifyFunction(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   lambdaFunction
+		want string
+	}{
+		{
+			name: "new — supported runtime, no DT layer",
+			fn: lambdaFunction{
+				Name:    "my-func",
+				Runtime: "nodejs18.x",
+				Layers:  []string{"arn:aws:lambda:us-east-1:123:layer:SomeOther:1"},
+			},
+			want: "new",
+		},
+		{
+			name: "update — supported runtime, has DT layer",
+			fn: lambdaFunction{
+				Name:    "my-func",
+				Runtime: "python3.12",
+				Layers:  []string{"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_x86:1"},
+			},
+			want: "update",
+		},
+		{
+			name: "skip — unsupported runtime",
+			fn: lambdaFunction{
+				Name:    "my-func",
+				Runtime: "dotnet8",
+				Layers:  nil,
+			},
+			want: "skip",
+		},
+		{
+			name: "skip — unsupported runtime even with DT layer",
+			fn: lambdaFunction{
+				Name:    "my-func",
+				Runtime: "provided.al2023",
+				Layers:  []string{"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_x86:1"},
+			},
+			want: "skip",
+		},
+		{
+			name: "skip — Dynatrace internal function",
+			fn: lambdaFunction{
+				Name:    "StackSet-dtaws-12345-DynatraceApiClientFunction-AbCdEf",
+				Runtime: "nodejs18.x",
+				Layers:  nil,
+			},
+			want: "skip",
+		},
+		{
+			name: "skip — Dynatrace internal even with DT layer",
+			fn: lambdaFunction{
+				Name:    "DynatraceApiClientFunction",
+				Runtime: "python3.12",
+				Layers:  []string{"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_python_x86:1"},
+			},
+			want: "skip",
+		},
+		{
+			name: "new — no layers at all",
+			fn: lambdaFunction{
+				Name:    "my-func",
+				Runtime: "java21",
+				Layers:  nil,
+			},
+			want: "new",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyFunction(tt.fn)
+			if got != tt.want {
+				t.Errorf("classifyFunction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasDynatraceLayer(t *testing.T) {
+	tests := []struct {
+		layers []string
+		want   bool
+	}{
+		{nil, false},
+		{[]string{}, false},
+		{[]string{"arn:aws:lambda:us-east-1:123:layer:SomeOther:1"}, false},
+		{[]string{"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_x86:1"}, true},
+		{[]string{"arn:aws:lambda:us-east-1:123:layer:Other:1", "arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_python_arm:2"}, true},
+	}
+	for _, tt := range tests {
+		got := hasDynatraceLayer(tt.layers)
+		if got != tt.want {
+			t.Errorf("hasDynatraceLayer(%v) = %v, want %v", tt.layers, got, tt.want)
+		}
+	}
+}
+
+func TestIsInstrumented(t *testing.T) {
+	instrumented := lambdaFunction{
+		Layers: []string{"arn:aws:lambda:eu-central-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_arm:1"},
+	}
+	notInstrumented := lambdaFunction{
+		Layers: []string{"arn:aws:lambda:us-east-1:123:layer:SomeLayer:1"},
+	}
+	empty := lambdaFunction{}
+
+	if !isInstrumented(instrumented) {
+		t.Error("isInstrumented should return true for function with DT layer")
+	}
+	if isInstrumented(notInstrumented) {
+		t.Error("isInstrumented should return false for function without DT layer")
+	}
+	if isInstrumented(empty) {
+		t.Error("isInstrumented should return false for function with no layers")
+	}
+}
+
+func TestMergeDTEnvVars(t *testing.T) {
+	conn := &dtConnectionInfo{
+		TenantUUID: "abc12345",
+		ClusterID:  "997993252",
+		BaseURL:    "https://abc12345.live.dynatrace.com",
+		Token:      "dt0c01.mytoken",
+	}
+
+	t.Run("preserves existing vars", func(t *testing.T) {
+		existing := map[string]string{
+			"MY_VAR":       "my-value",
+			"ANOTHER_VAR":  "another-value",
+			"DATABASE_URL": "postgres://localhost:5432/db",
+		}
+
+		merged := mergeDTEnvVars(existing, conn)
+
+		// All original vars must be preserved.
+		for k, v := range existing {
+			if merged[k] != v {
+				t.Errorf("existing var %q = %q, want %q", k, merged[k], v)
+			}
+		}
+
+		// DT vars must be set.
+		if merged["AWS_LAMBDA_EXEC_WRAPPER"] != "/opt/dynatrace" {
+			t.Errorf("AWS_LAMBDA_EXEC_WRAPPER = %q, want /opt/dynatrace", merged["AWS_LAMBDA_EXEC_WRAPPER"])
+		}
+		if merged["DT_TENANT"] != "abc12345" {
+			t.Errorf("DT_TENANT = %q, want abc12345", merged["DT_TENANT"])
+		}
+		if merged["DT_CLUSTER"] != "997993252" {
+			t.Errorf("DT_CLUSTER = %q, want 997993252", merged["DT_CLUSTER"])
+		}
+		if merged["DT_CONNECTION_BASE_URL"] != "https://abc12345.live.dynatrace.com" {
+			t.Errorf("DT_CONNECTION_BASE_URL = %q", merged["DT_CONNECTION_BASE_URL"])
+		}
+		if merged["DT_CONNECTION_AUTH_TOKEN"] != "dt0c01.mytoken" {
+			t.Errorf("DT_CONNECTION_AUTH_TOKEN = %q", merged["DT_CONNECTION_AUTH_TOKEN"])
+		}
+	})
+
+	t.Run("empty existing", func(t *testing.T) {
+		merged := mergeDTEnvVars(map[string]string{}, conn)
+		if len(merged) != 5 {
+			t.Errorf("expected 5 env vars, got %d", len(merged))
+		}
+		if merged["DT_CLUSTER"] != "997993252" {
+			t.Errorf("DT_CLUSTER = %q, want 997993252", merged["DT_CLUSTER"])
+		}
+	})
+}
+
+func TestRemoveDTEnvVars(t *testing.T) {
+	t.Run("removes DT vars, preserves others", func(t *testing.T) {
+		existing := map[string]string{
+			"MY_VAR":                   "keep",
+			"DATABASE_URL":             "keep",
+			"AWS_LAMBDA_EXEC_WRAPPER":  "/opt/dynatrace",
+			"DT_TENANT":                "abc12345",
+			"DT_CLUSTER":               "997993252",
+			"DT_CONNECTION_BASE_URL":   "https://abc12345.live.dynatrace.com",
+			"DT_CONNECTION_AUTH_TOKEN": "dt0c01.mytoken",
+		}
+
+		cleaned := removeDTEnvVars(existing)
+
+		if len(cleaned) != 2 {
+			t.Errorf("expected 2 vars after removal, got %d", len(cleaned))
+		}
+		if cleaned["MY_VAR"] != "keep" {
+			t.Errorf("MY_VAR should be preserved, got %q", cleaned["MY_VAR"])
+		}
+		if cleaned["DATABASE_URL"] != "keep" {
+			t.Errorf("DATABASE_URL should be preserved, got %q", cleaned["DATABASE_URL"])
+		}
+		for _, dtKey := range dtEnvVarKeys {
+			if _, ok := cleaned[dtKey]; ok {
+				t.Errorf("DT key %q should have been removed", dtKey)
+			}
+		}
+	})
+
+	t.Run("empty map after removing only DT vars", func(t *testing.T) {
+		existing := map[string]string{
+			"AWS_LAMBDA_EXEC_WRAPPER":  "/opt/dynatrace",
+			"DT_TENANT":                "abc12345",
+			"DT_CONNECTION_BASE_URL":   "https://abc12345.live.dynatrace.com",
+			"DT_CONNECTION_AUTH_TOKEN": "dt0c01.mytoken",
+		}
+
+		cleaned := removeDTEnvVars(existing)
+		if len(cleaned) != 0 {
+			t.Errorf("expected 0 vars, got %d", len(cleaned))
+		}
+	})
+
+	t.Run("no DT vars present — returns all", func(t *testing.T) {
+		existing := map[string]string{
+			"FOO": "bar",
+			"BAZ": "qux",
+		}
+
+		cleaned := removeDTEnvVars(existing)
+		if len(cleaned) != 2 {
+			t.Errorf("expected 2 vars, got %d", len(cleaned))
+		}
+	})
+}
+
+func TestUpdateLayers(t *testing.T) {
+	newARN := "arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_340_nodejs_x86:1"
+
+	t.Run("appends when no DT layer exists", func(t *testing.T) {
+		existing := []string{
+			"arn:aws:lambda:us-east-1:123:layer:SomeLayer:1",
+			"arn:aws:lambda:us-east-1:456:layer:AnotherLayer:2",
+		}
+		result := updateLayers(existing, newARN)
+		if len(result) != 3 {
+			t.Fatalf("expected 3 layers, got %d", len(result))
+		}
+		if result[2] != newARN {
+			t.Errorf("expected new ARN appended, got %q", result[2])
+		}
+	})
+
+	t.Run("replaces existing DT layer", func(t *testing.T) {
+		existing := []string{
+			"arn:aws:lambda:us-east-1:123:layer:SomeLayer:1",
+			"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_x86:1",
+			"arn:aws:lambda:us-east-1:456:layer:AnotherLayer:2",
+		}
+		result := updateLayers(existing, newARN)
+		if len(result) != 3 {
+			t.Fatalf("expected 3 layers (replaced), got %d", len(result))
+		}
+		if result[0] != existing[0] {
+			t.Errorf("first layer changed: %q", result[0])
+		}
+		if result[1] != newARN {
+			t.Errorf("DT layer not replaced: got %q, want %q", result[1], newARN)
+		}
+		if result[2] != existing[2] {
+			t.Errorf("third layer changed: %q", result[2])
+		}
+	})
+
+	t.Run("empty layers — appends", func(t *testing.T) {
+		result := updateLayers(nil, newARN)
+		if len(result) != 1 || result[0] != newARN {
+			t.Errorf("expected [%q], got %v", newARN, result)
+		}
+	})
+}
+
+func TestRemoveDynatraceLayers(t *testing.T) {
+	t.Run("removes DT layers, keeps others", func(t *testing.T) {
+		layers := []string{
+			"arn:aws:lambda:us-east-1:123:layer:SomeLayer:1",
+			"arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_1_338_nodejs_x86:1",
+			"arn:aws:lambda:us-east-1:456:layer:AnotherLayer:2",
+		}
+		result := removeDynatraceLayers(layers)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 layers, got %d", len(result))
+		}
+		if result[0] != layers[0] || result[1] != layers[2] {
+			t.Errorf("unexpected result: %v", result)
+		}
+	})
+
+	t.Run("no DT layers — returns all", func(t *testing.T) {
+		layers := []string{
+			"arn:aws:lambda:us-east-1:123:layer:SomeLayer:1",
+		}
+		result := removeDynatraceLayers(layers)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(result))
+		}
+	})
+
+	t.Run("nil layers — returns nil", func(t *testing.T) {
+		result := removeDynatraceLayers(nil)
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+}
+
+func TestIsDynatraceInternal(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"StackSet-dtaws-12345-DynatraceApiClientFunction-AbCdEf", true},
+		{"DynatraceApiClientFunction", true},
+		{"my-DynatraceApiClientFunction-suffix", true},
+		{"my-func", false},
+		{"dynatraceapiclientfunction", false}, // case-sensitive
+		{"", false},
+	}
+	for _, tt := range tests {
+		fn := lambdaFunction{Name: tt.name}
+		got := isDynatraceInternal(fn)
+		if got != tt.want {
+			t.Errorf("isDynatraceInternal(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestSkipReason(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   lambdaFunction
+		want string
+	}{
+		{
+			name: "Dynatrace internal",
+			fn:   lambdaFunction{Name: "StackSet-DynatraceApiClientFunction-123", Runtime: "nodejs18.x"},
+			want: "Dynatrace internal",
+		},
+		{
+			name: "unsupported runtime",
+			fn:   lambdaFunction{Name: "my-func", Runtime: "dotnet8"},
+			want: "unsupported runtime",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipReason(tt.fn)
+			if got != tt.want {
+				t.Errorf("skipReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello..."},
+		{"", 5, ""},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "abc..."},
+	}
+	for _, tt := range tests {
+		got := truncate(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `dtwiz install aws-lambda` and `dtwiz uninstall aws-lambda` commands that attach/remove the Dynatrace Lambda Layer on all functions in the current AWS region
- Lambda instrumentation runs in parallel from `dtwiz install aws` (non-fatal errors, skipped during `--dry-run`)

## Details

**Install flow:** validate → detect region → fetch DT connection info (tenant UUID, cluster ID, agent connection token) → list Lambda functions → classify (new/update/skip) → resolve layer ARNs from DT API → preview table → confirm (only for standalone `install aws-lambda`) → instrument sequentially

**Key design decisions:**
- **Layer type:** Dynatrace Lambda Layer (`withCollector=excluded`) — plain OneAgent extension, no embedded OTel Collector
- **Token:** Agent connection token (`dt0a01.*`) fetched from `GET /api/v2/agentConnectionToken`, not the API token
- **Cluster ID:** Fetched from `GET /api/v1/config/clusterid` (numeric)
- **Env var handling:** Merge — preserves existing function env vars, adds/updates `DT_*` vars
- **Skips:** Container image functions (layers unsupported), unsupported runtimes (dotnet, ruby, etc.), Dynatrace-internal functions (`DynatraceApiClientFunction`)
- **Already instrumented:** Updates layer to latest version (idempotent)
- **From `install aws`:** No confirmation prompt, runs concurrently with CloudFormation deployment

## Files changed

| File | Change |
|------|--------|
| `pkg/installer/aws_lambda.go` | New — full install/uninstall implementation (~860 lines) |
| `pkg/installer/aws_lambda_test.go` | New — unit tests for pure functions (classification, env var merge, layer update, skip logic) |
| `cmd/install.go` | Register `installAWSLambdaCmd` subcommand |
| `cmd/uninstall.go` | Register `uninstallAWSLambdaCmd` subcommand |
| `pkg/installer/aws.go` | Parallel Lambda goroutine from `InstallAWS()` |

## Testing

- `make test` — all pass
- `make lint` — clean
- Real-world tested on AWS (layer attaches, extension loads, env vars set correctly)