### PR TITLE
refactor(cmd): use the new display package

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
 )
@@ -27,20 +27,16 @@ var setupCmd = &cobra.Command{
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		printBanner()
-		setupHeader := color.New(color.FgMagenta, color.Bold)
-		setupMuted := color.New()
-		setupPrompt := color.New(color.FgMagenta)
-		setupBadge := color.New(color.FgMagenta, color.Bold)
 
 		if env := environmentHint(); env != "" {
-			setupMuted.Printf(" Environment: %s\n\n", env)
+			display.ColorDefault.Printf(" Environment: %s\n\n", env)
 		} else {
-			setupMuted.Println(" Environment: (not configured)")
+			display.ColorDefault.Println(" Environment: (not configured)")
 			fmt.Println()
 		}
 
-		setupHeader.Println("  Analyzing system...")
-		setupMuted.Println("  " + strings.Repeat("─", 42))
+		display.Header("Analyzing system...")
+
 		info, err := analyzer.AnalyzeSystem()
 		if err != nil {
 			return fmt.Errorf("analysis failed: %w", err)
@@ -48,8 +44,7 @@ var setupCmd = &cobra.Command{
 		fmt.Println(info.Summary())
 
 		fmt.Println()
-		setupHeader.Println("  Recommendations — What do you want to monitor?")
-		setupMuted.Println("  " + strings.Repeat("─", 42))
+		display.Header("Recommendations — What do you want to monitor?")
 		recs := recommender.GenerateRecommendations(info)
 
 		// Collect actionable (non-done, non-not-supported, non-coming-soon) recommendations.
@@ -65,19 +60,19 @@ var setupCmd = &cobra.Command{
 		}
 
 		for i, r := range actionable {
-			fmt.Printf("  %s  %s\n", setupBadge.Sprintf("[%d]", i+1), r.Title)
+			fmt.Printf("  %s  %s\n", display.ColorHeader.Sprintf("[%d]", i+1), r.Title)
 		}
 		// Show coming-soon items (informational only, not selectable).
 		for _, r := range recs {
 			if r.ComingSoon {
-				fmt.Printf("  %s  %s\n", setupMuted.Sprint(" · "), setupMuted.Sprint(r.Title))
+				fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint(" · "), display.ColorDefault.Sprint(r.Title))
 			}
 		}
 		fmt.Println()
-		fmt.Printf("  %s  %s\n", setupMuted.Sprint("[d]"), setupMuted.Sprint("Install demo app (schnitzel)"))
-		fmt.Printf("  %s  %s\n", setupMuted.Sprint("[0]"), setupMuted.Sprint("Cancel"))
+		fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint("[d]"), display.ColorDefault.Sprint("Install demo app (schnitzel)"))
+		fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint("[0]"), display.ColorDefault.Sprint("Cancel"))
 		fmt.Println()
-		setupPrompt.Print("  Enter number: ")
+		display.ColorMessage.Print("  Enter number: ")
 
 		reader := bufio.NewReader(cmd.InOrStdin())
 		input, err := reader.ReadString('\n')
@@ -87,14 +82,14 @@ var setupCmd = &cobra.Command{
 		input = strings.TrimSpace(input)
 
 		if input == "" || input == "0" {
-			setupMuted.Println("  Setup cancelled.")
+			display.ColorDefault.Println("  Setup cancelled.")
 			return nil
 		}
 
 		if input == "d" {
 			fmt.Println()
-			setupHeader.Println("  Installing: Demo app (schnitzel)")
-			setupMuted.Println("  " + strings.Repeat("─", 42))
+			display.Header("Installing: Demo app (schnitzel)")
+
 			envURL, accessTok, platformTok, err := getDtEnvironment()
 			if err != nil {
 				return err
@@ -118,8 +113,7 @@ var setupCmd = &cobra.Command{
 
 		selected := actionable[choice-1]
 		fmt.Println()
-		setupHeader.Printf("  Installing: %s\n", selected.Title)
-		setupMuted.Println("  " + strings.Repeat("─", 42))
+		display.Header(fmt.Sprintf("Installing: %s", selected.Title))
 
 		envURL, accessTok, platformTok, err := getDtEnvironment()
 		if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -70,7 +70,7 @@ var statusCmd = &cobra.Command{
 			printExtensionsStatus()
 		}
 
-		display.Header("System Analysis")
+		fmt.Println()
 		info, err := analyzer.AnalyzeSystem()
 		if err != nil {
 			fmt.Printf("  %s\n", display.ColorError.Sprintf("✗ system analysis failed: %v", err))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -38,7 +38,7 @@ var statusCmd = &cobra.Command{
 	Long:  `Verifies connectivity to Dynatrace and displays the current system analysis.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		display.Header(statusLabel, "Connection Status")
+		display.Header("Connection Status")
 
 		envURL := environmentHint()
 		accessTok := accessToken()
@@ -70,7 +70,7 @@ var statusCmd = &cobra.Command{
 			printExtensionsStatus()
 		}
 
-		display.Header(statusLabel, "System Analysis")
+		display.Header("System Analysis")
 		info, err := analyzer.AnalyzeSystem()
 		if err != nil {
 			fmt.Printf("  %s\n", display.ColorError.Sprintf("✗ system analysis failed: %v", err))
@@ -85,11 +85,11 @@ var statusCmd = &cobra.Command{
 }
 
 func printExtensionsStatus() {
-	display.Header(statusLabel, "Extensions API")
+	display.Header("Extensions API")
 
 	c, err := setupClient()
 	if err != nil {
-		display.PrintError("status", fmt.Errorf("setup: %s", err))
+		display.PrintError(statusLabel, fmt.Errorf("setup: %s", err))
 		return
 	}
 
@@ -147,7 +147,7 @@ func printFeatureFlags() {
 	}
 	if len(enabledFlags) > 0 {
 		fmt.Println()
-		display.Header(statusLabel, "Feature Flags")
+		display.Header("Feature Flags")
 		for _, f := range enabledFlags {
 			display.PrintFlagLine(f.EnvVar, fmt.Sprintf("✓ enabled (%s)", f.Source), display.ColorOK)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
@@ -20,19 +19,18 @@ type CredentialToken struct {
 	getUrlFn      func(envURL string) string
 }
 
+var clientFlag bool
+
 func init() {
 	statusCmd.Flags().BoolVar(&clientFlag, "extensions", false, "probe Classic and Platform Extensions APIs using the HTTP client")
 }
 
-var (
-	statusOK    = color.New(color.FgGreen, color.Bold)
-	statusError = color.New(color.FgRed, color.Bold)
-	statusLabel = color.New()
-	statusMuted = color.New()
-	statusHead  = color.New(color.FgMagenta, color.Bold)
+const (
+	statusLabel        = "status"
+	envLabel           = "Environment"
+	classicExtensions  = "Classic Extensions"
+	platformExtensions = "Platform Extensions"
 )
-
-var clientFlag bool
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
@@ -40,16 +38,16 @@ var statusCmd = &cobra.Command{
 	Long:  `Verifies connectivity to Dynatrace and displays the current system analysis.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		display.Header("Connection Status")
+		display.Header(statusLabel, "Connection Status")
 
 		envURL := environmentHint()
 		accessTok := accessToken()
 		platformTok := platformToken()
 
 		if envURL == "" {
-			display.PrintStatusLine("Environment", "✗ not set (use --environment or DT_ENVIRONMENT)", display.ColorError)
+			display.PrintStatusLine(envLabel, "✗ not set (use --environment or DT_ENVIRONMENT)", display.ColorError)
 		} else {
-			display.PrintStatusLine("Environment", fmt.Sprintf("✓ %s", envURL), display.ColorOK)
+			display.PrintStatusLine(envLabel, fmt.Sprintf("✓ %s", envURL), display.ColorOK)
 		}
 
 		printCredentialStatus("Access Token", envURL, CredentialToken{
@@ -72,8 +70,7 @@ var statusCmd = &cobra.Command{
 			printExtensionsStatus()
 		}
 
-		statusHead.Println("  System Analysis")
-		statusMuted.Println("  " + "──────────────────────────────────────────")
+		display.Header(statusLabel, "System Analysis")
 		info, err := analyzer.AnalyzeSystem()
 		if err != nil {
 			fmt.Printf("  %s\n", display.ColorError.Sprintf("✗ system analysis failed: %v", err))
@@ -88,12 +85,11 @@ var statusCmd = &cobra.Command{
 }
 
 func printExtensionsStatus() {
-	statusHead.Println("  Extensions API")
-	statusMuted.Println("  " + "──────────────────────────────────────────")
+	display.Header(statusLabel, "Extensions API")
 
 	c, err := setupClient()
 	if err != nil {
-		fmt.Printf("  %s  %s\n\n", statusLabel.Sprint("Setup:"), statusError.Sprintf("✗ %v", err))
+		display.PrintError("status", fmt.Errorf("setup: %s", err))
 		return
 	}
 
@@ -102,12 +98,13 @@ func printExtensionsStatus() {
 		TotalResults int `json:"totalResults"`
 	}
 	resp, err := c.Classic.HTTP().R().SetResult(&classicResp).Get("/api/v2/extensions")
+
 	if err != nil {
-		fmt.Printf("  %s  %s\n", statusLabel.Sprint("Classic Extensions:"), statusError.Sprintf("✗ %v", err))
+		display.PrintError(classicExtensions, err)
 	} else if resp.StatusCode() >= 400 {
-		fmt.Printf("  %s  %s\n", statusLabel.Sprint("Classic Extensions:"), statusError.Sprintf("✗ HTTP %d", resp.StatusCode()))
+		display.PrintError(classicExtensions, fmt.Errorf("HTTP %d", resp.StatusCode()))
 	} else {
-		fmt.Printf("  %s  %s\n", statusLabel.Sprint("Classic Extensions:"), statusOK.Sprintf("✓ reachable (%d extensions)", classicResp.TotalResults))
+		display.PrintStatusLine(classicExtensions, fmt.Sprintf("✓ reachable (%d extensions)", classicResp.TotalResults), display.ColorOK)
 	}
 
 	// Platform: GET /platform/extensions/v2/extensions
@@ -116,12 +113,13 @@ func printExtensionsStatus() {
 	}
 	resp, err = c.Platform.HTTP().R().SetResult(&platformResp).Get("/platform/extensions/v2/extensions")
 	if err != nil {
-		fmt.Printf("  %s  %s\n\n", statusLabel.Sprint("Platform Extensions:"), statusError.Sprintf("✗ %v", err))
+		display.PrintError(platformExtensions, err)
 	} else if resp.StatusCode() >= 400 {
-		fmt.Printf("  %s  %s\n\n", statusLabel.Sprint("Platform Extensions:"), statusError.Sprintf("✗ HTTP %d", resp.StatusCode()))
+		display.PrintError(platformExtensions, fmt.Errorf("HTTP %d", resp.StatusCode()))
 	} else {
-		fmt.Printf("  %s  %s\n\n", statusLabel.Sprint("Platform Extensions:"), statusOK.Sprintf("✓ reachable (%d packages)", platformResp.TotalCount))
+		display.PrintStatusLine(platformExtensions, fmt.Sprintf("✓ reachable (%d packages)", platformResp.TotalCount), display.ColorOK)
 	}
+	fmt.Println()
 }
 
 func printCredentialStatus(label, envURL string, token CredentialToken) {
@@ -149,7 +147,7 @@ func printFeatureFlags() {
 	}
 	if len(enabledFlags) > 0 {
 		fmt.Println()
-		display.Header("Feature Flags")
+		display.Header(statusLabel, "Feature Flags")
 		for _, f := range enabledFlags {
 			display.PrintFlagLine(f.EnvVar, fmt.Sprintf("✓ enabled (%s)", f.Source), display.ColorOK)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -89,7 +89,7 @@ func printExtensionsStatus() {
 
 	c, err := setupClient()
 	if err != nil {
-		display.PrintError(statusLabel, fmt.Errorf("setup: %s", err))
+		display.PrintError("Setup", err)
 		return
 	}
 

--- a/openspec/changes/feature-flags-package/tasks.md
+++ b/openspec/changes/feature-flags-package/tasks.md
@@ -49,16 +49,6 @@ End-to-end verification of all flows.
 - [x] 5.5 Manual: `export DTWIZ_ALL_RUNTIMES=1` → same result as 5.4
 - [x] 5.6 Manual: `dtwiz install otel --all-runtimes` → shows all runtimes (CLI flag works)
 
-## 7. Standardize output helpers in OTel installers
-
-Reuse standardized `pkg/display` functions (`Header`, `PrintSectionDivider`, `PrintStatusLine`, `PrintFlagLine`) across OTel-related installers (otel.go, otel_python.go, etc.) for consistent output formatting.
-
-**Files:** `pkg/installer/otel.go` (modify), `pkg/installer/otel_python.go` (modify), other OTel installer files as applicable
-
-- [ ] 7.1 Audit all OTel installer files for inline section dividers, ad-hoc status lines, or header formatting that duplicates `Header`, `PrintSectionDivider`, `PrintStatusLine`, or `PrintFlagLine`
-- [ ] 7.2 Replace duplicated formatting code with the appropriate `pkg/display` helpers throughout the OTel installer files
-- [ ] 7.3 Run `make test` and `make lint` — no regressions
-
 ## 6. Evaluate gating other analyzers/recommendations
 
 Manually evaluate whether Docker, Kubernetes, OneAgent, AWS, Azure, and GCP analysis/recommendations should be gated behind feature flags (Platform, OTel, and Services are already GA and excluded from this evaluation).

--- a/openspec/changes/refactor-status-display/specs/display-package/spec.md
+++ b/openspec/changes/refactor-status-display/specs/display-package/spec.md
@@ -4,13 +4,21 @@
 
 ### Requirement: Shared terminal color definitions
 
-The `pkg/display` package SHALL export a fixed set of terminal color variables used consistently across all CLI output: `ColorOK` (green bold), `ColorError` (red bold), `ColorHeader` (magenta bold), `ColorMuted` (faint), `ColorLabel` (no styling). These SHALL be the canonical colors for all CLI sections — no command or package SHALL define its own equivalent color variables for these roles.
+The `pkg/display` package SHALL export a fixed set of terminal color variables used consistently across all CLI output: `ColorOK` (green bold), `ColorError` (red bold), `ColorWarning` (yellow bold), `ColorBold` (white bold), `ColorHeader` (magenta bold), `ColorMessage` (magenta), `ColorMuted` (faint), `ColorDefault` (no styling). These SHALL be the canonical colors for all CLI sections — no command or package SHALL define its own equivalent color variables for these roles.
+
+Any new color or print need SHALL be evaluated against this palette first. A new color variable SHALL only be added to `pkg/display/colors.go` if the role it represents is generic and reusable across multiple commands or packages. Color variables that are too specific to a single command or feature SHALL NOT be added to `pkg/display` — they SHALL be defined locally where needed, but MUST be composed from `pkg/display` primitives (e.g. `color.New(...)` is only acceptable if no existing `display.Color*` variable covers the role).
 
 #### Scenario: ColorHeader used for section headings
 
 - **GIVEN** any CLI command prints a section heading
 - **WHEN** it calls `display.ColorHeader.Sprint(title)` or `display.Header(title)`
 - **THEN** the heading is rendered in magenta bold
+
+#### Scenario: ColorMessage used for informational titles
+
+- **GIVEN** any CLI command prints an informational title or inline label (not a section heading)
+- **WHEN** it renders the title
+- **THEN** it uses `display.ColorMessage` (magenta, no bold)
 
 #### Scenario: ColorError used for failure states
 
@@ -24,21 +32,46 @@ The `pkg/display` package SHALL export a fixed set of terminal color variables u
 - **WHEN** the success message is printed
 - **THEN** it is rendered using `display.ColorOK` (green bold)
 
+#### Scenario: ColorDefault used for unstyled secondary text
+
+- **GIVEN** any CLI command prints secondary or neutral text with no visual emphasis
+- **WHEN** it renders that text
+- **THEN** it uses `display.ColorDefault` (no styling) — inline `color.New()` SHALL NOT be used
+
+#### Scenario: ColorMuted used for faint/de-emphasized text
+
+- **GIVEN** any CLI command prints de-emphasised text such as hints, cancelled messages, or dry-run notices
+- **WHEN** it renders that text
+- **THEN** it uses `display.ColorMuted` (faint)
+
 ### Requirement: Print helpers for common output patterns
 
-The `pkg/display` package SHALL expose `Header(message string)`, `PrintSectionDivider()`, and `PrintStatusLine(label, message string, c *color.Color)` as helpers for the recurring output patterns used in `dtwiz status` and other commands.
+The `pkg/display` package SHALL expose `Header(message string)`, `PrintSectionDivider()`, `PrintStatusLine(label, message string, c *color.Color)`, `PrintFlagLine(label, message string, c *color.Color)`, and `PrintError(label string, err error)` as helpers for recurring output patterns used across commands and installers.
 
-`Header` SHALL print the message indented with two spaces using `ColorHeader`, followed immediately by a section divider — callers SHALL NOT call `PrintSectionDivider()` after `Header()`.
-`PrintSectionDivider` SHALL print a 42-character `─` separator indented with two spaces using `ColorMuted`. It is available for use outside of `Header` where a standalone divider is needed.
-`PrintStatusLine` SHALL print a line of the form `<label>:  <message>` indented by two spaces, where the label is styled with `ColorLabel` and the message is styled with the provided color.
+`Header` SHALL print the message indented with two spaces using `ColorHeader`, followed immediately by a section divider — callers SHALL NOT call `PrintSectionDivider()` after `Header()`. Callers SHALL NOT add leading spaces to the message argument; `Header` applies indentation itself.
+`PrintSectionDivider` SHALL print a `─` separator of `DividerLineLength` characters indented with two spaces using `ColorMuted`. It is available for use outside of `Header` where a standalone divider is needed.
+`PrintStatusLine` SHALL print a line of the form `<label>:  <message>` (indented two spaces) where the label is styled with `ColorDefault` and the message is styled with the provided color.
+`PrintFlagLine` SHALL print a line of the form `<label>  <message>` (no colon, indented two spaces) where the label is styled with `ColorDefault` and the message is styled with the provided color.
+`PrintError` SHALL print a line of the form `<label>: ✗ <err>` (indented two spaces) where the error text is styled with `ColorError`.
+
+Any print pattern that recurs across two or more files SHALL be extracted into `pkg/display/print.go`. Print patterns that are specific to a single installer or command MAY remain in that file but MUST reuse `display.Color*` variables and MUST NOT construct their own `color.New(...)` instances for roles already covered by the palette.
 
 #### Scenario: Header prints indented magenta bold title followed by a divider
 
 - **GIVEN** a caller invokes `display.Header("Connection Status")`
-- **THEN** the output is the text "Connection Status" indented by two spaces, rendered in magenta bold, followed by a newline, followed by a 42-character `─` separator indented by two spaces using `ColorMuted`
+- **THEN** the output is the text "Connection Status" indented by two spaces, rendered in magenta bold, followed by a newline, followed by a `─` separator of `DividerLineLength` characters indented by two spaces using `ColorMuted`
 - **AND** the caller does not need to call `display.PrintSectionDivider()` separately
+- **AND** the caller does not include leading spaces in the message argument
 
 #### Scenario: PrintStatusLine formats label and message
 
 - **GIVEN** a caller invokes `display.PrintStatusLine("Environment", "✓ [url.here]", display.ColorOK)`
 - **THEN** the output is the label "Environment:" followed by the message "✓ [url.here]" indented by two spaces, with the message in green bold
+
+#### Scenario: New color or print need evaluated against existing palette
+
+- **GIVEN** a developer needs to print colored output anywhere in the codebase
+- **WHEN** they choose a color or styling
+- **THEN** they SHALL consult `pkg/display/colors.go` and `pkg/display/print.go` first
+- **AND** only introduce a new `color.New(...)` locally if no existing `display.Color*` variable covers the semantic role
+- **AND** only add a new variable to `pkg/display` if the role is generic and used in more than one file

--- a/openspec/changes/refactor-status-display/tasks.md
+++ b/openspec/changes/refactor-status-display/tasks.md
@@ -43,12 +43,22 @@ Add the conditional "Feature Flags" section using `featureflags.List()` and the 
 - [x] 4.2 If any flags are enabled, call `display.Header("Feature Flags")`, `display.PrintSectionDivider()`, then print each flag as its env var name followed by `enabled (<Source>)` indented by two spaces
 - [x] 4.3 If no flags are enabled, omit the section entirely
 
-## 5. Verification
+## 5. Standardize output helpers in OTel installers
 
-- [x] 5.1 Run `make test` — all tests pass
-- [x] 5.2 Run `make lint` — no new lint issues
-- [x] 5.3 Manual: `dtwiz status` with no credentials set — verify Connection Status section renders correctly with `✗` lines
-- [x] 5.4 Manual: `dtwiz status` with valid credentials — verify `✓ valid (<url>)` shows correct URL for each token (API URL for Access Token, Apps URL for Platform Token)
-- [x] 5.5 Manual: `dtwiz status` with `DTWIZ_ALL_RUNTIMES=true` — verify Feature Flags section appears
-- [x] 5.6 Manual: `dtwiz status` with no flags set — verify no Feature Flags section in output
-- [x] 5.7 Manual: simulate system analysis failure — verify command exits non-zero and prints `✗ system analysis failed: ...`
+Reuse standardized `pkg/display` functions (`Header`, `PrintSectionDivider`, `PrintStatusLine`, `PrintFlagLine`) across OTel-related installers (otel.go, otel_python.go, etc.) for consistent output formatting.
+
+**Files:** `pkg/installer/otel.go` (modify), `pkg/installer/otel_python.go` (modify), other OTel installer files as applicable
+
+- [ ] 5.1 Audit all OTel installer files for inline section dividers, ad-hoc status lines, or header formatting that duplicates `Header`, `PrintSectionDivider`, `PrintStatusLine`, or `PrintFlagLine`
+- [ ] 5.2 Replace duplicated formatting code with the appropriate `pkg/display` helpers throughout the OTel installer files
+- [ ] 5.3 Run `make test` and `make lint` — no regressions
+
+## 6. Verification
+
+- [x] 6.1 Run `make test` — all tests pass
+- [x] 6.2 Run `make lint` — no new lint issues
+- [x] 6.3 Manual: `dtwiz status` with no credentials set — verify Connection Status section renders correctly with `✗` lines
+- [x] 6.4 Manual: `dtwiz status` with valid credentials — verify `✓ valid (<url>)` shows correct URL for each token (API URL for Access Token, Apps URL for Platform Token)
+- [x] 6.5 Manual: `dtwiz status` with `DTWIZ_ALL_RUNTIMES=true` — verify Feature Flags section appears
+- [x] 6.6 Manual: `dtwiz status` with no flags set — verify no Feature Flags section in output
+- [x] 6.7 Manual: simulate system analysis failure — verify command exits non-zero and prints `✗ system analysis failed: ...`

--- a/openspec/changes/refactor-status-display/tasks.md
+++ b/openspec/changes/refactor-status-display/tasks.md
@@ -49,9 +49,9 @@ Reuse standardized `pkg/display` functions (`Header`, `PrintSectionDivider`, `Pr
 
 **Files:** `pkg/installer/otel.go` (modify), `pkg/installer/otel_python.go` (modify), other OTel installer files as applicable
 
-- [ ] 5.1 Audit all OTel installer files for inline section dividers, ad-hoc status lines, or header formatting that duplicates `Header`, `PrintSectionDivider`, `PrintStatusLine`, or `PrintFlagLine`
-- [ ] 5.2 Replace duplicated formatting code with the appropriate `pkg/display` helpers throughout the OTel installer files
-- [ ] 5.3 Run `make test` and `make lint` — no regressions
+- [x] 5.1 Audit all OTel installer files for inline section dividers, ad-hoc status lines, or header formatting that duplicates `Header`, `PrintSectionDivider`, `PrintStatusLine`, or `PrintFlagLine`
+- [x] 5.2 Replace duplicated formatting code with the appropriate `pkg/display` helpers throughout the OTel installer files
+- [x] 5.3 Run `make test` and `make lint` — no regressions
 
 ## 6. Verification
 

--- a/pkg/display/colors.go
+++ b/pkg/display/colors.go
@@ -5,9 +5,12 @@ import (
 )
 
 var (
-	ColorOK     = color.New(color.FgGreen, color.Bold)
-	ColorError  = color.New(color.FgRed, color.Bold)
-	ColorLabel  = color.New()
-	ColorMuted  = color.New(color.Faint)
-	ColorHeader = color.New(color.FgMagenta, color.Bold)
+	ColorOK      = color.New(color.FgGreen, color.Bold)
+	ColorError   = color.New(color.FgRed, color.Bold)
+	ColorWarning = color.New(color.FgYellow, color.Bold)
+	ColorBold    = color.New(color.FgWhite, color.Bold)
+	ColorDefault = color.New()
+	ColorMuted   = color.New(color.Faint)
+	ColorHeader  = color.New(color.FgMagenta, color.Bold)
+	ColorMessage = color.New(color.FgMagenta)
 )

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -45,5 +45,5 @@ func PrintFlagLine(label, message string, colorFunc *color.Color) {
 }
 
 func PrintError(label string, err error) {
-	fmt.Printf("  %s: %s\n", label, ColorError.Sprintf("✗ %s", err))
+	_, _ = fmt.Fprintf(color.Output, "  %s: %s\n", ColorDefault.Sprint(label), ColorError.Sprintf("✗ %s", err))
 }

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -11,26 +11,26 @@ const (
 	DividerLineLength int = 42
 )
 
-func Header(message string) {
+func Header(label string, message string) {
 	_, err := ColorHeader.Printf("  %s\n", message)
 	if err != nil {
-		PrintStatusLine("status", fmt.Sprintf("✗ %s", err), ColorError)
+		PrintStatusLine(label, fmt.Sprintf("✗ %s", err), ColorError)
 	}
 
-	PrintSectionDivider()
+	PrintSectionDivider(label)
 }
 
-func PrintSectionDivider() {
+func PrintSectionDivider(label string) {
 	_, err := ColorMuted.Println("  " + strings.Repeat("─", DividerLineLength))
 	if err != nil {
-		PrintStatusLine("status", fmt.Sprintf("✗ %s", err), ColorError)
+		PrintError(label, err)
 	}
 }
 
 func PrintStatusLine(label, message string, colorFunc *color.Color) {
 	_, err := fmt.Fprintf(color.Output, "  %s:  %s\n", ColorLabel.Sprint(label), colorFunc.Sprint(message))
 	if err != nil {
-		fmt.Printf("status: %s\n", ColorError.Sprintf("✗ %s", err))
+		PrintError(label, err)
 	}
 }
 
@@ -39,6 +39,10 @@ func PrintStatusLine(label, message string, colorFunc *color.Color) {
 func PrintFlagLine(label, message string, colorFunc *color.Color) {
 	_, err := fmt.Fprintf(color.Output, "  %s  %s\n", ColorLabel.Sprint(label), colorFunc.Sprint(message))
 	if err != nil {
-		fmt.Printf("status: %s\n", ColorError.Sprintf("✗ %s", err))
+		PrintError(label, err)
 	}
+}
+
+func PrintError(label string, err error) {
+	fmt.Printf("  %s: %s\n", label, ColorError.Sprintf("✗ %s", err))
 }

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -8,27 +8,28 @@ import (
 )
 
 const (
-	DividerLineLength int = 42
+	DividerLineLength int = 50
+	DefaultLabel          = "dtwiz"
 )
 
-func Header(label string, message string) {
+func Header(message string) {
 	_, err := ColorHeader.Printf("  %s\n", message)
 	if err != nil {
-		PrintStatusLine(label, fmt.Sprintf("✗ %s", err), ColorError)
+		PrintError(DefaultLabel, err)
 	}
 
-	PrintSectionDivider(label)
+	PrintSectionDivider()
 }
 
-func PrintSectionDivider(label string) {
+func PrintSectionDivider() {
 	_, err := ColorMuted.Println("  " + strings.Repeat("─", DividerLineLength))
 	if err != nil {
-		PrintError(label, err)
+		PrintError(DefaultLabel, err)
 	}
 }
 
 func PrintStatusLine(label, message string, colorFunc *color.Color) {
-	_, err := fmt.Fprintf(color.Output, "  %s:  %s\n", ColorLabel.Sprint(label), colorFunc.Sprint(message))
+	_, err := fmt.Fprintf(color.Output, "  %s:  %s\n", ColorDefault.Sprint(label), colorFunc.Sprint(message))
 	if err != nil {
 		PrintError(label, err)
 	}
@@ -37,7 +38,7 @@ func PrintStatusLine(label, message string, colorFunc *color.Color) {
 // PrintFlagLine prints a feature flag line without a colon after the label,
 // producing output like:  DTWIZ_ALL_RUNTIMES  ✓ enabled (env)
 func PrintFlagLine(label, message string, colorFunc *color.Color) {
-	_, err := fmt.Fprintf(color.Output, "  %s  %s\n", ColorLabel.Sprint(label), colorFunc.Sprint(message))
+	_, err := fmt.Fprintf(color.Output, "  %s  %s\n", ColorDefault.Sprint(label), colorFunc.Sprint(message))
 	if err != nil {
 		PrintError(label, err)
 	}

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -2,6 +2,8 @@ package display
 
 import (
 	"bytes"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -31,7 +33,7 @@ func captureOutput(t *testing.T, fn func()) string {
 
 func TestHeader_PrintsIndentedTitle(t *testing.T) {
 	got := captureOutput(t, func() {
-		Header("Connection Status")
+		Header("test", "Connection Status")
 	})
 	if !strings.Contains(got, "  Connection Status\n") {
 		t.Errorf("Header() = %q, want output to contain indented title", got)
@@ -43,7 +45,7 @@ func TestHeader_PrintsIndentedTitle(t *testing.T) {
 
 func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
 	got := captureOutput(t, func() {
-		PrintSectionDivider()
+		PrintSectionDivider("test")
 	})
 	if !strings.HasPrefix(got, "  ") {
 		t.Errorf("PrintSectionDivider() output missing two-space indent: %q", got)
@@ -93,6 +95,31 @@ func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
 	want := "  DTWIZ_ALL_RUNTIMES  ✓ enabled (env)\n"
 	if got != want {
 		t.Errorf("PrintFlagLine() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintError_FormatsLabelAndError(t *testing.T) {
+	// PrintError writes to os.Stdout via fmt.Printf, not color.Output,
+	// so we capture stdout directly.
+	origNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = origNoColor })
+
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	PrintError("Setup", errors.New("connection refused"))
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	got := buf.String()
+	want := "  Setup: ✗ connection refused\n"
+	if got != want {
+		t.Errorf("PrintError() = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -3,7 +3,6 @@ package display
 import (
 	"bytes"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 
@@ -99,24 +98,9 @@ func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
 }
 
 func TestPrintError_FormatsLabelAndError(t *testing.T) {
-	// PrintError writes to os.Stdout via fmt.Printf, not color.Output,
-	// so we capture stdout directly.
-	origNoColor := color.NoColor
-	color.NoColor = true
-	t.Cleanup(func() { color.NoColor = origNoColor })
-
-	r, w, _ := os.Pipe()
-	origStdout := os.Stdout
-	os.Stdout = w
-	t.Cleanup(func() { os.Stdout = origStdout })
-
-	PrintError("Setup", errors.New("connection refused"))
-
-	w.Close()
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-
-	got := buf.String()
+	got := captureOutput(t, func() {
+		PrintError("Setup", errors.New("connection refused"))
+	})
 	want := "  Setup: ✗ connection refused\n"
 	if got != want {
 		t.Errorf("PrintError() = %q, want %q", got, want)

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -33,7 +33,7 @@ func captureOutput(t *testing.T, fn func()) string {
 
 func TestHeader_PrintsIndentedTitle(t *testing.T) {
 	got := captureOutput(t, func() {
-		Header("test", "Connection Status")
+		Header("Connection Status")
 	})
 	if !strings.Contains(got, "  Connection Status\n") {
 		t.Errorf("Header() = %q, want output to contain indented title", got)
@@ -45,7 +45,7 @@ func TestHeader_PrintsIndentedTitle(t *testing.T) {
 
 func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
 	got := captureOutput(t, func() {
-		PrintSectionDivider("test")
+		PrintSectionDivider()
 	})
 	if !strings.HasPrefix(got, "  ") {
 		t.Errorf("PrintSectionDivider() output missing two-space indent: %q", got)

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 // awsTemplateURL is the pinned Dynatrace CloudFormation template.
@@ -415,7 +415,6 @@ func buildDeployArgs(cfg awsStackConfig, templateFile string) []string {
 //   - dryRun:         when true, show what would be done without executing
 //   - startTime:      RFC3339 timestamp used as the from-clause for WatchIngest (empty = skip watch)
 func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime string) error {
-	cyan := color.New(color.FgMagenta)
 	sep := strings.Repeat("─", 60)
 
 	// Prefer the explicit platform token; fall back to the access token.
@@ -425,7 +424,7 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 	}
 
 	fmt.Println()
-	cyan.Println("  Dynatrace AWS CloudFormation Integration")
+	display.ColorMessage.Println("  Dynatrace AWS CloudFormation Integration")
 	fmt.Println()
 
 	// ── Validate parameters ──────────────────────────────────────────────────
@@ -494,7 +493,7 @@ func InstallAWS(envURL, token, platformToken string, dryRun bool, startTime stri
 
 	fmt.Println()
 	fmt.Printf("  %s\n", sep)
-	cyan.Println("  Command to be executed:")
+	display.ColorMessage.Println("  Command to be executed:")
 	fmt.Printf("  %s\n", sep)
 	fmt.Printf("    aws %s\n", formatDeployCmd(maskTokenArgs(deployArgs)))
 	fmt.Printf("  %s\n\n", sep)

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -415,7 +415,7 @@ func isInstrumented(fn lambdaFunction) bool {
 
 // printLambdaPreviewTable renders the preview table of Lambda functions.
 func printLambdaPreviewTable(functions []lambdaFunction, actions []string) (actionable, skipped int) {
-	cyan := color.New(color.FgMagenta)
+	cyan := display.ColorMessage
 	sep := strings.Repeat("─", 70)
 
 	fmt.Println()
@@ -447,7 +447,7 @@ func printLambdaPreviewTable(functions []lambdaFunction, actions []string) (acti
 
 // printLambdaUninstallPreview renders the preview for uninstallation.
 func printLambdaUninstallPreview(functions []lambdaFunction) {
-	cyan := color.New(color.FgMagenta)
+	cyan := display.ColorMessage
 	sep := strings.Repeat("─", 55)
 
 	fmt.Println()
@@ -653,10 +653,8 @@ func updateFunctionConfig(functionName string, envVars map[string]string, layers
 // before applying changes; when false, changes are applied immediately after
 // the preview (used when called from install aws).
 func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool) error {
-	cyan := color.New(color.FgMagenta)
-
 	fmt.Println()
-	cyan.Println("  Dynatrace AWS Lambda Instrumentation")
+	display.ColorMessage.Println("  Dynatrace AWS Lambda Instrumentation")
 	fmt.Println()
 
 	// ── Validate ─────────────────────────────────────────────────────────────
@@ -789,10 +787,8 @@ func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool)
 // UninstallAWSLambda removes the Dynatrace Lambda Layer and DT_* environment
 // variables from all instrumented functions in the current AWS region.
 func UninstallAWSLambda(dryRun bool) error {
-	cyan := color.New(color.FgMagenta)
-
 	fmt.Println()
-	cyan.Println("  Dynatrace AWS Lambda — Remove Instrumentation")
+	display.ColorMessage.Println("  Dynatrace AWS Lambda — Remove Instrumentation")
 	fmt.Println()
 
 	if !isAWSCLIInstalled() {

--- a/pkg/installer/aws_uninstall.go
+++ b/pkg/installer/aws_uninstall.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 // deleteDTMonitoringConfig deletes a Dynatrace AWS monitoring configuration
@@ -39,14 +39,12 @@ func deleteDTMonitoringConfig(apiURL, token, objectID string) error {
 //   - token:   access token for Dynatrace API (falls back to DT_ACCESS_TOKEN env var)
 //   - dryRun:  when true, show what would be done without executing
 func UninstallAWS(envURL, token string, dryRun bool) error {
-	cyan := color.New(color.FgMagenta)
-
 	if !isAWSCLIInstalled() {
 		return fmt.Errorf("AWS CLI not found — install it from https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html")
 	}
 
 	fmt.Println()
-	cyan.Println("  Dynatrace AWS Uninstall")
+	display.ColorMessage.Println("  Dynatrace AWS Uninstall")
 	fmt.Println()
 
 	fmt.Printf("  Fetching AWS account info...\n")

--- a/pkg/installer/demo.go
+++ b/pkg/installer/demo.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 const (
@@ -171,8 +171,6 @@ func extractZip(zipPath, destDir string) error {
 // 2. Install Python if missing
 // 3. Install OTel Collector + Python auto-instrumentation targeting ./schnitzel
 func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
-	cyan := color.New(color.FgMagenta)
-
 	demoExists := checkDemoExists()
 	pythonCmd, err := pythonInstallPlan()
 	if err != nil {
@@ -181,7 +179,7 @@ func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
 
 	// Build plan lines
 	fmt.Println()
-	cyan.Println("  Dynatrace Demo Installation (schnitzel)")
+	display.ColorMessage.Println("  Dynatrace Demo Installation (schnitzel)")
 	fmt.Println()
 	fmt.Println("  This will:")
 

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 //go:embed dynakube.tmpl
@@ -347,25 +347,24 @@ func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error 
 	}
 
 	// --- Preview ---
-	cyan := color.New(color.FgMagenta)
 	sep := strings.Repeat("─", 60)
 
 	fmt.Println()
-	cyan.Println("  Dynatrace Kubernetes Integration")
+	display.ColorMessage.Println("  Dynatrace Kubernetes Integration")
 	fmt.Println()
 	fmt.Printf("  Cluster name:  %s\n", name)
 	fmt.Printf("  API URL:       %s\n\n", apiURL)
 	fmt.Printf("  %s\n", sep)
-	cyan.Println("  dynakube.yaml manifest to be applied:")
+	display.ColorMessage.Println("  dynakube.yaml manifest to be applied:")
 	fmt.Printf("  %s\n", sep)
 	for _, line := range strings.Split(strings.TrimRight(manifest, "\n"), "\n") {
 		fmt.Printf("    %s\n", line)
 	}
 	fmt.Printf("\n  %s\n", sep)
-	cyan.Printf("  Commands to be executed:\n")
+	display.ColorMessage.Printf("  Commands to be executed:\n")
 	fmt.Printf("  %s\n", sep)
-	cyan.Printf("    1. %s\n", helmCmd)
-	cyan.Printf("    2. kubectl apply -f dynakube.yaml  # manifest shown above\n")
+	display.ColorMessage.Printf("    1. %s\n", helmCmd)
+	display.ColorMessage.Printf("    2. kubectl apply -f dynakube.yaml  # manifest shown above\n")
 	fmt.Printf("  %s\n\n", sep)
 
 	// --- Confirm ---

--- a/pkg/installer/kubernetes_uninstall.go
+++ b/pkg/installer/kubernetes_uninstall.go
@@ -3,7 +3,7 @@ package installer
 import (
 	"fmt"
 
-	"github.com/fatih/color"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 // UninstallKubernetes removes the Dynatrace Operator and all managed resources
@@ -13,10 +13,8 @@ import (
 //  3. Helm uninstall dynatrace-operator
 //  4. Delete the dynatrace namespace
 func UninstallKubernetes() error {
-	cyan := color.New(color.FgMagenta)
-
 	fmt.Println()
-	cyan.Println("  Dynatrace Kubernetes Uninstall")
+	display.ColorMessage.Println("  Dynatrace Kubernetes Uninstall")
 	fmt.Println()
 	fmt.Println("  This will perform the following steps:")
 	fmt.Println("    1. Delete all DynaKube and EdgeConnect custom resources")

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -9,8 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fatih/color"
-
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
@@ -204,10 +203,9 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 			return fmt.Errorf("project path not found: %s", projectPath)
 		}
 	}
-	cyan := color.New(color.FgMagenta)
 
 	fmt.Println()
-	cyan.Println("  Dynatrace OpenTelemetry Installation")
+	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
 	fmt.Println()
 
 	cp, err := prepareCollectorPlan(envURL, token, ingestToken)
@@ -232,8 +230,8 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 	} else {
 		projects := detectAllProjects(runtimes)
 		if len(projects) > 0 {
-			cyan.Println("  Detected projects:")
-			fmt.Println("  " + strings.Repeat("─", 50))
+			display.ColorMessage.Println("  Detected projects:")
+			display.PrintSectionDivider()
 			printProjectList(projects)
 
 			if selected, ok := selectProject(projects); ok {
@@ -244,11 +242,11 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 	fmt.Println()
 
 	if plan != nil {
-		cyan.Println("  This will install the OTel Collector and auto-instrument your application.")
+		display.ColorMessage.Println("  This will install the OTel Collector and auto-instrument your application.")
 	}
 	fmt.Println()
 
-	cyan.Println("  1) OTel Collector")
+	display.ColorMessage.Println("  1) OTel Collector")
 	fmt.Printf("     Directory: %s\n", cp.installDir)
 	fmt.Printf("     Binary:    %s\n", cp.binaryPath)
 	if len(cp.runningPIDs) > 0 {
@@ -262,11 +260,11 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 	}
 
 	sep := strings.Repeat("─", 60)
-	cp.printConfigPreview(cyan, sep)
+	cp.printConfigPreview(sep)
 
 	if plan != nil {
 		fmt.Println()
-		cyan.Printf("  2) %s auto-instrumentation\n", plan.Runtime())
+		display.ColorMessage.Printf("  2) %s auto-instrumentation\n", plan.Runtime())
 		plan.PrintPlanSteps()
 	}
 

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -23,8 +23,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/fatih/color"
-
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -605,11 +604,11 @@ func generateOtelConfig(apiURL, token string) (string, error) {
 
 // printConfigPreview prints the OTel Collector config in the separator+title
 // style consistent with the AWS and Kubernetes install previews.
-func (cp *collectorPlan) printConfigPreview(cyan *color.Color, sep string) {
+func (cp *collectorPlan) printConfigPreview(sep string) {
 	label := filepath.Base(cp.configPath)
 	fmt.Println()
 	fmt.Printf("  %s\n", sep)
-	cyan.Printf("  %s:\n", label)
+	display.ColorMessage.Printf("  %s:\n", label)
 	fmt.Printf("  %s\n", sep)
 	for _, line := range strings.Split(strings.TrimRight(cp.configPreview, "\n"), "\n") {
 		fmt.Printf("    %s\n", line)
@@ -736,7 +735,6 @@ func prepareCollectorPlan(envURL, token, ingestToken string) (*collectorPlan, er
 }
 
 func (cp *collectorPlan) printDryRun(ingestToken string) {
-	cyan := color.New(color.FgMagenta)
 	sep := strings.Repeat("─", 60)
 
 	fmt.Println("[dry-run] Would install Dynatrace OpenTelemetry Collector")
@@ -752,7 +750,7 @@ func (cp *collectorPlan) printDryRun(ingestToken string) {
 		return "(from token)"
 	}())
 
-	cp.printConfigPreview(cyan, sep)
+	cp.printConfigPreview(sep)
 }
 
 // execute downloads, writes config, and starts the collector.
@@ -812,10 +810,8 @@ func (cp *collectorPlan) execute(envURL, platformToken string, skipVerification 
 // InstallOtelCollectorOnly installs the Dynatrace OTel Collector without
 // runtime instrumentation.
 func InstallOtelCollectorOnly(envURL, token, ingestToken, platformToken string, dryRun bool) error {
-	cyan := color.New(color.FgMagenta)
-
 	fmt.Println()
-	cyan.Println("  Dynatrace OpenTelemetry Installation")
+	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
 	fmt.Println()
 
 	cp, err := prepareCollectorPlan(envURL, token, ingestToken)
@@ -842,7 +838,7 @@ func InstallOtelCollectorOnly(envURL, token, ingestToken, platformToken string, 
 		}
 	}
 
-	cp.printConfigPreview(cyan, sep)
+	cp.printConfigPreview(sep)
 
 	fmt.Println()
 	ok, err := confirmProceed("  Proceed with installation?")

--- a/pkg/installer/otel_python.go
+++ b/pkg/installer/otel_python.go
@@ -9,8 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
-
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -310,11 +309,10 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 		return nil
 	}
 
-	cyan := color.New(color.FgMagenta)
 	sep := strings.Repeat("─", 60)
 
 	fmt.Println()
-	cyan.Println("  Dynatrace Python Auto-Instrumentation")
+	display.ColorMessage.Println("  Dynatrace Python Auto-Instrumentation")
 	fmt.Println("  " + sep)
 
 	plan := DetectPythonPlanFromPath(projectPath, apiURL, token)
@@ -324,7 +322,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 	}
 
 	fmt.Println()
-	cyan.Println("  Steps:")
+	display.ColorMessage.Println("  Steps:")
 	plan.PrintPlanSteps()
 
 	ok, err := confirmProceed("  Proceed with installation?")

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fatih/color"
-
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -182,10 +181,9 @@ func matchProcessesToProjects(projects []ScannedProject, processes []DetectedPro
 }
 
 func promptProjectSelection(label string, projects []ScannedProject) *ScannedProject {
-	header := color.New(color.FgMagenta)
 	fmt.Println()
-	header.Printf("  %s projects on this machine:\n", label)
-	fmt.Println("  " + strings.Repeat("─", 50))
+	display.ColorHeader.Printf("  %s projects on this machine:\n", label)
+	display.PrintSectionDivider()
 	for i, project := range projects {
 		line := fmt.Sprintf("  [%d]  %s  (%s)", i+1, project.Path, strings.Join(project.Markers, ", "))
 		if len(project.RunningProcessIDs) > 0 {

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
-
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -138,10 +137,6 @@ func removeWithRetry(path string) error {
 }
 
 func UninstallOtelCollector(dryRun bool) error {
-	header := color.New(color.FgMagenta, color.Bold)
-	muted := color.New()
-	red := color.New(color.FgRed)
-
 	processes := findRunningOtelProcesses()
 	dirs := candidateOtelDirs(processes)
 
@@ -168,12 +163,11 @@ func UninstallOtelCollector(dryRun bool) error {
 		}
 	}
 
-	header.Println("  Dynatrace OTel Collector Uninstall")
-	muted.Println("  " + strings.Repeat("─", 50))
-	fmt.Println()
+	// ── Preview ──────────────────────────────────────────────────────────────
+	display.Header("Dynatrace OTel Collector Uninstall")
 
 	if len(processes) == 0 && len(dirs) == 0 && !anyRuntimeProcs {
-		muted.Println("  Nothing to remove — no running collector and no install directories found.")
+		display.ColorDefault.Println("  Nothing to remove — no running collector and no install directories found.")
 		return nil
 	}
 
@@ -185,12 +179,12 @@ func UninstallOtelCollector(dryRun bool) error {
 				hint = "  (" + p.binaryPath + ")"
 			}
 			fmt.Printf("    ")
-			red.Printf("kill PID %d", p.pid)
-			muted.Printf("%s\n", hint)
+			display.ColorError.Printf("kill PID %d", p.pid)
+			display.ColorDefault.Printf("%s\n", hint)
 		}
 		fmt.Println()
 	} else {
-		muted.Println("  No running collector processes found.")
+		display.ColorDefault.Println("  No running collector processes found.")
 		fmt.Println()
 	}
 
@@ -198,11 +192,11 @@ func UninstallOtelCollector(dryRun bool) error {
 		fmt.Println("  Directories that will be removed:")
 		for _, d := range dirs {
 			fmt.Printf("    ")
-			red.Printf("rm -rf %s\n", d)
+			display.ColorError.Printf("rm -rf %s\n", d)
 		}
 		fmt.Println()
 	} else {
-		muted.Println("  No installation directories found.")
+		display.ColorDefault.Println("  No installation directories found.")
 		fmt.Println()
 	}
 
@@ -211,17 +205,17 @@ func UninstallOtelCollector(dryRun bool) error {
 			fmt.Printf("  Instrumented %s processes that will be stopped:\n", r.label)
 			for _, p := range r.procs {
 				fmt.Printf("    ")
-				red.Printf("stop PID %d", p.PID)
-				muted.Printf("  (%s)\n", p.Command)
+				display.ColorError.Printf("stop PID %d", p.PID)
+				display.ColorDefault.Printf("  (%s)\n", p.Command)
 			}
 			fmt.Println()
 		}
 	}
 
-	muted.Println("  " + strings.Repeat("─", 50))
+	display.PrintSectionDivider()
 
 	if dryRun {
-		muted.Println("  [dry-run] No changes made.")
+		display.ColorDefault.Println("  [dry-run] No changes made.")
 		return nil
 	}
 
@@ -230,7 +224,7 @@ func UninstallOtelCollector(dryRun bool) error {
 		return fmt.Errorf("reading confirmation: %w", err)
 	}
 	if !ok {
-		muted.Println("  Uninstall cancelled.")
+		display.ColorDefault.Println("  Uninstall cancelled.")
 		return nil
 	}
 	fmt.Println()
@@ -258,6 +252,6 @@ func UninstallOtelCollector(dryRun bool) error {
 	}
 
 	fmt.Println()
-	color.New(color.FgGreen, color.Bold).Println("  ✓ OTel Collector uninstalled.")
+	display.ColorOK.Println("  ✓ OTel Collector uninstalled.")
 	return nil
 }

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"gopkg.in/yaml.v3"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -129,21 +129,17 @@ func diffLines(oldLines, newLines []string) []diffEdit {
 // showConfigDiff prints a coloured line diff to stdout.
 // Added lines are green (+), removed lines are red (-), unchanged lines are dimmed.
 func showConfigDiff(origData, updatedData []byte) {
-	green := color.New(color.FgGreen, color.Bold)
-	red := color.New(color.FgRed)
-	dim := color.New()
-
 	oldLines := strings.Split(strings.TrimRight(string(origData), "\n"), "\n")
 	newLines := strings.Split(strings.TrimRight(string(updatedData), "\n"), "\n")
 
 	for _, e := range diffLines(oldLines, newLines) {
 		switch e.kind {
 		case editAdd:
-			fmt.Println(green.Sprint("+ " + e.line))
+			fmt.Println(display.ColorOK.Sprint("+ " + e.line))
 		case editDel:
-			fmt.Println(red.Sprint("- " + e.line))
+			fmt.Println(display.ColorError.Sprint("- " + e.line))
 		case editKeep:
-			fmt.Println(dim.Sprint("  " + e.line))
+			fmt.Println(display.ColorDefault.Sprint("  " + e.line))
 		}
 	}
 }
@@ -291,37 +287,33 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 		return fmt.Errorf("serialising preview: %w", err)
 	}
 
-	header := color.New(color.FgMagenta, color.Bold)
-	muted := color.New()
-	bold := color.New(color.FgWhite, color.Bold)
-	green := color.New(color.FgGreen, color.Bold)
+	display.Header(fmt.Sprintf("Preview of changes to %s:", configPath))
+	fmt.Println()
 
-	header.Printf("  Preview of changes to %s:\n", configPath)
-	muted.Println("  " + strings.Repeat("─", 60))
-	fmt.Println()
 	showConfigDiff(origData, updatedData)
+
 	fmt.Println()
-	muted.Println("  " + strings.Repeat("─", 60))
+	display.PrintSectionDivider()
 	fmt.Println()
 
 	// Show restart plan.
 	if len(runningProcs) > 0 {
-		bold.Println("  Running collectors that will be restarted:")
+		display.ColorBold.Println("  Running collectors that will be restarted:")
 		for _, p := range runningProcs {
 			hint := p.binaryPath
 			if hint == "" {
 				hint = "(unknown binary)"
 			}
-			fmt.Printf("    • PID %d  %s\n", p.pid, muted.Sprint(hint))
+			fmt.Printf("    • PID %d  %s\n", p.pid, display.ColorDefault.Sprint(hint))
 		}
 	} else {
-		muted.Println("  No running collector found — config will be updated on disk only.")
+		display.ColorDefault.Println("  No running collector found — config will be updated on disk only.")
 	}
 	fmt.Println()
-	muted.Println("  " + strings.Repeat("─", 60))
+	display.PrintSectionDivider()
 
 	if dryRun {
-		muted.Println("  [dry-run] No changes made.")
+		display.ColorDefault.Println("  [dry-run] No changes made.")
 		return nil
 	}
 
@@ -330,7 +322,7 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 		return fmt.Errorf("reading confirmation: %w", err)
 	}
 	if !ok {
-		muted.Println("  Cancelled — no changes written.")
+		display.ColorDefault.Println("  Cancelled — no changes written.")
 		return nil
 	}
 	fmt.Println()
@@ -345,7 +337,7 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 	fmt.Println()
 
 	if len(runningProcs) == 0 {
-		muted.Println("  No running collector to restart.")
+		display.ColorDefault.Println("  No running collector to restart.")
 		return nil
 	}
 
@@ -354,8 +346,8 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 	fmt.Println()
 
 	if restartBinary == "" {
-		muted.Println("  Could not determine binary path — skipping restart.")
-		muted.Println("  Start the collector manually with the updated config.")
+		display.ColorDefault.Println("  Could not determine binary path — skipping restart.")
+		display.ColorDefault.Println("  Start the collector manually with the updated config.")
 		return nil
 	}
 
@@ -372,6 +364,6 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 		return nil
 	}
 
-	green.Println("  ✓ Collector restarted and verified.")
+	display.ColorOK.Println("  ✓ Collector restarted and verified.")
 	return nil
 }

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -139,7 +139,7 @@ func showConfigDiff(origData, updatedData []byte) {
 		case editDel:
 			fmt.Println(display.ColorError.Sprint("- " + e.line))
 		case editKeep:
-			fmt.Println(display.ColorDefault.Sprint("  " + e.line))
+			fmt.Println(display.ColorMuted.Sprint("  " + e.line))
 		}
 	}
 }


### PR DESCRIPTION
## Feature Description
Introduces a `pkg/display` package that centralises all terminal output styling for `dtwiz`. Previously, each installer and command constructed its own `color.New(...)` instances and formatted status lines ad-hoc. This PR:
- Expands the colour palette (`ColorWarning`, `ColorBold`, `ColorMessage`, `ColorDefault`) and renames `ColorLabel` → `ColorDefault` for clarity.
- Adds `PrintError(label, err)` — a dedicated helper for error lines, consistent with `PrintStatusLine` and `PrintFlagLine`.
- Adds `DefaultLabel` constant and increases `DividerLineLength` from `42` to `50`.
- Migrates all installers (`otel`, `kubernetes`, `aws`, `demo`) and commands (`setup`, `status`) to use `display.Color*` variables and the shared print helpers, removing all local `color.New(...)` constructions for roles already covered by the palette.
- There's still commands and files that use the outdated approach, but this was limited to prevent the PR scope from exploding. More refactoring changes should be implemented as we go with the next features.

## How to test
1. Run `dtwiz status` — verify the header, divider, and status lines render correctly.
2. Run `dtwiz setup` through a failing auth path — verify error lines use the `✗` prefix and red styling.
3. Run `make test` — all tests, including the new `TestPrintError_FormatsLabelAndError`, must pass.

## Which other features are affected?
1. All installers that previously used local color instances now rely on `pkg/display` — visual output of `dtwiz install *` and `dtwiz uninstall *` commands is affected.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
