### PR TITLE
chore: use gh api to clean up tags

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Delete preview release and tag
         run: |
           gh release delete "${{ steps.branch.outputs.tag }}" --yes || true
-          git push origin ":refs/tags/${{ steps.branch.outputs.tag }}" || true
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${{ steps.branch.outputs.tag }}" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -22,13 +22,15 @@ jobs:
             BRANCH="${{ github.event.pull_request.head.ref }}"
           fi
           TAG="snapshot-$(echo "$BRANCH" | tr '/' '-')"
+          ENCODED_TAG="$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$TAG")"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "encoded_tag=$ENCODED_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Delete preview release and tag
         run: |
           gh release delete "${{ steps.branch.outputs.tag }}" --yes || true
-          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${{ steps.branch.outputs.tag }}" || true
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${{ steps.branch.outputs.encoded_tag }}" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,7 +38,6 @@ jobs:
           fi
 
       - name: Delete existing pre-release (if any)
-        if: steps.semver.outputs.found == 'true'
         run: |
           gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
           git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,7 +27,18 @@ jobs:
           TAG="snapshot-$(echo "${{ github.ref_name }}" | tr '/' '-')"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Check for semver tag
+        id: semver
+        run: |
+          if git describe --tags --match "v*" --abbrev=0 > /dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No semver tag reachable — skipping snapshot." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Delete existing pre-release (if any)
+        if: steps.semver.outputs.found == 'true'
         run: |
           gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
           git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true
@@ -36,6 +47,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser snapshot
+        if: steps.semver.outputs.found == 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
@@ -44,6 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Capture snapshot version
+        if: steps.semver.outputs.found == 'true'
         id: version
         run: |
           VERSION=$(ls dist/dtwiz_*_linux_amd64.tar.gz | sed 's|.*dtwiz_\(.*\)_linux_amd64.tar.gz|\1|')
@@ -57,6 +70,7 @@ jobs:
           echo "$VERSION" > dist/version.txt
 
       - name: Publish pre-release
+        if: steps.semver.outputs.found == 'true'
         run: |
           gh release create "${{ steps.tag.outputs.tag }}" \
             --prerelease \


### PR DESCRIPTION
## Description

- [x] Other (please describe): improve preview cleanup

use GitHub API command instead of the git command to clean up tags because tags are not reachable post PR merge.

Streamlining preview creation to create previews only if tags are reachable.

## How to test
1. unfortunately needs to be merged to be tested

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I followed the existing code style and conventions.
