### PR TITLE
chore: add multiple PR templates & git alias script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,11 +1,11 @@
-## Description
+## Bug Fix Description
+<!-- What was changed and why? -->
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Other (please describe):
+## Root cause
+<!-- What was causing the bug? -->
 
-<!-- What does this PR add? Why is it relevant? -->
+## How to reproduce
+1.
 
 ## How to test
 1.

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,11 @@
+## Chore Description
+
+<!-- Use for refactoring, dependency updates, tooling, CI, documentation, or cleanup. -->
+
+## What changed and why?
+<!-- Describe the change. For dependency updates, note the version diff and any breaking changes. -->
+
+## Checklist
+- [ ] Make sure Copilot has reviewed the PR as a preliminary check.
+- [ ] No unintended behavior changes were introduced.
+- [ ] CHANGELOG and/or documentation was updated where necessary.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,10 +1,4 @@
-## Description
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Other (please describe):
-
+## Feature Description
 <!-- What does this PR add? Why is it relevant? -->
 
 ## How to test

--- a/.github/gitconfig-shared-aliases
+++ b/.github/gitconfig-shared-aliases
@@ -1,0 +1,28 @@
+[alias]
+    # branching
+    feature = "!f() { git switch -c feature/$1; }; f"
+    hotfix = "!f() { git switch -c hotfix/$1; }; f"
+    bugfix = "!f() { git switch -c bugfix/$1; }; f"
+    chore = "!f() { git switch -c chore/$1; }; f"
+    # pr
+    open-pr = "!f() { \
+        branch=$(git rev-parse --abbrev-ref HEAD); \
+        base=\"https://github.com/dynatrace-oss/dtwiz/compare/main...${branch}?expand=1&template\"; \
+        case \"${branch}\" in \
+            feature/*) rec=\"feature.md\" ;; \
+            bugfix/*|fix/*|hotfix/*) rec=\"bugfix.md\" ;; \
+            chore/*|docs/*|refactor/*|test/*|style/*|release/*) rec=\"chore.md\" ;; \
+            *) rec=\"\" ;; \
+        esac; \
+        echo \"\"; \
+        echo \"Open PR for branch: ${branch}\"; \
+        echo \"\"; \
+        if [ -n \"${rec}\" ]; then \
+            echo \"  recommended  →  ${base}=${rec}\"; \
+            echo \"\"; \
+        fi; \
+        echo \"  feature  →  ${base}=feature.md\"; \
+        echo \"  bugfix   →  ${base}=bugfix.md\"; \
+        echo \"  chore    →  ${base}=chore.md\"; \
+        echo \"\"; \
+    }; f"

--- a/.github/gitconfig-shared-aliases
+++ b/.github/gitconfig-shared-aliases
@@ -1,9 +1,9 @@
 [alias]
     # branching
-    feature = "!f() { git switch -c feature/$1; }; f"
-    hotfix = "!f() { git switch -c hotfix/$1; }; f"
-    bugfix = "!f() { git switch -c bugfix/$1; }; f"
-    chore = "!f() { git switch -c chore/$1; }; f"
+    feature = "!f() { if [ -z \"$1\" ]; then echo \"usage: git feature <name>\"; return 1; fi; git switch -c \"feature/$1\"; }; f"
+    hotfix = "!f() { if [ -z \"$1\" ]; then echo \"usage: git hotfix <name>\"; return 1; fi; git switch -c \"hotfix/$1\"; }; f"
+    bugfix = "!f() { if [ -z \"$1\" ]; then echo \"usage: git bugfix <name>\"; return 1; fi; git switch -c \"bugfix/$1\"; }; f"
+    chore = "!f() { if [ -z \"$1\" ]; then echo \"usage: git chore <name>\"; return 1; fi; git switch -c \"chore/$1\"; }; f"
     # pr
     open-pr = "!f() { \
         branch=$(git rev-parse --abbrev-ref HEAD); \


### PR DESCRIPTION
## Chore Description

We need to standardize our PR templates for various purposes, currently only for features, bugfixes and chores.

## What changed and why?
1. Added three templates and updated an existing one.
2. To use the templates, we need to specify the `template` query parameter in the URL when creating the PR. To improve on that, a script was added that introduces git aliases, including the one for generating a PR link.
Usage:
```
git config --local include.path "$(pwd)/.github/gitconfig-shared-aliases"  
```

## Checklist
- [x] No unintended behavior changes were introduced.
- [x] CHANGELOG and/or documentation was updated where necessary.
