### PR TITLE
chore: bump go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,6 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.24.13']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,84 @@
-version: "2"
+version: '2'
+
+run:
+  timeout: 5m
+  go: '1.26'
+
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/dynatrace-oss/dtwiz
 
 linters:
-  default: none
   enable:
-    - errcheck
     - govet
-    - ineffassign
     - staticcheck
+    - errcheck
+    - gocritic
+    - ineffassign
     - unused
+
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"    # Disable quickfix suggestions (stylistic, not bugs)
+        - "-ST1003" # Don't enforce ID naming convention (breaks JSON field mapping)
+        - "-S1016"  # Don't require struct conversion shorthand
+        # ST1005 (error string conventions) re-enabled — Go convention
+
+    errcheck:
+      exclude-functions:
+        # Cobra flag registration — panics on error, never fails at runtime
+        - "(*github.com/spf13/cobra/Command).MarkFlagRequired"
+        # HTTP response writers — errors are unrecoverable in handlers
+        - "(net/http.ResponseWriter).Write"
+        # JSON encoder — used in test mock servers and HTTP handlers
+        - "(*encoding/json.Encoder).Encode"
+
+  exclusions:
+    presets:
+      - comments          # ST1000, ST1020, ST1021, ST1022
+      - std-error-handling # errcheck: Close, Flush, Remove(All), print/printf/println, Setenv/Unsetenv, stdout/stderr
+
+    rules:
+      # Allow unchecked errors in test code (deferred cleanup, test helpers, mock servers)
+      - path: _test\.go
+        linters:
+          - errcheck
+      # Allow unchecked fmt.Fprint* (writing to io.Writer for output)
+      - linters:
+          - errcheck
+        text: "fmt\\.Fprint"
+      # Allow unchecked w.Write / w.Close / buf.ReadFrom (io.Writer/Reader in output code)
+      - linters:
+          - errcheck
+        text: "w\\.Write|w\\.Close|buf\\.ReadFrom"
+      # Allow unchecked error builder methods (fluent API)
+      - linters:
+          - errcheck
+        text: "err\\.Add|err\\.With"
+      # Allow unchecked io.Copy / io.WriteString
+      - linters:
+          - errcheck
+        text: "io\\.Copy|io\\.WriteString"
+      # Allow unchecked clone.Close / listener.Close / resp.Body.Close
+      - linters:
+          - errcheck
+        text: "clone\\.Close|listener\\.Close|resp\\.Body\\.Close"
+      # Allow unchecked MarkFlagRequired (Cobra panics on error, safe to ignore)
+      - linters:
+          - errcheck
+        text: "MarkFlagRequired"
+      # Pre-existing: unused append results in document name collection (cosmetic, not a bug)
+      - linters:
+          - staticcheck
+        text: "SA4010"
+        path: cmd/get_documents\.go
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 )
 
 var analyzeJSON bool

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var installDryRun bool

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
-	"github.com/spf13/cobra"
 )
 
 var recommendJSON bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // Version is set at build time via -ldflags.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // Version is set at build time via -ldflags.

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
-	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 )
 
 var setupDryRun bool

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var (

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/spf13/cobra"
 )
 
 type CredentialToken struct {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fatih/color"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/fatih/color"
 )
 
 // captureOutput redirects color.Output (the writer used by fatih/color and

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var uninstallDryRun bool

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var updateDryRun bool

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/spf13/cobra"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var watchFromFlag string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynatrace-oss/dtwiz
 
-go 1.24
+go 1.26.2
 
 require (
 	github.com/fatih/color v1.18.0

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -276,14 +276,15 @@ func (s *SystemInfo) Summary() string {
 			colorMuted.Sprint("<none> — sign in with 'gcloud auth login' to detect your project")))
 	}
 
-	if s.OneAgentRunning {
+	switch {
+	case s.OneAgentRunning:
 		sb.WriteString(fmt.Sprintf("  %s running\n",
 			label("OneAgent")))
-	} else if s.Platform == PlatformDarwin {
+	case s.Platform == PlatformDarwin:
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("OneAgent"),
 			colorMuted.Sprint("<none>")+colorMuted.Sprint(" (macOS not supported)")))
-	} else {
+	default:
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("OneAgent"),
 			colorMuted.Sprint("<none>")))

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -279,7 +279,7 @@ func (s *SystemInfo) Summary() string {
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("OneAgent"),
 			display.ColorMuted.Sprint("<none>")+display.ColorMuted.Sprint(" (macOS not supported)")))
-	} else {
+	default:
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("OneAgent"),
 			display.ColorMuted.Sprint("<none>")))

--- a/pkg/analyzer/detect_aws.go
+++ b/pkg/analyzer/detect_aws.go
@@ -45,40 +45,40 @@ func parseIntFirst(out string) int {
 
 var awsProbes = []awsServiceProbe{
 	{
-		name: "EC2",
-		cmd:  []string{"aws", "ec2", "describe-instances", "--filters", "Name=instance-state-name,Values=running", "--query", "length(Reservations[].Instances[])", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "EC2",
+		cmd:     []string{"aws", "ec2", "describe-instances", "--filters", "Name=instance-state-name,Values=running", "--query", "length(Reservations[].Instances[])", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 	{
-		name: "EKS",
-		cmd:  []string{"aws", "eks", "list-clusters", "--query", "length(clusters)", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "EKS",
+		cmd:     []string{"aws", "eks", "list-clusters", "--query", "length(clusters)", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 	{
-		name: "ECS",
-		cmd:  []string{"aws", "ecs", "list-clusters", "--query", "length(clusterArns)", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "ECS",
+		cmd:     []string{"aws", "ecs", "list-clusters", "--query", "length(clusterArns)", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 	{
-		name: "Lambda",
-		cmd:  []string{"aws", "lambda", "list-functions", "--query", "length(Functions)", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "Lambda",
+		cmd:     []string{"aws", "lambda", "list-functions", "--query", "length(Functions)", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 	{
-		name: "RDS",
-		cmd:  []string{"aws", "rds", "describe-db-instances", "--query", "length(DBInstances)", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "RDS",
+		cmd:     []string{"aws", "rds", "describe-db-instances", "--query", "length(DBInstances)", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 	{
-		name: "S3",
-		cmd:  []string{"aws", "s3api", "list-buckets", "--query", "length(Buckets)", "--output", "text", "--cli-read-timeout", "20"},
+		name:    "S3",
+		cmd:     []string{"aws", "s3api", "list-buckets", "--query", "length(Buckets)", "--output", "text", "--cli-read-timeout", "20"},
 		countFn: parseIntFirst,
 	},
 }
 
 func detectAWSServices() []AWSService {
 	type result struct {
-		svc AWSService
+		svc   AWSService
 		valid bool
 	}
 	results := make([]result, len(awsProbes))

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -18,12 +18,18 @@ func detectKubernetes() *KubernetesInfo {
 
 	var (
 		ctx, cluster, serverURL, ver, nodesOut string
-		wg sync.WaitGroup
+		wg                                     sync.WaitGroup
 	)
 	wg.Add(5)
 	go func() { defer wg.Done(); _, ctx = runCmd("kubectl", "config", "current-context") }()
-	go func() { defer wg.Done(); _, cluster = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].name}") }()
-	go func() { defer wg.Done(); _, serverURL = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}") }()
+	go func() {
+		defer wg.Done()
+		_, cluster = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].name}")
+	}()
+	go func() {
+		defer wg.Done()
+		_, serverURL = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}")
+	}()
 	go func() { defer wg.Done(); _, ver = runCmd("kubectl", "version", "-o", "json") }()
 	go func() { defer wg.Done(); _, nodesOut = runCmd("kubectl", "get", "nodes", "--no-headers", "-o", "name") }()
 	wg.Wait()

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -433,7 +433,7 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 	stackName := "dynatrace-data-acquisition"
 	dynatraceURL := envURL
 	if dynatraceURL == "" {
-		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:ST1005 to keep brand capitalization
+		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 
 	if defaultToken == "" {

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -433,7 +433,7 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 	stackName := "dynatrace-data-acquisition"
 	dynatraceURL := envURL
 	if dynatraceURL == "" {
-		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)")
+		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:ST1005 to keep brand capitalization
 	}
 
 	if defaultToken == "" {

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -662,7 +662,7 @@ func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool)
 	// ── Validate ─────────────────────────────────────────────────────────────
 
 	if envURL == "" {
-		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:ST1005 to keep brand capitalization
+		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 	if token == "" {
 		return fmt.Errorf("access token is required (--access-token or DT_ACCESS_TOKEN)")

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -662,7 +662,7 @@ func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool)
 	// ── Validate ─────────────────────────────────────────────────────────────
 
 	if envURL == "" {
-		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)")
+		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:ST1005 to keep brand capitalization
 	}
 	if token == "" {
 		return fmt.Errorf("access token is required (--access-token or DT_ACCESS_TOKEN)")

--- a/pkg/installer/demo.go
+++ b/pkg/installer/demo.go
@@ -36,7 +36,7 @@ func pythonInstallPlan() ([]string, error) {
 	switch runtime.GOOS {
 	case "darwin":
 		if _, err := exec.LookPath("brew"); err != nil {
-			return nil, fmt.Errorf("Python 3 is required but not found.\nInstall Homebrew first: https://brew.sh, then re-run this command")
+			return nil, fmt.Errorf("Python 3 is required but not found.\nInstall Homebrew first: https://brew.sh, then re-run this command") //nolint:staticcheck // ST1005: keep brand capitalization
 		}
 		return []string{"brew", "install", "python3"}, nil
 
@@ -54,7 +54,7 @@ func pythonInstallPlan() ([]string, error) {
 		return []string{"winget", "install", "Python.Python.3"}, nil
 
 	default:
-		return nil, fmt.Errorf("Python 3 is required but not found; please install it manually")
+		return nil, fmt.Errorf("Python 3 is required but not found; please install it manually") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 }
 
@@ -229,7 +229,7 @@ func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
 	if pythonCmd != nil {
 		fmt.Printf("  Installing Python 3 via %s...\n", pythonCmd[0])
 		if err := RunCommand(pythonCmd[0], pythonCmd[1:]...); err != nil {
-			return fmt.Errorf("Python installation failed: %w", err)
+			return fmt.Errorf("Python installation failed: %w", err) //nolint:staticcheck // ST1005: keep brand capitalization
 		}
 		fmt.Println("  Python 3 installed.")
 	}

--- a/pkg/installer/docker.go
+++ b/pkg/installer/docker.go
@@ -52,7 +52,7 @@ func InstallDocker(envURL, token string, dryRun bool) error {
 	}
 
 	if !isDockerAvailable() {
-		return fmt.Errorf("Docker is not available — install Docker and ensure the daemon is running")
+		return fmt.Errorf("Docker is not available — install Docker and ensure the daemon is running") //nolint:ST1005 to keep brand capitalization
 	}
 
 	// Remove any existing container with the same name.

--- a/pkg/installer/docker.go
+++ b/pkg/installer/docker.go
@@ -52,7 +52,7 @@ func InstallDocker(envURL, token string, dryRun bool) error {
 	}
 
 	if !isDockerAvailable() {
-		return fmt.Errorf("Docker is not available — install Docker and ensure the daemon is running") //nolint:ST1005 to keep brand capitalization
+		return fmt.Errorf("Docker is not available — install Docker and ensure the daemon is running") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 
 	// Remove any existing container with the same name.

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
 	"golang.org/x/term"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 const watchPollInterval = 5 * time.Second

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -402,7 +402,7 @@ func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error 
 		fmt.Printf("  Installing Dynatrace Operator via Helm (helm v%d)...\n", helmMajor)
 	}
 	if err := RunCommandQuiet("helm", helmArgs...); err != nil {
-		return fmt.Errorf("Helm operator install failed: %w", err)
+		return fmt.Errorf("Helm operator install failed: %w", err)  //nolint:ST1005 to keep brand capitalization
 	}
 	fmt.Println("  Helm chart deployed.")
 

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -402,7 +402,7 @@ func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error 
 		fmt.Printf("  Installing Dynatrace Operator via Helm (helm v%d)...\n", helmMajor)
 	}
 	if err := RunCommandQuiet("helm", helmArgs...); err != nil {
-		return fmt.Errorf("Helm operator install failed: %w", err)  //nolint:ST1005 to keep brand capitalization
+		return fmt.Errorf("Helm operator install failed: %w", err) //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 	fmt.Println("  Helm chart deployed.")
 

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/fatih/color"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 type InstrumentationPlan interface {

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -393,7 +393,8 @@ func waitForLogInDynatrace(envURL, token, searchTerm string, timeout time.Durati
 				body, _ := io.ReadAll(resp.Body)
 				resp.Body.Close()
 
-				if resp.StatusCode/100 == 2 {
+				switch {
+				case resp.StatusCode/100 == 2:
 					// Parse JSON to check for actual log records, matching the
 					// Python implementation: data["result"]["records"] non-empty.
 					var data struct {
@@ -406,7 +407,7 @@ func waitForLogInDynatrace(envURL, token, searchTerm string, timeout time.Durati
 					}
 					// 2xx but no records yet — continue polling.
 					lastErr = ""
-				} else if resp.StatusCode == 401 || resp.StatusCode == 403 {
+				case resp.StatusCode == 401 || resp.StatusCode == 403:
 					// Show token prefix so the user can verify they passed the right one.
 					tokenHint := token
 					if len(tokenHint) > 20 {
@@ -420,7 +421,7 @@ func waitForLogInDynatrace(envURL, token, searchTerm string, timeout time.Durati
 							"  Response:   %s",
 						resp.StatusCode, tokenHint, queryURL, strings.TrimSpace(string(body)),
 					)
-				} else if resp.StatusCode/100 != 2 {
+				default:
 					lastErr = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 				}
 			}

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -23,8 +23,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 //go:embed otel.tmpl

--- a/pkg/installer/otel_java.go
+++ b/pkg/installer/otel_java.go
@@ -30,7 +30,7 @@ func detectJava() (string, error) {
 	path, err := exec.LookPath("java")
 	if err != nil {
 		logger.Debug("java not found on PATH")
-		return "", fmt.Errorf("Java not found — install a JDK/JRE and ensure it is in PATH")
+		return "", fmt.Errorf("Java not found — install a JDK/JRE and ensure it is in PATH")  //nolint:ST1005
 	}
 	out, err := exec.Command(path, "-version").CombinedOutput()
 	if err != nil {

--- a/pkg/installer/otel_java.go
+++ b/pkg/installer/otel_java.go
@@ -30,7 +30,7 @@ func detectJava() (string, error) {
 	path, err := exec.LookPath("java")
 	if err != nil {
 		logger.Debug("java not found on PATH")
-		return "", fmt.Errorf("Java not found — install a JDK/JRE and ensure it is in PATH")  //nolint:ST1005
+		return "", fmt.Errorf("Java not found — install a JDK/JRE and ensure it is in PATH") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 	out, err := exec.Command(path, "-version").CombinedOutput()
 	if err != nil {

--- a/pkg/installer/otel_process.go
+++ b/pkg/installer/otel_process.go
@@ -82,15 +82,16 @@ func (p *ManagedProcess) printLine(listeningPort string) {
 	hasExited, waitErr := p.WaitResult()
 
 	statusLine := fmt.Sprintf("  %s (PID %d)", p.Name, p.PID)
-	if hasExited {
+	switch {
+	case hasExited:
 		if waitErr != nil {
 			statusLine += fmt.Sprintf("  [crashed: %v — check log for details]", waitErr)
 		} else {
 			statusLine += "  [exited cleanly]"
 		}
-	} else if listeningPort != "" {
+	case listeningPort != "":
 		statusLine += fmt.Sprintf(" → http://localhost:%s", listeningPort)
-	} else {
+	default:
 		statusLine += "  [running, port not detected]"
 	}
 	statusLine += fmt.Sprintf("  [log: %s]", p.LogName)

--- a/pkg/installer/otel_python.go
+++ b/pkg/installer/otel_python.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 func generateOtelPythonEnvVars(apiURL, token, serviceName string) map[string]string {

--- a/pkg/installer/otel_python_project.go
+++ b/pkg/installer/otel_python_project.go
@@ -116,5 +116,3 @@ func parseEntrypointFromPyproject(content string) string {
 	}
 	return ""
 }
-
-

--- a/pkg/installer/otel_python_venv.go
+++ b/pkg/installer/otel_python_venv.go
@@ -33,7 +33,7 @@ func detectPython() (string, error) {
 		}
 	}
 	logger.Debug("no usable python 3 interpreter found on PATH")
-	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH")
+	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH")  //nolint:ST1005 to keep brand capitalization
 }
 
 func validatePythonPrerequisites() error {

--- a/pkg/installer/otel_python_venv.go
+++ b/pkg/installer/otel_python_venv.go
@@ -33,7 +33,7 @@ func detectPython() (string, error) {
 		}
 	}
 	logger.Debug("no usable python 3 interpreter found on PATH")
-	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH")  //nolint:ST1005 to keep brand capitalization
+	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH") //nolint:staticcheck // ST1005: keep brand capitalization
 }
 
 func validatePythonPrerequisites() error {

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 type DetectedProcess struct {

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // otelProcessInfo holds PID + resolved binary path for a running collector.

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/fatih/color"
 	"gopkg.in/yaml.v3"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // exporterSnippet is the YAML block to inject into an existing OTel Collector

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -90,11 +90,12 @@ func lcsDP(a, b []string) [][]int {
 	}
 	for i := 1; i <= m; i++ {
 		for j := 1; j <= n; j++ {
-			if a[i-1] == b[j-1] {
+			switch {
+			case a[i-1] == b[j-1]:
 				dp[i][j] = dp[i-1][j-1] + 1
-			} else if dp[i-1][j] > dp[i][j-1] {
+			case dp[i-1][j] > dp[i][j-1]:
 				dp[i][j] = dp[i-1][j]
-			} else {
+			default:
 				dp[i][j] = dp[i][j-1]
 			}
 		}
@@ -373,4 +374,3 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 	green.Println("  ✓ Collector restarted and verified.")
 	return nil
 }
-

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 )
 
 // IngestMethod identifies a Dynatrace ingestion approach.

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -204,20 +204,21 @@ func FormatRecommendations(recs []Recommendation) string {
 
 	n := 0
 	for _, r := range recs {
-		if r.Done {
+		switch {
+		case r.Done:
 			badge := recBadgeDone.Sprint(" ✓ ")
 			title := recTitleDone.Sprint(r.Title)
 			sb.WriteString(fmt.Sprintf("  %s  %s\n", badge, title))
-		} else if r.Method == MethodNotSupported {
+		case r.Method == MethodNotSupported:
 			badge := recBadgeWarn.Sprint(" ! ")
 			title := recTitleWarn.Sprint(r.Title)
 			sb.WriteString(fmt.Sprintf("  %s  %s\n", badge, title))
-		} else if r.ComingSoon {
+		case r.ComingSoon:
 			// Coming-soon items are shown muted without a number.
 			bullet := recMuted.Sprint(" · ")
 			title := recMuted.Sprint(r.Title)
 			sb.WriteString(fmt.Sprintf("  %s  %s\n", bullet, title))
-		} else {
+		default:
 			n++
 			badge := recBadgeNum.Sprintf(" %d ", n)
 			title := recTitleActive.Sprint(r.Title)


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] Other (please describe): Linter fixes

Fixes 32 golangci-lint issues across the codebase:

- **goimports**: re-formatted import blocks in 21 files to match the `local-prefixes` setting in `.golangci.yml` (internal imports grouped separately)
- **gocritic / ifElseChain**: rewrote 5 if-else chains as `switch` statements in `analyzer.go`, `otel_collector.go`, `otel_process.go`, `otel_update.go`, and `recommender.go`
- **staticcheck / ST1005**: added `//nolint:staticcheck` directives on 6 error strings that intentionally start with a capitalized proper noun (Dynatrace, Docker, Helm, Java, Python)

Alligns linting setup to https://github.com/dynatrace-oss/dtctl/blob/main/.github/workflows/lint.yml

## How to test
1. Run `golangci-lint run ./...` — no issues should be reported. (install `golangci-lint` with [brew](https://golangci-lint.run/docs/welcome/install/local/#homebrew))
2. Run `make build` — build should succeed.

## Which other features are affected?
1. None — all changes are formatting and style only, no logic changes.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I followed the existing code style and conventions.
