### PR TITLE
test: add coverage testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,60 @@
 name: Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
+
+# Minimum test coverage percentage required to pass CI.
+# Target: gradually increase to 30 -> 40 -> 50.
+env:
+  COVERAGE_THRESHOLD: 20
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    name: Unit Tests
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ['1.24.13']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v5
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify code compiles
+        shell: bash
+        run: go build ./...
+
+      - name: Run go vet
+        shell: bash
+        run: go vet ./...
+
       - name: Run tests
-        run: make test
+        shell: bash
+        run: make test-coverage COVERAGE_THRESHOLD=$COVERAGE_THRESHOLD
+
+      - name: Generate coverage report
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          go tool cover -func=coverage.out | tail -20 >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: Upload coverage
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Thumbs.db
 # Config files (might contain tokens)
 config.yaml
 
+# Local secrets notepad (never commit)
+.env
+
 # Build artifacts
 *.log
 .integrationtests.env

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test lint cleanmarkdownlint markdownlint-fix
+.PHONY: build install test test-coverage lint clean markdownlint markdownlint-fix
 
 BINARY := dtwiz
 GO     := go
@@ -11,9 +11,28 @@ build:
 install:
 	$(GO) install .
 
+COVERAGE_THRESHOLD ?= 20
+
 test:
 	$(GO) test ./... -coverprofile=coverage.out
 	$(GO) tool cover -func=coverage.out
+
+# Run tests and enforce coverage threshold
+test-coverage:
+	@echo "Running tests with coverage..."
+	@$(GO) test -race -coverprofile=coverage.out -covermode=atomic ./...
+	@echo ""
+	@echo "=== Package Coverage ==="
+	@$(GO) tool cover -func=coverage.out | grep -E "^(total|.*\t)" | tail -30
+	@echo ""
+	@COVERAGE=$$($(GO) tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//'); \
+	COVERAGE_INT=$${COVERAGE%.*}; \
+	echo "Total coverage: $${COVERAGE}% (threshold: $(COVERAGE_THRESHOLD)%)"; \
+	if [ "$$COVERAGE_INT" -lt "$(COVERAGE_THRESHOLD)" ]; then \
+		echo "FAIL: Coverage $${COVERAGE}% is below the $(COVERAGE_THRESHOLD)% threshold"; \
+		exit 1; \
+	fi; \
+	echo "OK: Coverage meets threshold"
 
 lint:
 	golangci-lint run ./...

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -23,16 +23,20 @@ func runCmd(cmd string, args ...string) (bool, string) {
 	c.Stderr = &buf
 
 	// Use a timeout so a slow/hanging command doesn't block the whole analysis.
+	// Start the process first so c.Process is safely set before we read it.
+	if err := c.Start(); err != nil {
+		return false, ""
+	}
+
 	done := make(chan error, 1)
-	go func() { done <- c.Run() }()
+	go func() { done <- c.Wait() }()
 
 	select {
 	case err := <-done:
 		return err == nil, strings.TrimSpace(buf.String())
 	case <-time.After(20 * time.Second):
-		if c.Process != nil {
-			_ = c.Process.Kill()
-		}
+		_ = c.Process.Kill()
+		<-done // wait for the goroutine to finish
 		return false, ""
 	}
 }

--- a/pkg/installer/otel_env.go
+++ b/pkg/installer/otel_env.go
@@ -31,7 +31,8 @@ func generateBaseOtelEnvVars(apiURL, token, serviceName string) map[string]strin
 
 func projectServiceName(projectPath string) string {
 	baseName := filepath.Base(projectPath)
-	if baseName == "" || baseName == "." || baseName == "/" {
+	// filepath.Base("/") returns "/" on Unix and "\\" on Windows; treat either as root.
+	if baseName == "" || baseName == "." || strings.Trim(baseName, `/\`) == "" {
 		return "my-service"
 	}
 	return baseName


### PR DESCRIPTION
## Description


- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): 
This pull request updates the CI workflow to improve test coverage enforcement and reporting, and enhances the `makefile` for better test control. The main changes are the addition of a coverage threshold, running tests across multiple operating systems, and improved coverage reporting.

## Changes

**CI/CD workflow improvements:**

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R4-R57): The workflow now runs on pushes and pull requests to the `main` branch, and across `ubuntu-latest`, `macos-latest`, and `windows-latest` runners. It enforces a minimum test coverage threshold (default 20%), and generates a coverage summary in the GitHub Actions UI. Coverage artifacts are only uploaded for Ubuntu.

**Makefile enhancements:**

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L1-R1): Added a `test-coverage` target that runs tests with the race detector and enforces the coverage threshold, failing the build if coverage is below the set value. The `COVERAGE_THRESHOLD` variable is now configurable. The `.PHONY` section and test targets were updated to reflect these changes. [[1]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L1-R1) [[2]](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R14-R36)

## How to test

1. validate the tests execute successfully

## Checklist

- [x] I have tested these changes locally.
- [x] I updated documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions. - aligned with dtctl
