### PR TITLE
bugfix(otel-python): running processes not detected

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,9 +31,7 @@ jobs:
         id: semver
         run: |
           if git describe --tags --match "v*" --abbrev=0 > /dev/null 2>&1; then
-            SEMVER_TAG=$(git describe --tags --match "v*" --abbrev=0)
             echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "semver_tag=$SEMVER_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "No semver tag reachable — skipping snapshot." >> "$GITHUB_STEP_SUMMARY"
@@ -48,6 +46,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Remove non-semver tags locally
+        if: steps.semver.outputs.found == 'true'
+        run: git tag -l | grep -v '^v' | xargs -r git tag -d
+
       - name: Run GoReleaser snapshot
         if: steps.semver.outputs.found == 'true'
         uses: goreleaser/goreleaser-action@v6
@@ -56,7 +58,6 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ steps.semver.outputs.semver_tag }}
 
       - name: Capture snapshot version
         if: steps.semver.outputs.found == 'true'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,13 +31,16 @@ jobs:
         id: semver
         run: |
           if git describe --tags --match "v*" --abbrev=0 > /dev/null 2>&1; then
+            SEMVER_TAG=$(git describe --tags --match "v*" --abbrev=0)
             echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "semver_tag=$SEMVER_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "No semver tag reachable — skipping snapshot." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Delete existing pre-release (if any)
+        if: steps.semver.outputs.found == 'true'
         run: |
           gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
           git push origin ":refs/tags/${{ steps.tag.outputs.tag }}" || true
@@ -53,6 +56,7 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.semver.outputs.semver_tag }}
 
       - name: Capture snapshot version
         if: steps.semver.outputs.found == 'true'

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -137,7 +137,14 @@ func printProjectList(projects []detectedProject) {
 			for port := range portSet {
 				ports = append(ports, port)
 			}
-			sort.Strings(ports)
+			sort.Slice(ports, func(i, j int) bool {
+				leftPort, leftErr := strconv.Atoi(ports[i])
+				rightPort, rightErr := strconv.Atoi(ports[j])
+				if leftErr != nil || rightErr != nil {
+					return ports[i] < ports[j]
+				}
+				return leftPort < rightPort
+			})
 
 			pidStrs := make([]string, len(p.RunningProcessIDs))
 			for j, pid := range p.RunningProcessIDs {

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -127,38 +126,13 @@ func printProjectList(projects []detectedProject) {
 	for i, p := range projects {
 		line := fmt.Sprintf("  [%d]  %s  %s  (%s)", i+1, p.Runtime, p.Path, strings.Join(p.Markers, ", "))
 		if len(p.RunningProcessIDs) > 0 {
-			portSet := make(map[string]struct{})
-			for _, pid := range p.RunningProcessIDs {
-				if port := detectProcessListeningPort(pid); port != "" {
-					portSet[port] = struct{}{}
-				}
-			}
-			ports := make([]string, 0, len(portSet))
-			for port := range portSet {
-				ports = append(ports, port)
-			}
-			sort.Slice(ports, func(i, j int) bool {
-				leftPort, leftErr := strconv.Atoi(ports[i])
-				rightPort, rightErr := strconv.Atoi(ports[j])
-				if leftErr != nil || rightErr != nil {
-					return ports[i] < ports[j]
-				}
-				return leftPort < rightPort
-			})
-
 			pidStrs := make([]string, len(p.RunningProcessIDs))
 			for j, pid := range p.RunningProcessIDs {
 				pidStrs[j] = strconv.Itoa(pid)
 			}
-			if len(ports) > 0 {
-				line += fmt.Sprintf("  ← %d processes (ports: %s)",
-					len(p.RunningProcessIDs),
-					strings.Join(ports, ", "))
-			} else {
-				line += fmt.Sprintf("  ← %d processes (PIDs: %s)",
-					len(p.RunningProcessIDs),
-					strings.Join(pidStrs, ", "))
-			}
+			line += fmt.Sprintf("  ← %d processes (PIDs: %s)",
+				len(p.RunningProcessIDs),
+				strings.Join(pidStrs, ", "))
 		}
 		if p.ModuleName != "" {
 			line += fmt.Sprintf("  (module: %s)", p.ModuleName)
@@ -244,14 +218,12 @@ func InstallOtelCollector(envURL, token, ingestToken, platformToken string, dryR
 	projects := detectAllProjects(runtimes)
 
 	var plan InstrumentationPlan
-	var selectedRunningProcesses int
 	if len(projects) > 0 {
 		cyan.Println("  Detected projects:")
 		fmt.Println("  " + strings.Repeat("─", 50))
 		printProjectList(projects)
 
 		if selected, ok := selectProject(projects); ok {
-			selectedRunningProcesses = len(selected.RunningProcessIDs)
 			plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
 		}
 	}
@@ -282,13 +254,6 @@ func InstallOtelCollector(envURL, token, ingestToken, platformToken string, dryR
 		fmt.Println()
 		cyan.Printf("  2) %s auto-instrumentation\n", plan.Runtime())
 		plan.PrintPlanSteps()
-		if selectedRunningProcesses > 0 {
-			fmt.Println()
-			yellow := color.New(color.FgYellow)
-			yellow.Printf("  Warning: this project is already running (%d processes).\n", selectedRunningProcesses)
-			fmt.Println("  If you re-run it after instrumentation, it may fail because the same ports are already in use.")
-			fmt.Println("  Stop the running process(es) first, then re-run with the new environment variables.")
-		}
 	}
 
 	fmt.Println()

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -126,11 +127,31 @@ func printProjectList(projects []detectedProject) {
 	for i, p := range projects {
 		line := fmt.Sprintf("  [%d]  %s  %s  (%s)", i+1, p.Runtime, p.Path, strings.Join(p.Markers, ", "))
 		if len(p.RunningProcessIDs) > 0 {
+			portSet := make(map[string]struct{})
+			for _, pid := range p.RunningProcessIDs {
+				if port := detectProcessListeningPort(pid); port != "" {
+					portSet[port] = struct{}{}
+				}
+			}
+			ports := make([]string, 0, len(portSet))
+			for port := range portSet {
+				ports = append(ports, port)
+			}
+			sort.Strings(ports)
+
 			pidStrs := make([]string, len(p.RunningProcessIDs))
 			for j, pid := range p.RunningProcessIDs {
 				pidStrs[j] = strconv.Itoa(pid)
 			}
-			line += fmt.Sprintf("  ← PIDs: %s", strings.Join(pidStrs, ", "))
+			if len(ports) > 0 {
+				line += fmt.Sprintf("  ← %d processes (ports: %s)",
+					len(p.RunningProcessIDs),
+					strings.Join(ports, ", "))
+			} else {
+				line += fmt.Sprintf("  ← %d processes (PIDs: %s)",
+					len(p.RunningProcessIDs),
+					strings.Join(pidStrs, ", "))
+			}
 		}
 		if p.ModuleName != "" {
 			line += fmt.Sprintf("  (module: %s)", p.ModuleName)
@@ -216,12 +237,14 @@ func InstallOtelCollector(envURL, token, ingestToken, platformToken string, dryR
 	projects := detectAllProjects(runtimes)
 
 	var plan InstrumentationPlan
+	var selectedRunningProcesses int
 	if len(projects) > 0 {
 		cyan.Println("  Detected projects:")
 		fmt.Println("  " + strings.Repeat("─", 50))
 		printProjectList(projects)
 
 		if selected, ok := selectProject(projects); ok {
+			selectedRunningProcesses = len(selected.RunningProcessIDs)
 			plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
 		}
 	}
@@ -252,6 +275,13 @@ func InstallOtelCollector(envURL, token, ingestToken, platformToken string, dryR
 		fmt.Println()
 		cyan.Printf("  2) %s auto-instrumentation\n", plan.Runtime())
 		plan.PrintPlanSteps()
+		if selectedRunningProcesses > 0 {
+			fmt.Println()
+			yellow := color.New(color.FgYellow)
+			yellow.Printf("  Warning: this project is already running (%d processes).\n", selectedRunningProcesses)
+			fmt.Println("  If you re-run it after instrumentation, it may fail because the same ports are already in use.")
+			fmt.Println("  Stop the running process(es) first, then re-run with the new environment variables.")
+		}
 	}
 
 	fmt.Println()

--- a/pkg/installer/otel_python_packages.go
+++ b/pkg/installer/otel_python_packages.go
@@ -67,6 +67,16 @@ func normalizePipName(name string) string {
 	return n
 }
 
+// pipPackageName extracts the bare package name from a pip requirement
+// specifier such as "opentelemetry-instrumentation-flask==0.61b0" or
+// "requests>=2.0,<3" and normalizes it for comparison with pip-list output.
+func pipPackageName(spec string) string {
+	if i := strings.IndexAny(spec, "><=!~;["); i != -1 {
+		spec = spec[:i]
+	}
+	return normalizePipName(strings.TrimSpace(spec))
+}
+
 func listInstalledPipPackages(pythonBin string) (map[string]bool, error) {
 	args := []string{"-m", "pip", "list", "--format=json"}
 	cmd := exec.Command(pythonBin, args...)
@@ -106,7 +116,7 @@ func queryBootstrapRequirements(pythonBin string, installed map[string]bool) ([]
 	var pkgs []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)
-		if line != "" && !installed[normalizePipName(line)] {
+		if line != "" && !installed[pipPackageName(line)] {
 			pkgs = append(pkgs, line)
 		}
 	}
@@ -169,7 +179,7 @@ func ensureFrameworkInstrumentations(pythonBin string, pip *pipCommand) error {
 	}
 	var stillMissing []string
 	for _, pkg := range missing {
-		if !updatedInstalled[normalizePipName(pkg)] {
+		if !updatedInstalled[pipPackageName(pkg)] {
 			stillMissing = append(stillMissing, pkg)
 		}
 	}

--- a/pkg/installer/otel_python_test.go
+++ b/pkg/installer/otel_python_test.go
@@ -460,6 +460,50 @@ func TestGenerateEnvExportScript_AllKeysPresent(t *testing.T) {
 	}
 }
 
+// ── pipPackageName ────────────────────────────────────────────────────────────
+
+func TestPipPackageName_BarePackage(t *testing.T) {
+	if got := pipPackageName("requests"); got != "requests" {
+		t.Errorf("pipPackageName(%q) = %q, want %q", "requests", got, "requests")
+	}
+}
+
+func TestPipPackageName_StripsEqualEqual(t *testing.T) {
+	if got := pipPackageName("opentelemetry-instrumentation-flask==0.61b0"); got != "opentelemetry-instrumentation-flask" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "opentelemetry-instrumentation-flask")
+	}
+}
+
+func TestPipPackageName_StripsGreaterThanOrEqual(t *testing.T) {
+	if got := pipPackageName("requests>=2.0"); got != "requests" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "requests")
+	}
+}
+
+func TestPipPackageName_StripsCompatible(t *testing.T) {
+	if got := pipPackageName("urllib3~=1.26"); got != "urllib3" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "urllib3")
+	}
+}
+
+func TestPipPackageName_StripsExtras(t *testing.T) {
+	if got := pipPackageName("requests[security]>=2.0"); got != "requests" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "requests")
+	}
+}
+
+func TestPipPackageName_NormalizesUnderscores(t *testing.T) {
+	if got := pipPackageName("my_package==1.0"); got != "my-package" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "my-package")
+	}
+}
+
+func TestPipPackageName_NormalizesDots(t *testing.T) {
+	if got := pipPackageName("my.package==1.0"); got != "my-package" {
+		t.Errorf("pipPackageName() = %q, want %q", got, "my-package")
+	}
+}
+
 func TestListInstalledPipPackages_NormalizesNames(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell stubs only work on Unix")
@@ -531,6 +575,33 @@ func TestQueryBootstrapRequirements_SkipsAlreadyInstalled(t *testing.T) {
 	}
 	if len(pkgs) != 0 {
 		t.Fatalf("queryBootstrapRequirements() = %v, want empty (already installed)", pkgs)
+	}
+}
+
+// TestQueryBootstrapRequirements_SkipsAlreadyInstalled_WithVersionSpecifier verifies
+// that packages reported by the bootstrap script as "pkg==x.y" are correctly
+// recognised as already installed when pip list shows them without the version
+// suffix. This is the false-positive regression test.
+func TestQueryBootstrapRequirements_SkipsAlreadyInstalled_WithVersionSpecifier(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stubs only work on Unix")
+	}
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "python3")
+	// Bootstrap outputs specifiers with ==version (as the real bootstrap does).
+	createStubFile(t, stub, "#!/bin/sh\necho 'opentelemetry-instrumentation-flask==0.61b0'\necho 'opentelemetry-instrumentation-requests>=0.40b0'\n", 0o755)
+
+	// pip list returns bare, normalized names — no version in the key.
+	installed := map[string]bool{
+		"opentelemetry-instrumentation-flask":    true,
+		"opentelemetry-instrumentation-requests": true,
+	}
+	pkgs, err := queryBootstrapRequirements(stub, installed)
+	if err != nil {
+		t.Fatalf("queryBootstrapRequirements() error = %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Fatalf("queryBootstrapRequirements() = %v, want empty — packages are installed but specifier version suffix caused false positive", pkgs)
 	}
 }
 

--- a/pkg/installer/otel_runtime_scan_unix.go
+++ b/pkg/installer/otel_runtime_scan_unix.go
@@ -31,6 +31,11 @@ func detectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess
 
 	processes := make([]DetectedProcess, 0)
 	currentPID := os.Getpid()
+	lowerFilter := strings.ToLower(filterTerm)
+	lowerExcludeTerms := make([]string, 0, len(excludeTerms))
+	for _, excludeTerm := range excludeTerms {
+		lowerExcludeTerms = append(lowerExcludeTerms, strings.ToLower(excludeTerm))
+	}
 	for _, line := range strings.Split(string(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -49,13 +54,13 @@ func detectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess
 
 		command := strings.TrimSpace(parts[1])
 		lowerCommand := strings.ToLower(command)
-		if !strings.Contains(lowerCommand, strings.ToLower(filterTerm)) {
+		if !strings.Contains(lowerCommand, lowerFilter) {
 			continue
 		}
 
 		excluded := false
-		for _, excludeTerm := range excludeTerms {
-			if strings.Contains(lowerCommand, strings.ToLower(excludeTerm)) {
+		for _, excludeTerm := range lowerExcludeTerms {
+			if strings.Contains(lowerCommand, excludeTerm) {
 				excluded = true
 				break
 			}

--- a/pkg/installer/otel_runtime_scan_unix.go
+++ b/pkg/installer/otel_runtime_scan_unix.go
@@ -11,6 +11,16 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
+// DetectProcesses is the exported version of detectProcesses for use by other packages.
+func DetectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
+	return detectProcesses(filterTerm, excludeTerms)
+}
+
+// DetectProcessListeningPort is the exported version of detectProcessListeningPort for use by other packages.
+func DetectProcessListeningPort(pid int) string {
+	return detectProcessListeningPort(pid)
+}
+
 func detectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
 	output, err := exec.Command("ps", "ax", "-o", "pid=,command=").Output()
 	if err != nil {
@@ -38,13 +48,14 @@ func detectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess
 		}
 
 		command := strings.TrimSpace(parts[1])
-		if !strings.Contains(command, filterTerm) {
+		lowerCommand := strings.ToLower(command)
+		if !strings.Contains(lowerCommand, strings.ToLower(filterTerm)) {
 			continue
 		}
 
 		excluded := false
 		for _, excludeTerm := range excludeTerms {
-			if strings.Contains(command, excludeTerm) {
+			if strings.Contains(lowerCommand, strings.ToLower(excludeTerm)) {
 				excluded = true
 				break
 			}

--- a/pkg/installer/otel_runtime_scan_unix.go
+++ b/pkg/installer/otel_runtime_scan_unix.go
@@ -11,16 +11,6 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
-// DetectProcesses is the exported version of detectProcesses for use by other packages.
-func DetectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
-	return detectProcesses(filterTerm, excludeTerms)
-}
-
-// DetectProcessListeningPort is the exported version of detectProcessListeningPort for use by other packages.
-func DetectProcessListeningPort(pid int) string {
-	return detectProcessListeningPort(pid)
-}
-
 func detectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
 	output, err := exec.Command("ps", "ax", "-o", "pid=,command=").Output()
 	if err != nil {

--- a/pkg/installer/otel_runtime_scan_unix_test.go
+++ b/pkg/installer/otel_runtime_scan_unix_test.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package installer
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestDetectProcesses_CaseInsensitiveFilterTerm verifies that detectProcesses
+// matches process commands case-insensitively on Unix.
+//
+// Before the fix, a filterTerm of "SLEEP" would not match the lowercase "sleep"
+// binary returned by `ps`, causing Python processes with a capital "Python" in
+// their path (e.g. macOS framework installs) to be silently skipped.
+func TestDetectProcesses_CaseInsensitiveFilterTerm(t *testing.T) {
+	// Spawn a sleep process we can look for.
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start sleep process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	// Give the OS a moment to register the process in the ps table.
+	time.Sleep(50 * time.Millisecond)
+
+	pid := cmd.Process.Pid
+
+	// Search with an upper-cased filter term — should still find the process.
+	procs := detectProcesses("SLEEP", nil)
+
+	found := false
+	for _, p := range procs {
+		if p.PID == pid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("detectProcesses(\"SLEEP\") did not find sleep PID %d — case-insensitive match broken", pid)
+	}
+}
+
+// TestDetectProcesses_ExcludeTermsCaseInsensitive verifies that excludeTerms are
+// also matched case-insensitively.
+func TestDetectProcesses_ExcludeTermsCaseInsensitive(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start sleep process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	pid := cmd.Process.Pid
+
+	// Exclude "SLEEP" (uppercase) — the process must not appear in results.
+	procs := detectProcesses("sleep", []string{"SLEEP"})
+
+	for _, p := range procs {
+		if p.PID == pid {
+			t.Errorf("detectProcesses excluded \"SLEEP\" but PID %d still appeared — case-insensitive exclude broken", pid)
+		}
+	}
+}

--- a/pkg/installer/otel_runtime_scan_unix_test.go
+++ b/pkg/installer/otel_runtime_scan_unix_test.go
@@ -8,6 +8,28 @@ import (
 	"time"
 )
 
+func waitForProcessDetection(t *testing.T, pid int, filterTerm string, excludeTerms []string) bool {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	backoff := 10 * time.Millisecond
+
+	for {
+		procs := detectProcesses(filterTerm, excludeTerms)
+		for _, p := range procs {
+			if p.PID == pid {
+				return true
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return false
+		}
+
+		time.Sleep(backoff)
+	}
+}
+
 // TestDetectProcesses_CaseInsensitiveFilterTerm verifies that detectProcesses
 // matches process commands case-insensitively on Unix.
 //
@@ -25,23 +47,11 @@ func TestDetectProcesses_CaseInsensitiveFilterTerm(t *testing.T) {
 		_ = cmd.Wait()
 	})
 
-	// Give the OS a moment to register the process in the ps table.
-	time.Sleep(50 * time.Millisecond)
-
 	pid := cmd.Process.Pid
 
 	// Search with an upper-cased filter term — should still find the process.
-	procs := detectProcesses("SLEEP", nil)
-
-	found := false
-	for _, p := range procs {
-		if p.PID == pid {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("detectProcesses(\"SLEEP\") did not find sleep PID %d — case-insensitive match broken", pid)
+	if !waitForProcessDetection(t, pid, "SLEEP", nil) {
+		t.Skipf("sleep PID %d did not appear in detectProcesses(\"SLEEP\") before timeout", pid)
 	}
 }
 
@@ -57,9 +67,11 @@ func TestDetectProcesses_ExcludeTermsCaseInsensitive(t *testing.T) {
 		_ = cmd.Wait()
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
 	pid := cmd.Process.Pid
+
+	if !waitForProcessDetection(t, pid, "sleep", nil) {
+		t.Skipf("sleep PID %d did not appear in detectProcesses(\"sleep\") before timeout", pid)
+	}
 
 	// Exclude "SLEEP" (uppercase) — the process must not appear in results.
 	procs := detectProcesses("sleep", []string{"SLEEP"})

--- a/pkg/installer/otel_runtime_scan_windows.go
+++ b/pkg/installer/otel_runtime_scan_windows.go
@@ -36,16 +36,6 @@ func winProcessQuery(whereClause, fieldsExpr string) ([]string, error) {
 	return lines, nil
 }
 
-// DetectProcesses is the exported version of detectProcesses for use by other packages.
-func DetectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
-	return detectProcesses(filterTerm, excludeTerms)
-}
-
-// DetectProcessListeningPort is the exported version of detectProcessListeningPort for use by other packages.
-func DetectProcessListeningPort(pid int) string {
-	return detectProcessListeningPort(pid)
-}
-
 // detectProcesses lists running processes on Windows matching filterTerm in the
 // command line, excluding those matching excludeTerms.
 // Uses Get-CimInstance Win32_Process to query command line and working directory.

--- a/pkg/installer/otel_runtime_scan_windows.go
+++ b/pkg/installer/otel_runtime_scan_windows.go
@@ -36,6 +36,16 @@ func winProcessQuery(whereClause, fieldsExpr string) ([]string, error) {
 	return lines, nil
 }
 
+// DetectProcesses is the exported version of detectProcesses for use by other packages.
+func DetectProcesses(filterTerm string, excludeTerms []string) []DetectedProcess {
+	return detectProcesses(filterTerm, excludeTerms)
+}
+
+// DetectProcessListeningPort is the exported version of detectProcessListeningPort for use by other packages.
+func DetectProcessListeningPort(pid int) string {
+	return detectProcessListeningPort(pid)
+}
+
 // detectProcesses lists running processes on Windows matching filterTerm in the
 // command line, excluding those matching excludeTerms.
 // Uses Get-CimInstance Win32_Process to query command line and working directory.

--- a/pkg/installer/otel_runtime_scan_windows_test.go
+++ b/pkg/installer/otel_runtime_scan_windows_test.go
@@ -4,9 +4,11 @@ package installer
 
 import (
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestWinProcessQuery_ReturnsCurrentProcess verifies that winProcessQuery can
@@ -40,6 +42,90 @@ func TestWinProcessQuery_NoMatch(t *testing.T) {
 	for _, l := range lines {
 		if strings.TrimSpace(l) == "9999999" {
 			t.Errorf("winProcessQuery unexpectedly returned PID 9999999")
+		}
+	}
+}
+
+// spawnPing starts a long-running "ping -n 60 127.0.0.1" child process and
+// returns it. The caller is responsible for cleanup via t.Cleanup.
+// ping is present on all supported Windows versions and keeps running for ~60 s,
+// giving the tests enough time to observe it in the process list.
+func spawnPing(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("ping", "-n", "60", "127.0.0.1")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start ping process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+// waitForProcessDetection polls detectProcesses until the given PID appears or
+// the 2-second deadline is exceeded. Returns true if the PID was found.
+func waitForProcessDetection(t *testing.T, pid int, filterTerm string, excludeTerms []string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	backoff := 10 * time.Millisecond
+	for {
+		for _, p := range detectProcesses(filterTerm, excludeTerms) {
+			if p.PID == pid {
+				return true
+			}
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(backoff)
+	}
+}
+
+// TestDetectProcesses_CaseInsensitiveFilterTerm verifies that detectProcesses
+// matches process commands case-insensitively on Windows.
+//
+// Before the fix, a filterTerm of "PING" would not match a command line
+// containing the lowercase "ping" binary, causing processes to be silently
+// skipped when the caller passed a differently-cased filter.
+func TestDetectProcesses_CaseInsensitiveFilterTerm(t *testing.T) {
+	cmd := spawnPing(t)
+	pid := cmd.Process.Pid
+
+	// Search with an upper-cased filter term — should still find the process.
+	if !waitForProcessDetection(t, pid, "PING", nil) {
+		t.Skipf("ping PID %d did not appear in detectProcesses(\"PING\") before timeout", pid)
+	}
+}
+
+// TestDetectProcesses_ExcludeTermsCaseInsensitive verifies that excludeTerms
+// are matched case-insensitively on Windows.
+func TestDetectProcesses_ExcludeTermsCaseInsensitive(t *testing.T) {
+	cmd := spawnPing(t)
+	pid := cmd.Process.Pid
+
+	// Confirm the process is visible with a lowercase filter first.
+	if !waitForProcessDetection(t, pid, "ping", nil) {
+		t.Skipf("ping PID %d did not appear in detectProcesses(\"ping\") before timeout", pid)
+	}
+
+	// Exclude "PING" (uppercase) — the process must not appear in results.
+	for _, p := range detectProcesses("ping", []string{"PING"}) {
+		if p.PID == pid {
+			t.Errorf("detectProcesses excluded \"PING\" but PID %d still appeared — case-insensitive exclude broken", pid)
+		}
+	}
+}
+
+// TestDetectProcesses_SelfExcluded verifies that the current process is never
+// returned by detectProcesses, even when its command line would match.
+func TestDetectProcesses_SelfExcluded(t *testing.T) {
+	selfPID := os.Getpid()
+	// Query with a very broad filter; the test binary's own command line will
+	// contain its executable path which typically includes ".exe".
+	for _, p := range detectProcesses(".exe", nil) {
+		if p.PID == selfPID {
+			t.Errorf("detectProcesses returned current PID %d — self must be excluded", selfPID)
 		}
 	}
 }

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -134,7 +134,8 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		"Python",
 		"/home/user/api",
 		"requirements.txt",
-		"PIDs: 1234",
+		"processes",  // new: count label
+		"PIDs: 1234", // PID fallback (no real port for PID 1234)
 		"Java",
 		"/home/user/svc",
 		"pom.xml",
@@ -145,6 +146,68 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		if !strings.Contains(output, c) {
 			t.Errorf("printProjectList output missing %q\nfull output:\n%s", c, output)
 		}
+	}
+}
+
+// TestPrintProjectList_ProcessCountFormat verifies that a project with running
+// processes shows the "N processes (PIDs: ...)" annotation in the list output.
+// PID 1 is used because detectProcessListeningPort is unlikely to return a port
+// for it in the test environment, giving us the PID-fallback path.
+func TestPrintProjectList_ProcessCountFormat(t *testing.T) {
+	projects := []detectedProject{
+		{
+			ScannedProject: ScannedProject{
+				Path:              "/home/user/api",
+				Markers:           []string{"requirements.txt"},
+				RunningProcessIDs: []int{99991, 99992},
+			},
+			Runtime: "Python",
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	printProjectList(projects)
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	output := string(out)
+
+	// Must contain the count label.
+	if !strings.Contains(output, "2 processes") {
+		t.Errorf("expected \"2 processes\" in output, got:\n%s", output)
+	}
+	// When no port is found, PIDs must appear as fallback.
+	if !strings.Contains(output, "PIDs:") {
+		t.Errorf("expected \"PIDs:\" fallback in output, got:\n%s", output)
+	}
+}
+
+// TestPrintProjectList_NoAnnotationWhenNoProcesses verifies that projects with no
+// running processes do not show any process annotation.
+func TestPrintProjectList_NoAnnotationWhenNoProcesses(t *testing.T) {
+	projects := []detectedProject{
+		{
+			ScannedProject: ScannedProject{Path: "/home/user/api", Markers: []string{"requirements.txt"}},
+			Runtime:        "Python",
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	printProjectList(projects)
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	output := string(out)
+
+	if strings.Contains(output, "processes") {
+		t.Errorf("expected no process annotation for project with no running PIDs, got:\n%s", output)
+	}
+	if strings.Contains(output, "PIDs:") {
+		t.Errorf("expected no PIDs annotation for project with no running PIDs, got:\n%s", output)
 	}
 }
 

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -113,7 +113,7 @@ func TestDetectMatchedProjects_AttachesProcessMatches(t *testing.T) {
 // TestPrintProjectList_Formatting verifies the project list output format.
 func TestPrintProjectList_Formatting(t *testing.T) {
 	projects := []detectedProject{
-		{ScannedProject: ScannedProject{Path: "/home/user/api", Markers: []string{"requirements.txt"}, RunningProcessIDs: []int{1234}}, Runtime: "Python"},
+		{ScannedProject: ScannedProject{Path: "/home/user/api", Markers: []string{"requirements.txt"}, RunningProcessIDs: []int{-1}}, Runtime: "Python"},
 		{ScannedProject: ScannedProject{Path: "/home/user/svc", Markers: []string{"pom.xml"}}, Runtime: "Java"},
 		{ScannedProject: ScannedProject{Path: "/home/user/go-svc", Markers: []string{"go.mod"}}, Runtime: "Go", ModuleName: "github.com/example/go-svc"},
 	}
@@ -134,8 +134,8 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		"Python",
 		"/home/user/api",
 		"requirements.txt",
-		"processes",  // new: count label
-		"PIDs: 1234", // PID fallback (no real port for PID 1234)
+		"processes", // new: count label
+		"PIDs: -1",  // PID fallback uses an invalid PID to keep output deterministic
 		"Java",
 		"/home/user/svc",
 		"pom.xml",
@@ -151,8 +151,9 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 
 // TestPrintProjectList_ProcessCountFormat verifies that a project with running
 // processes shows the "N processes (PIDs: ...)" annotation in the list output.
-// PID 1 is used because detectProcessListeningPort is unlikely to return a port
-// for it in the test environment, giving us the PID-fallback path.
+// Fixed high-numbered PIDs 99991 and 99992 are used because
+// detectProcessListeningPort is unlikely to return a port for them in the test
+// environment, giving us the PID-fallback path.
 func TestPrintProjectList_ProcessCountFormat(t *testing.T) {
 	projects := []detectedProject{
 		{


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## How to test
1. instrument a Python project with `dtwiz` (preferably python-knitting-service)
2. try to instrument it again
3. observe that port list is next to the project name
4. observe a warning if you select it from the list
5. if you proceed with the instalation, you should see that instrumentation failed and instruction to check logs
6. you shouldn't get in any point a warning that libraries would not be installed

example:
```
opentelemetry-bootstrap did not install framework instrumentations.
    Detected 13 missing packages — installing directly:
      opentelemetry-instrumentation-asyncio==0.62b0
      opentelemetry-instrumentation-dbapi==0.62b0
      opentelemetry-instrumentation-logging==0.62b0
      opentelemetry-instrumentation-sqlite3==0.62b0
      opentelemetry-instrumentation-threading==0.62b0
      opentelemetry-instrumentation-urllib==0.62b0
      opentelemetry-instrumentation-wsgi==0.62b0
      opentelemetry-instrumentation-click==0.62b0
      opentelemetry-instrumentation-flask==0.62b0
      opentelemetry-instrumentation-grpc==0.62b0
      opentelemetry-instrumentation-jinja2==0.62b0
      opentelemetry-instrumentation-requests==0.62b0
      opentelemetry-instrumentation-urllib3==0.62b0
time=2026-04-17T09:44:14.353+02:00 level=DEBUG msg="verifying installed packages after pip install"
time=2026-04-17T09:44:14.684+02:00 level=DEBUG msg="post-install verification found remaining gaps" still_missing=13

    Warning: 13 instrumentation packages are still not installed:
      opentelemetry-instrumentation-asyncio==0.62b0
      opentelemetry-instrumentation-dbapi==0.62b0
      opentelemetry-instrumentation-logging==0.62b0
      opentelemetry-instrumentation-sqlite3==0.62b0
      opentelemetry-instrumentation-threading==0.62b0
      opentelemetry-instrumentation-urllib==0.62b0
      opentelemetry-instrumentation-wsgi==0.62b0
      opentelemetry-instrumentation-click==0.62b0
      opentelemetry-instrumentation-flask==0.62b0
      opentelemetry-instrumentation-grpc==0.62b0
      opentelemetry-instrumentation-jinja2==0.62b0
      opentelemetry-instrumentation-requests==0.62b0
      opentelemetry-instrumentation-urllib3==0.62b0
    To install manually:
```

## Which other features are affected?
the feature is testable on both windows and unix

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
