### PR TITLE
feat: start watch in parallel with AWS CloudFormation deploy

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -183,11 +183,8 @@ var installAWSCmd = &cobra.Command{
 		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
 			return err
 		}
-		if err := installer.InstallAWS(envURL, accessTok, platformTok, installDryRun); err != nil {
+		if err := installer.InstallAWS(envURL, accessTok, platformTok, installDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z")); err != nil {
 			return err
-		}
-		if !installDryRun {
-			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		}
 		return nil
 	},

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -123,14 +123,15 @@ var setupCmd = &cobra.Command{
 			}
 			installErr = installer.UpdateOtelConfig(cfgPath, envURL, accessTok, platformTok, setupDryRun)
 		case recommender.MethodAWS:
-			installErr = installer.InstallAWS(envURL, accessTok, platformTok, setupDryRun)
+			installErr = installer.InstallAWS(envURL, accessTok, platformTok, setupDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		default:
 			return fmt.Errorf("unsupported method: %s", selected.Method)
 		}
 		if installErr != nil {
 			return installErr
 		}
-		if !setupDryRun {
+		// AWS watch is started inside InstallAWS (runs in parallel with deploy).
+		if !setupDryRun && selected.Method != recommender.MethodAWS {
 			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		}
 		return nil

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -413,7 +413,8 @@ func buildDeployArgs(cfg awsStackConfig, templateFile string) []string {
 //   - token:          access token (used as default for prompt pre-fill)
 //   - platformToken:  dt0s16.* token from --platform-token / DT_PLATFORM_TOKEN (used as default for prompts)
 //   - dryRun:         when true, show what would be done without executing
-func InstallAWS(envURL, token, platformToken string, dryRun bool) error {
+//   - startTime:      RFC3339 timestamp used as the from-clause for WatchIngest (empty = skip watch)
+func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime string) error {
 	cyan := color.New(color.FgMagenta)
 	sep := strings.Repeat("─", 60)
 
@@ -523,46 +524,65 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool) error {
 
 	// ── Deploy ────────────────────────────────────────────────────────────────
 
-	// Start Lambda instrumentation concurrently. Only when actually deploying
-	// — dry-run skips this to avoid interleaved output and unnecessary API calls.
-	var wg sync.WaitGroup
-	var lambdaErr error
-	if !dryRun {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			lambdaErr = InstallAWSLambda(envURL, token, platformToken, false, false)
-		}()
-	}
-
 	fmt.Printf("  Downloading CloudFormation template...\n")
 	tmplFile, err := downloadAWSTemplate()
 	if err != nil {
-		wg.Wait()
 		return err
 	}
 	defer os.Remove(tmplFile)
 
 	realArgs := buildDeployArgs(cfg, tmplFile)
 
-	fmt.Printf("  Deploying CloudFormation stack %q...\n", cfg.StackName)
-	fmt.Println("  (This may take a few minutes)")
-	fmt.Println()
+	// statusCh carries deployment progress messages into the watch display.
+	statusCh := make(chan string, 4)
 
-	if err := RunCommand("aws", realArgs...); err != nil {
-		wg.Wait()
-		return fmt.Errorf("CloudFormation deployment failed: %w", err)
+	// Run CFN deploy and Lambda instrumentation in the background so the
+	// watch can start immediately and show incoming data while AWS provisions.
+	var wg sync.WaitGroup
+	var deployErr, lambdaErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		statusCh <- fmt.Sprintf("CloudFormation stack %q deploying... (this may take a few minutes)", cfg.StackName)
+		if err := runCommandSilent("aws", realArgs...); err != nil {
+			deployErr = fmt.Errorf("CloudFormation deployment failed: %w", err)
+			statusCh <- fmt.Sprintf("CloudFormation deployment failed: %s", err)
+			return
+		}
+		statusCh <- fmt.Sprintf("CloudFormation stack %q deployed successfully.", cfg.StackName)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		lambdaErr = InstallAWSLambda(envURL, token, platformToken, false, false)
+	}()
+
+	// Start watch immediately — it will display status messages from the
+	// background deploy as they arrive and keep running after deploy finishes.
+	if startTime != "" && platformToken != "" {
+		WatchIngestWithStatus(envURL, platformToken, startTime, statusCh)
 	}
 
-	fmt.Println()
-	fmt.Printf("  Stack %q deployed successfully.\n", cfg.StackName)
-	fmt.Printf("  View in the AWS Console: https://console.aws.amazon.com/cloudformation/home#/stacks\n")
-
-	// Wait for Lambda instrumentation to finish.
 	wg.Wait()
+	close(statusCh)
+
+	if deployErr != nil {
+		return deployErr
+	}
 	if lambdaErr != nil {
 		fmt.Printf("\n  Warning: Lambda instrumentation encountered an error: %s\n", lambdaErr)
 		fmt.Println("  You can retry with: dtwiz install aws-lambda")
 	}
 	return nil
+}
+
+// runCommandSilent runs a command like RunCommand but discards stdout/stderr
+// output, preventing interleaving with the watch display.
+func runCommandSilent(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
 }

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -536,10 +536,10 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 	// statusCh carries deployment progress messages into the watch display.
 	statusCh := make(chan string, 4)
 
-	// Run CFN deploy and Lambda instrumentation in the background so the
-	// watch can start immediately and show incoming data while AWS provisions.
+	// Start CFN deploy in the background immediately — it takes several minutes
+	// and produces no meaningful intermediate output.
 	var wg sync.WaitGroup
-	var deployErr, lambdaErr error
+	var deployErr error
 
 	wg.Add(1)
 	go func() {
@@ -553,14 +553,16 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 		statusCh <- fmt.Sprintf("CloudFormation stack %q deployed successfully.", cfg.StackName)
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		lambdaErr = InstallAWSLambda(envURL, token, platformToken, false, false)
-	}()
+	// Run Lambda instrumentation on the main thread — it is quick but produces
+	// a lot of output, so let it finish before handing the terminal to watch.
+	lambdaErr := InstallAWSLambda(envURL, token, platformToken, false, false)
+	if lambdaErr != nil {
+		fmt.Printf("\n  Warning: Lambda instrumentation encountered an error: %s\n", lambdaErr)
+		fmt.Println("  You can retry with: dtwiz install aws-lambda")
+	}
 
-	// Start watch immediately — it will display status messages from the
-	// background deploy as they arrive and keep running after deploy finishes.
+	// Start watch after Lambda output is done — CFN deploy is still running
+	// in the background and will send its result into statusCh.
 	if startTime != "" && platformToken != "" {
 		WatchIngestWithStatus(envURL, platformToken, startTime, statusCh)
 	}
@@ -570,10 +572,6 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 
 	if deployErr != nil {
 		return deployErr
-	}
-	if lambdaErr != nil {
-		fmt.Printf("\n  Warning: Lambda instrumentation encountered an error: %s\n", lambdaErr)
-		fmt.Println("  You can retry with: dtwiz install aws-lambda")
 	}
 	return nil
 }

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -44,10 +44,22 @@ type watchState struct {
 }
 
 // WatchIngest polls Dynatrace for newly ingested data and renders a live
-// terminal summary. It blocks until the user presses Ctrl+C.
+// terminal summary. It blocks until the user presses Enter or Ctrl+C.
 // fromClause is injected directly into DQL queries — accepts RFC3339 timestamps
 // or DQL relative expressions (e.g. "now()-1h").
 func WatchIngest(envURL, pToken, fromClause string) {
+	watchIngest(envURL, pToken, fromClause, nil)
+}
+
+// WatchIngestWithStatus is like WatchIngest but displays a background-task
+// status line (e.g. a CloudFormation deployment) in the watch header.
+// The caller sends status messages to statusCh; the most recent message is
+// shown on every render. Closing or sending on a nil channel is safe.
+func WatchIngestWithStatus(envURL, pToken, fromClause string, statusCh <-chan string) {
+	watchIngest(envURL, pToken, fromClause, statusCh)
+}
+
+func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string) {
 	if pToken == "" {
 		fmt.Println("  Platform token required for watch. Set --platform-token or DT_PLATFORM_TOKEN.")
 		return
@@ -69,6 +81,7 @@ func WatchIngest(envURL, pToken, fromClause string) {
 	}
 
 	var prevLines int
+	var statusMsg string // latest message from statusCh (empty = no background task)
 
 	// Listen for Enter key in a goroutine to let the user stop watching.
 	stopCh := make(chan struct{}, 1)
@@ -99,6 +112,24 @@ func WatchIngest(envURL, pToken, fromClause string) {
 		}
 
 		elapsed := time.Since(watchStart).Truncate(time.Second)
+
+		// Drain latest status message from background task (non-blocking).
+		if statusCh != nil {
+		drainStatus:
+			for {
+				select {
+				case msg, ok := <-statusCh:
+					if !ok {
+						statusCh = nil
+					} else {
+						statusMsg = msg
+					}
+				default:
+					break drainStatus
+				}
+			}
+		}
+
 		state := pollAll(queryURL, pToken, fromClause)
 
 		var buf strings.Builder
@@ -106,6 +137,9 @@ func WatchIngest(envURL, pToken, fromClause string) {
 		// Header
 		highlight.Fprintf(&buf, " Watching for new data in Dynatrace... (elapsed: %s)\n", formatElapsed(elapsed))
 		dim.Fprintf(&buf, " Generate some load on your system to see data appear.\n")
+		if statusMsg != "" {
+			dim.Fprintf(&buf, " %s\n", statusMsg)
+		}
 		buf.WriteString("\n")
 
 		// Sections


### PR DESCRIPTION
## Summary

- CFN deploy runs immediately in a background goroutine (output silenced to avoid interleaving) while Lambda instrumentation runs on the main thread with its full output visible
- After Lambda finishes, `WatchIngestWithStatus` takes over the terminal — CFN deploy status (deploying / success / failure) appears as a live status line in the watch header
- Also fixes `watch --from "now()-1d"` — DQL relative expressions were incorrectly wrapped in quotes, making them string literals instead of expressions

## Changes

- `pkg/installer/ingest_watch.go` — added `WatchIngestWithStatus` variant that accepts a `statusCh <-chan string` and renders the latest message in the watch header; also added `dqlFromLiteral` helper that only quotes absolute RFC3339 timestamps
- `pkg/installer/aws.go` — CFN deploy and watch are now decoupled; Lambda runs first (main thread), then watch starts with CFN status updates fed via channel
- `cmd/install.go` / `cmd/setup.go` — removed redundant `WatchIngest` call after `InstallAWS` (watch is now owned by the installer)