### PR TITLE
chore: allow previews

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,34 @@
+name: Preview Cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+  delete:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event.ref_type == 'branch'
+    permissions:
+      contents: write
+    steps:
+      - name: Derive branch name
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" = "delete" ]; then
+            BRANCH="${{ github.event.ref }}"
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          fi
+          TAG="snapshot-$(echo "$BRANCH" | tr '/' '-')"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Delete preview release and tag
+        run: |
+          gh release delete "${{ steps.branch.outputs.tag }}" --yes || true
+          git push origin ":refs/tags/${{ steps.branch.outputs.tag }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,64 @@
+name: Preview Snapshot
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+      - '!release/**'
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compute release tag
+        id: tag
+        run: |
+          TAG="snapshot-$(echo "${{ github.ref_name }}" | tr '/' '-')"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture snapshot version
+        id: version
+        run: |
+          VERSION=$(ls dist/dtwiz_*_linux_amd64.tar.gz | sed 's|.*dtwiz_\(.*\)_linux_amd64.tar.gz|\1|')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "$VERSION" > dist/version.txt
+
+      - name: Delete existing pre-release (if any)
+        run: |
+          gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
+          git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish pre-release
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --prerelease \
+            --title "Snapshot: ${{ github.ref_name }}" \
+            --notes "Preview snapshot from branch \`${{ github.ref_name }}\`. Not for production use." \
+            dist/dtwiz_*_linux_*.tar.gz \
+            dist/dtwiz_*_darwin_*.tar.gz \
+            dist/dtwiz_*_windows_*.zip \
+            dist/version.txt \
+            dist/checksums.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,14 @@ jobs:
           TAG="snapshot-$(echo "${{ github.ref_name }}" | tr '/' '-')"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Delete existing pre-release (if any)
+        run: |
+          gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
+          git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true
+          git tag -d "${{ steps.tag.outputs.tag }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser snapshot
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -39,15 +47,14 @@ jobs:
         id: version
         run: |
           VERSION=$(ls dist/dtwiz_*_linux_amd64.tar.gz | sed 's|.*dtwiz_\(.*\)_linux_amd64.tar.gz|\1|')
+          if [ -z "$VERSION" ]; then
+            echo "Error: could not determine snapshot version — no matching artifact found." >&2
+            echo "Contents of dist/:" >&2
+            ls -la dist/ 2>/dev/null || echo "  dist/ does not exist" >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "$VERSION" > dist/version.txt
-
-      - name: Delete existing pre-release (if any)
-        run: |
-          gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
-          git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish pre-release
         run: |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,7 +14,8 @@
 
 [CmdletBinding()]
 param(
-    [string]$InstallDir = ""
+    [string]$InstallDir = "",
+    [string]$Branch = $env:DTWIZ_BRANCH
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,26 +45,39 @@ switch ($RawArch) {
 
 Write-Host "Detected platform: windows/$Arch"
 
-# ── Resolve latest release version ────────────────────────────────────────────
-# Follow the /releases/latest redirect to extract the tag from the final URL.
-$Response = Invoke-WebRequest `
-    -Uri "https://github.com/$Repo/releases/latest" `
-    -MaximumRedirection 0 `
-    -ErrorAction SilentlyContinue `
-    -UseBasicParsing
-$RedirectUrl = $Response.Headers.Location
-if (-not $RedirectUrl) {
-    # Some PS versions follow the redirect automatically
-    $RedirectUrl = $Response.BaseResponse.ResponseUri.AbsoluteUri
-    if (-not $RedirectUrl) {
-        $RedirectUrl = $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+# ── Resolve release version ────────────────────────────────────────────────────
+if ($Branch) {
+    # Derive the pre-release tag from the branch name (e.g. preview/foo -> snapshot-preview-foo)
+    $ReleaseTag = "snapshot-" + ($Branch -replace '/', '-')
+    Write-Host "Installing preview snapshot for branch: $Branch"
+    $Version = (Invoke-WebRequest `
+        -Uri "https://github.com/$Repo/releases/download/$ReleaseTag/version.txt" `
+        -UseBasicParsing).Content.Trim()
+    if (-not $Version) {
+        Write-Error "Could not find a snapshot release for branch '$Branch'. Make sure the branch exists and its snapshot workflow has completed."
+        exit 1
     }
-}
-$Version = ($RedirectUrl -split '/')[-1]
-
-if (-not $Version) {
-    Write-Error "Could not determine the latest dtwiz version."
-    exit 1
+} else {
+    # Follow the /releases/latest redirect to extract the tag from the final URL.
+    $Response = Invoke-WebRequest `
+        -Uri "https://github.com/$Repo/releases/latest" `
+        -MaximumRedirection 0 `
+        -ErrorAction SilentlyContinue `
+        -UseBasicParsing
+    $RedirectUrl = $Response.Headers.Location
+    if (-not $RedirectUrl) {
+        # Some PS versions follow the redirect automatically
+        $RedirectUrl = $Response.BaseResponse.ResponseUri.AbsoluteUri
+        if (-not $RedirectUrl) {
+            $RedirectUrl = $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        }
+    }
+    $ReleaseTag = ($RedirectUrl -split '/')[-1]
+    $Version = $ReleaseTag
+    if (-not $Version) {
+        Write-Error "Could not determine the latest dtwiz version."
+        exit 1
+    }
 }
 
 # ── Determine install directory ────────────────────────────────────────────────
@@ -74,6 +88,9 @@ if (-not $InstallDir) {
 # ── Confirm installation ──────────────────────────────────────────────────────
 Write-Host ""
 Write-Host "This will download and install dtwiz ${Version}:"
+if ($Branch) {
+    Write-Host "  * Branch:   $Branch (pre-release)"
+}
 Write-Host "  * Download from github.com/${Repo}"
 Write-Host "  * Install to $InstallDir"
 Write-Host "  * Add $InstallDir to your user PATH (if not already present)"
@@ -96,7 +113,7 @@ New-Item -ItemType Directory -Path $TmpDir | Out-Null
 try {
     $ArchivePath = Join-Path $TmpDir $Archive
 
-    $DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$Archive"
+    $DownloadUrl = "https://github.com/$Repo/releases/download/$ReleaseTag/$Archive"
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath -UseBasicParsing
 
     Expand-Archive -Path $ArchivePath -DestinationPath $TmpDir -Force

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,11 @@
 
 REPO="dynatrace-oss/dtwiz"
 
+# Branch to install from. If set, a snapshot pre-release for that branch is used
+# instead of the latest stable release. Set via the DTWIZ_BRANCH env variable.
+# Example: DTWIZ_BRANCH=preview/my-branch source <(curl -sSL ...)
+BRANCH="${DTWIZ_BRANCH:-}"
+
 # ── Parse known flags ──────────────────────────────────────────────────────────
 INSTALL_DIR=""
 
@@ -51,20 +56,33 @@ esac
 
 echo "Detected platform: ${OS}/${ARCH}"
 
-# ── Resolve latest release version ────────────────────────────────────────────
+# ── Resolve release version ────────────────────────────────────────────────────
 if ! command -v curl >/dev/null 2>&1; then
     echo "Error: curl is required but not found." >&2
     exit 1
 fi
 
-# Follow the /releases/latest redirect to extract the tag from the final URL.
-VERSION="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
-    "https://github.com/${REPO}/releases/latest" \
-    | sed 's|.*/||')"
-
-if [ -z "$VERSION" ]; then
-    echo "Error: could not determine the latest dtwiz version." >&2
-    exit 1
+if [ -n "$BRANCH" ]; then
+    # Derive the pre-release tag from the branch name (e.g. preview/foo → snapshot-preview-foo)
+    RELEASE_TAG="snapshot-$(echo "$BRANCH" | tr '/' '-')"
+    echo "Installing preview snapshot for branch: ${BRANCH}"
+    VERSION="$(curl -fsSL \
+        "https://github.com/${REPO}/releases/download/${RELEASE_TAG}/version.txt")"
+    if [ -z "$VERSION" ]; then
+        echo "Error: could not find a snapshot release for branch '${BRANCH}'." >&2
+        echo "Make sure the branch exists and its snapshot workflow has completed." >&2
+        exit 1
+    fi
+else
+    # Follow the /releases/latest redirect to extract the tag from the final URL.
+    RELEASE_TAG="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+        "https://github.com/${REPO}/releases/latest" \
+        | sed 's|.*/||')"
+    VERSION="$RELEASE_TAG"
+    if [ -z "$VERSION" ]; then
+        echo "Error: could not determine the latest dtwiz version." >&2
+        exit 1
+    fi
 fi
 
 # ── Determine install directory ────────────────────────────────────────────────
@@ -79,6 +97,9 @@ fi
 # ── Confirm installation ───────────────────────────────────────────────────────
 echo ""
 echo "This will download and install dtwiz ${VERSION}:"
+if [ -n "$BRANCH" ]; then
+    echo "  - Branch:   ${BRANCH} (pre-release)"
+fi
 echo "  - Download from github.com/${REPO}"
 echo "  - Install to ${INSTALL_DIR}"
 echo "  - Add ${INSTALL_DIR} to your PATH (if not already present)"
@@ -100,7 +121,7 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
 
 curl -fsSL \
-    "https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}" \
+    "https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ARCHIVE}" \
     -o "${WORK_DIR}/${ARCHIVE}"
 
 tar -xzf "${WORK_DIR}/${ARCHIVE}" -C "$WORK_DIR"


### PR DESCRIPTION

The most important changes are:


## Description

This pull request introduces a preview snapshot release workflow for every branch (except `main` and `release/**`), and updates the install scripts to support installing from these branch-specific pre-release snapshots. This enables users and CI environments to easily test changes from any branch before they are merged.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Changes

* Added `.github/workflows/preview.yml` to build and publish a snapshot pre-release for every branch except `main` and `release/**`. The release is tagged as `snapshot-<branch-name>`, and includes versioning and artifact uploads for all platforms.
* Added `.github/workflows/preview-cleanup.yml` to automatically remove preview snapshot releases and tags when a pull request is closed or a branch is deleted.

## How to test

<!-- Steps for reviewers to test this PR. -->

1. notice snapshot for this release: https://github.com/dynatrace-oss/dtwiz/releases/tag/snapshot-chore-prototyping
2. actual calling of the install script can't be tested yet, it will be after merge to main.

## Checklist

- [x] I have tested these changes locally.
- [x] I followed the existing code style and conventions.
