### PR TITLE
bugfix: increase project search depth

### DIFF
--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -80,7 +80,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	discoveredProjects := make([]ScannedProject, 0)
 	visitedDirs := make(map[string]bool) // present=visited, value=matched
 
-	inspectDir := func(dir string) bool {
+	dirMatches := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
 			logger.Debug("skipping ignored dir", "path", dir)
 			return false
@@ -124,7 +124,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 				continue
 			}
 			childDir := filepath.Join(dir, entry.Name())
-			if !inspectDir(childDir) {
+			if !dirMatches(childDir) {
 				scanChildDirs(childDir)
 			}
 		}
@@ -136,7 +136,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return discoveredProjects
 	}
 
-	if !inspectDir(workingDir) {
+	if !dirMatches(workingDir) {
 		scanChildDirs(workingDir)
 	}
 

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -78,11 +78,11 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	}
 
 	discoveredProjects := make([]ScannedProject, 0)
-	visitedDirs := make(map[string]bool)
-	matchedDirs := make(map[string]bool)
+	visitedDirs := make(map[string]bool) // present=visited, value=matched
 
 	inspectDir := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
+			logger.Debug("skipping ignored dir", "path", dir)
 			return false
 		}
 
@@ -92,10 +92,9 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		}
 
 		normalizedDir := strings.ToLower(resolvedDir)
-		if visitedDirs[normalizedDir] {
-			return matchedDirs[normalizedDir]
+		if matched, seen := visitedDirs[normalizedDir]; seen {
+			return matched
 		}
-		visitedDirs[normalizedDir] = true
 
 		matchedMarkers := make([]string, 0, len(markers))
 		for _, marker := range markers {
@@ -106,12 +105,13 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 		if len(matchedMarkers) == 0 {
 			logger.Debug("project dir scanned, no markers", "path", dir, "looking_for", strings.Join(markers, ","))
+			visitedDirs[normalizedDir] = false
 			return false
 		}
 
 		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
 		discoveredProjects = append(discoveredProjects, ScannedProject{Path: dir, Markers: matchedMarkers})
-		matchedDirs[normalizedDir] = true
+		visitedDirs[normalizedDir] = true
 		return true
 	}
 
@@ -146,6 +146,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		if parentDir == currentDir {
 			break
 		}
+		logger.Debug("scanning ancestor dir", "path", parentDir)
 		if scanChildDirs(parentDir) > 0 {
 			break
 		}

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -79,10 +79,11 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 	discoveredProjects := make([]ScannedProject, 0)
 	visitedDirs := make(map[string]bool)
+	matchedDirs := make(map[string]bool)
 
-	inspectDir := func(dir string) {
+	inspectDir := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
-			return
+			return false
 		}
 
 		resolvedDir, err := filepath.EvalSymlinks(dir)
@@ -92,7 +93,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 		normalizedDir := strings.ToLower(resolvedDir)
 		if visitedDirs[normalizedDir] {
-			return
+			return matchedDirs[normalizedDir]
 		}
 		visitedDirs[normalizedDir] = true
 
@@ -105,33 +106,26 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 		if len(matchedMarkers) == 0 {
 			logger.Debug("project dir scanned, no markers", "path", dir, "looking_for", strings.Join(markers, ","))
-			return
+			return false
 		}
 
 		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
 		discoveredProjects = append(discoveredProjects, ScannedProject{Path: dir, Markers: matchedMarkers})
+		matchedDirs[normalizedDir] = true
+		return true
 	}
 
-	scanChildDirs := func(dir string) int {
+	var scanChildDirs func(dir string) int
+	scanChildDirs = func(dir string) int {
 		initialCount := len(discoveredProjects)
 		entries, _ := os.ReadDir(dir)
 		for _, entry := range entries {
 			if !entry.IsDir() || shouldSkipDir(entry.Name()) {
 				continue
 			}
-
 			childDir := filepath.Join(dir, entry.Name())
-			beforeChild := len(discoveredProjects)
-			inspectDir(childDir)
-			if len(discoveredProjects) != beforeChild {
-				continue
-			}
-
-			grandchildren, _ := os.ReadDir(childDir)
-			for _, grandchild := range grandchildren {
-				if grandchild.IsDir() && !shouldSkipDir(grandchild.Name()) {
-					inspectDir(filepath.Join(childDir, grandchild.Name()))
-				}
+			if !inspectDir(childDir) {
+				scanChildDirs(childDir)
 			}
 		}
 		return len(discoveredProjects) - initialCount
@@ -142,8 +136,9 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return discoveredProjects
 	}
 
-	inspectDir(workingDir)
-	scanChildDirs(workingDir)
+	if !inspectDir(workingDir) {
+		scanChildDirs(workingDir)
+	}
 
 	currentDir := workingDir
 	for range 2 {

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -303,6 +303,69 @@ func TestScanProjectDirs_MonorepoGrouping(t *testing.T) {
 	}
 }
 
+func TestScanProjectDirs_DeepNesting(t *testing.T) {
+	root := t.TempDir()
+
+	// depth: root/a/b/c/d — four levels below cwd
+	deep := filepath.Join(root, "a", "b", "c", "d")
+	if err := os.MkdirAll(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "go.mod"), []byte("module deep\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, root)
+	projects := scanProjectDirs([]string{"go.mod"}, nil)
+
+	want := filepath.Join("a", "b", "c", "d")
+	found := false
+	for _, p := range projects {
+		if strings.HasSuffix(filepath.ToSlash(p.Path), filepath.ToSlash(filepath.Join(root, want))) ||
+			strings.HasSuffix(p.Path, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected project at depth 4 to be found, got %v", projects)
+	}
+}
+
+func TestScanProjectDirs_SubtreePruning(t *testing.T) {
+	root := t.TempDir()
+
+	// parent project
+	parent := filepath.Join(root, "myapp")
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "go.mod"), []byte("module myapp\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// nested marker inside the same project — should not produce a second result
+	nested := filepath.Join(parent, "internal", "sub")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "go.mod"), []byte("module sub\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, root)
+	projects := scanProjectDirs([]string{"go.mod"}, nil)
+
+	count := 0
+	for _, p := range projects {
+		if strings.Contains(p.Path, "myapp") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 project under myapp (subtree pruned), got %d: %v", count, projects)
+	}
+}
+
 func TestScanProjectDirs_AncestorWalk(t *testing.T) {
 	grandparent := t.TempDir()
 


### PR DESCRIPTION

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Changes

This pull request improves the project directory scanning logic to better handle deep directory nesting. The main changes include refactoring the scanning algorithm for efficiency and correctness, and adding new tests to verify these behaviors.

## How to test

1. test locally
2. have one very deeply nested python package and have one in the same directory as the source code
3. run `go run main.go setup`
4. both should appear
```
  [2]  Python  /Users/bruno.blazeka/Projects/semantic-dictionary/publishing/cpp  (requirements.txt)
  [3]  Python  /Users/bruno.blazeka/Projects/terra-sample-apps/python-knitting-service  (requirements.txt)
```


## Checklist

- [x] I have tested these changes locally.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
