### PR TITLE
chore: fix waiting for services timeout and QuickStart prototype app URL

### DIFF
--- a/pkg/installer/otel_env.go
+++ b/pkg/installer/otel_env.go
@@ -124,7 +124,7 @@ func waitForServices(envURL, platformToken string, serviceNames []string) {
 		remainingServices[name] = true
 	}
 
-	timeout := time.After(120 * time.Second)
+	timeout := time.After(240 * time.Second)
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 

--- a/pkg/installer/otel_env.go
+++ b/pkg/installer/otel_env.go
@@ -147,7 +147,7 @@ func waitForServices(envURL, platformToken string, serviceNames []string) {
 			for _, name := range foundServices {
 				if remainingServices[name] {
 					delete(remainingServices, name)
-					fmt.Printf("  ✓ \"%s\" appeared in Dynatrace → %s\n", name, appsURL+"/ui/apps/dynatrace.quickstart/")
+					fmt.Printf("  ✓ \"%s\" appeared in Dynatrace → %s\n", name, appsURL+"/ui/apps/my.getting.started.dieter/")
 				}
 			}
 			if len(remainingServices) == 0 {

--- a/pkg/installer/otel_env.go
+++ b/pkg/installer/otel_env.go
@@ -16,6 +16,8 @@ import (
 
 const otelExporterOTLPHeadersEnvVar = "OTEL_EXPORTER_OTLP_HEADERS"
 
+const waitForServicesTimeout = 240 * time.Second
+
 func generateBaseOtelEnvVars(apiURL, token, serviceName string) map[string]string {
 	return map[string]string{
 		"OTEL_SERVICE_NAME":                                 serviceName,
@@ -124,7 +126,7 @@ func waitForServices(envURL, platformToken string, serviceNames []string) {
 		remainingServices[name] = true
 	}
 
-	timeout := time.After(240 * time.Second)
+	timeout := time.After(waitForServicesTimeout)
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 

--- a/pkg/installer/otel_env_test.go
+++ b/pkg/installer/otel_env_test.go
@@ -147,6 +147,30 @@ func TestFormatPrintableEnvVars(t *testing.T) {
 	}
 }
 
+func TestWaitForServices_LinkContainsDieter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(dqlResponse{
+			Result: struct {
+				Records []map[string]interface{} `json:"records"`
+			}{
+				Records: []map[string]interface{}{
+					{"name": "my-svc"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		waitForServices(server.URL, "dt0s16.token", []string{"my-svc"})
+	})
+
+	const wantSubstr = "my.getting.started.dieter"
+	if !strings.Contains(output, wantSubstr) {
+		t.Errorf("output does not contain %q:\n%s", wantSubstr, output)
+	}
+}
+
 func TestFetchSmartscapeServiceNames(t *testing.T) {
 	var receivedAuthorization string
 	var receivedContentType string


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): improvement

## Changes

- instrument timeout increased from 2 to 4 minutes
- link to proper app when instrumentation is successful

## How to test

1. check out this branch locally
2. try to instrument (for example) Python
3. in this version, make sure you have all the dependencies installed that you need - unlike the Python PR, here user needs to set up their own environment.
4. on first run: do nothing for 4 minutes
5. notice the default timeout (message containing waiting for services) appears after 4 minutes
6. on second run: run the app that got started and interact with it
7. notice the link now goes to the prototype app

## Checklist

- [x] I have tested these changes locally.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
