### PR TITLE
refactor: inject configured HTTP client into OneAgent installer

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,9 +30,13 @@ var installOneAgentCmd = &cobra.Command{
 		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
 			return err
 		}
+		c, err := setupClient()
+		if err != nil {
+			return err
+		}
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		hostGroup, _ := cmd.Flags().GetString("host-group")
-		if err := installer.InstallOneAgent(envURL, accessTok, installDryRun, quiet, hostGroup); err != nil {
+		if err := installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup); err != nil {
 			return err
 		}
 		if !installDryRun {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -129,10 +129,15 @@ var setupCmd = &cobra.Command{
 			return err
 		}
 
+		c, err := setupClient()
+		if err != nil {
+			return err
+		}
+
 		var installErr error
 		switch selected.Method {
 		case recommender.MethodOneAgent:
-			installErr = installer.InstallOneAgent(envURL, accessTok, setupDryRun, false, "")
+			installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")
 		case recommender.MethodKubernetes:
 			installErr = installer.InstallKubernetes(envURL, accessTok, accessTok, "" /* name */, setupDryRun)
 		case recommender.MethodDocker:

--- a/openspec/changes/refactor-oneagent-http-client/.openspec.yaml
+++ b/openspec/changes/refactor-oneagent-http-client/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/refactor-oneagent-http-client/specs/oneagent-client-injection/spec.md
+++ b/openspec/changes/refactor-oneagent-http-client/specs/oneagent-client-injection/spec.md
@@ -1,0 +1,112 @@
+# OneAgent Client Injection
+
+## CHANGED Requirements
+
+### Requirement: OneAgent installer uses configured HTTP client
+
+The `pkg/installer` package SHALL use the configured resty-based `*client.ClassicClient` from `pkg/client` instead of raw `http.DefaultClient` for all OneAgent HTTP operations. This ensures proper retry logic, timeout, user-agent headers, and verbosity logging for connectivity checks and installer downloads.
+
+#### Scenario: OneAgent install command creates and injects configured client
+
+- **GIVEN** a user runs `dtwiz install oneagent`
+- **WHEN** the `installOneAgentCmd.RunE` handler executes
+- **THEN** it calls `setupClient()` to create a `*client.Client`
+- **AND** passes `client.Classic` to `installer.InstallOneAgent()`
+
+#### Scenario: OneAgent setup command creates and injects configured client
+
+- **GIVEN** a user runs `dtwiz setup` and selects OneAgent from recommendations
+- **WHEN** the setup workflow switches to `MethodOneAgent`
+- **THEN** it calls `setupClient()` to create a `*client.Client`
+- **AND** passes `client.Classic` to `installer.InstallOneAgent()`
+
+#### Scenario: Connectivity check uses configured client
+
+- **GIVEN** `InstallOneAgent()` receives a `*client.ClassicClient`
+- **AND** it is not a dry-run
+- **WHEN** `checkOneAgentConnectivity()` is called
+- **THEN** it uses `c.HTTP().R().Get("/api/v1/time")` (resty client)
+- **AND** not raw `http.DefaultClient`
+
+#### Scenario: Installer download uses configured client
+
+- **GIVEN** `InstallOneAgent()` receives a `*client.ClassicClient`
+- **WHEN** `downloadOneAgentInstaller()` is called
+- **THEN** it uses `c.HTTP().R().SetDoNotParseResponse(true).Get(path)` for streaming downloads
+- **AND** constructs request path relative to base URL (not full URL)
+
+#### Scenario: API URL is obtained from client, not passed as parameter
+
+- **GIVEN** `InstallOneAgent()` receives a `*client.ClassicClient`
+- **WHEN** constructing installer arguments or printing dry-run output
+- **THEN** it calls `c.BaseURL()` instead of using a separate `apiURL` parameter
+- **AND** the signature is `InstallOneAgent(c *client.ClassicClient, dryRun, quiet bool, hostGroup string)`
+
+### Requirement: Configured client provides retry and timeout
+
+The `*client.ClassicClient` created by `setupClient()` SHALL have:
+
+- 3 retry attempts on transient failures (429, 5xx errors)
+- 1-second wait between retries, up to 10-second max
+- 6-minute total timeout
+- Proper User-Agent header (`dtwiz/{version}`)
+- Verbose logging hooks when `--verbose` or `--debug` flags are set
+
+#### Scenario: OneAgent HTTP requests respect retry policy
+
+- **GIVEN** a transient 503 error from the Dynatrace API
+- **WHEN** `checkOneAgentConnectivity()` makes a request via the resty client
+- **THEN** the request is automatically retried up to 3 times
+- **AND** the user does not need to implement retry logic in the installer
+
+#### Scenario: OneAgent HTTP requests respect timeout
+
+- **GIVEN** the Dynatrace API does not respond within 6 minutes
+- **WHEN** `downloadOneAgentInstaller()` streams the binary
+- **THEN** the request times out after 6 minutes
+- **AND** returns an error to the caller
+
+#### Scenario: Verbose logging shows HTTP details
+
+- **GIVEN** a user runs `dtwiz install oneagent --verbose` with valid credentials
+- **WHEN** `checkOneAgentConnectivity()` or `downloadOneAgentInstaller()` make HTTP requests
+- **THEN** the resty client's hooks log request/response details to stderr
+- **AND** the details include method, URL, status, and response time
+
+### Requirement: No circular import between pkg/client and pkg/installer
+
+The refactoring SHALL break the dependency of `pkg/client` on `pkg/installer.AuthHeader()`. Instead, the auth header logic is implemented locally in `pkg/client` so that `pkg/installer` can depend on `pkg/client` without creating a circular import.
+
+#### Scenario: AuthHeader logic moved to pkg/client
+
+- **GIVEN** the `authHeader(token string)` function in `pkg/client/client.go`
+- **WHEN** `client.New()` creates a resty client
+- **THEN** it calls the local `authHeader()` function
+- **AND** no longer imports `pkg/installer` for this functionality
+
+#### Scenario: Code compiles without circular import errors
+
+- **GIVEN** the refactored codebase
+- **WHEN** `make build` is run
+- **THEN** compilation succeeds with no circular import errors
+- **AND** all imports are acyclic: `cmd` → `pkg/installer` → `pkg/client`, `cmd` → `pkg/client`
+
+### Requirement: Backward compatibility with command callers
+
+Callers of `InstallOneAgent()` SHALL not need to know about or handle the configured client. The callers (`cmd/install.go`, `cmd/setup.go`) manage client creation and injection, while the installer focuses on the installation logic.
+
+#### Scenario: Commands still handle credential validation and watch
+
+- **GIVEN** a user runs `dtwiz install oneagent`
+- **WHEN** the command handler executes
+- **THEN** it continues to call `validateCredentials()` (using its own HTTP client)
+- **AND** continues to call `installer.WatchIngest()` after installation succeeds
+- **AND** the installer does not need to know about or call these functions
+
+#### Scenario: Dry-run behavior unchanged
+
+- **GIVEN** a user runs `dtwiz install oneagent --dry-run`
+- **WHEN** `InstallOneAgent()` is called
+- **THEN** it returns early with a preview of what would be installed
+- **AND** no HTTP requests are made
+- **AND** the configured client is created but not used in the dry-run path

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/version"
 )
 
@@ -54,9 +53,18 @@ var sensitiveHTTPHeaders = map[string]bool{
 	"set-cookie":    true,
 }
 
+// authHeader returns the Authorization header value for a Dynatrace token.
+// dt0c01.* tokens use "Api-Token", all others use "Bearer".
+func authHeader(token string) string {
+	if strings.HasPrefix(token, "dt0c01.") {
+		return "Api-Token " + token
+	}
+	return "Bearer " + token
+}
+
 // New builds a Client with a ClassicClient and a PlatformClient.
 // classicURL and platformURL should already be in the correct URL families
-// (use installer.APIURL / installer.AppsURL to convert from the raw env URL).
+// (strip .apps. for classic, add .apps. for platform).
 func New(classicURL, accessToken, platformURL, platformToken string, verbosityLevel int) (*Client, error) {
 	if classicURL == "" {
 		return nil, fmt.Errorf("classic API URL is required")
@@ -67,7 +75,7 @@ func New(classicURL, accessToken, platformURL, platformToken string, verbosityLe
 
 	classic := &ClassicClient{
 		baseURL: classicURL,
-		http:    newRestyClient(classicURL, installer.AuthHeader(accessToken), verbosityLevel),
+		http:    newRestyClient(classicURL, authHeader(accessToken), verbosityLevel),
 	}
 
 	platform := &PlatformClient{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,7 +64,6 @@ func authHeader(token string) string {
 
 // New builds a Client with a ClassicClient and a PlatformClient.
 // classicURL and platformURL should already be in the correct URL families
-// (strip .apps. for classic, add .apps. for platform).
 func New(classicURL, accessToken, platformURL, platformToken string, verbosityLevel int) (*Client, error) {
 	if classicURL == "" {
 		return nil, fmt.Errorf("classic API URL is required")

--- a/pkg/installer/oneagent.go
+++ b/pkg/installer/oneagent.go
@@ -29,6 +29,10 @@ const (
 	installerTypeWindows installerType = "windows"
 )
 
+// apiV1TimePath is used for connectivity checks. The /api/v1/time endpoint
+// requires no token scopes, making it safe to probe with any valid token.
+const apiV1TimePath = "/api/v1/time"
+
 // oneAgentInstallerType returns the installer type string for the current
 // OS/architecture combination, to be used in the download URL path.
 func oneAgentInstallerType() (installerType, string, error) {
@@ -63,7 +67,7 @@ func oneAgentInstallerFilename() string {
 // checkOneAgentConnectivity performs a quick connectivity check against the
 // Dynatrace API endpoint.
 func checkOneAgentConnectivity(c *client.ClassicClient) error {
-	resp, err := c.HTTP().R().Get("/api/v1/time")
+	resp, err := c.HTTP().R().Get(apiV1TimePath)
 	if err != nil {
 		return fmt.Errorf("connectivity check failed — cannot reach %s: %w", c.BaseURL(), err)
 	}

--- a/pkg/installer/oneagent.go
+++ b/pkg/installer/oneagent.go
@@ -3,11 +3,12 @@ package installer
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
 )
 
 // InstallMode controls which OneAgent components are installed.
@@ -60,57 +61,44 @@ func oneAgentInstallerFilename() string {
 
 // checkOneAgentConnectivity performs a quick connectivity check against the
 // Dynatrace API endpoint.
-func checkOneAgentConnectivity(apiURL, token string) error {
-	req, err := http.NewRequest(http.MethodGet, apiURL+"/api/v1/time", nil)
+func checkOneAgentConnectivity(c *client.ClassicClient) error {
+	resp, err := c.HTTP().R().Get("/api/v1/time")
 	if err != nil {
-		return fmt.Errorf("building connectivity request: %w", err)
+		return fmt.Errorf("connectivity check failed — cannot reach %s: %w", c.BaseURL(), err)
 	}
-	req.Header.Set("Authorization", AuthHeader(token))
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("connectivity check failed — cannot reach %s: %w", apiURL, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusUnauthorized {
+	if resp.StatusCode() == 401 {
 		return fmt.Errorf("connectivity check failed: invalid credentials (401 Unauthorized)")
 	}
-	if resp.StatusCode >= 300 {
-		return fmt.Errorf("connectivity check returned unexpected status %d", resp.StatusCode)
+	if resp.StatusCode() >= 300 {
+		return fmt.Errorf("connectivity check returned unexpected status %d", resp.StatusCode())
 	}
 	return nil
 }
 
 // downloadOneAgentInstaller downloads the OneAgent installer binary to a
 // temporary file and returns its path.
-func downloadOneAgentInstaller(apiURL, token string) (string, error) {
+func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 	iType, arch, err := oneAgentInstallerType()
 	if err != nil {
 		return "", err
 	}
 
 	// API: GET /api/v1/deployment/installer/agent/{osType}/default/latest?arch={arch}
-	downloadURL := fmt.Sprintf(
-		"%s/api/v1/deployment/installer/agent/%s/default/latest?arch=%s",
-		apiURL, iType, arch,
+	path := fmt.Sprintf(
+		"/api/v1/deployment/installer/agent/%s/default/latest?arch=%s",
+		iType, arch,
 	)
 
-	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("building download request: %w", err)
-	}
-	req.Header.Set("Authorization", AuthHeader(token))
-
-	fmt.Printf("  Downloading OneAgent installer from %s...\n", apiURL)
-	resp, err := http.DefaultClient.Do(req)
+	fmt.Printf("  Downloading OneAgent installer from %s...\n", c.BaseURL())
+	resp, err := c.HTTP().R().SetDoNotParseResponse(true).Get(path)
 	if err != nil {
 		return "", fmt.Errorf("downloading OneAgent installer: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.RawBody().Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode)
+	if resp.StatusCode() != 200 {
+		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
 	}
 
 	tmpFile, err := os.CreateTemp("", oneAgentInstallerFilename())
@@ -119,7 +107,7 @@ func downloadOneAgentInstaller(apiURL, token string) (string, error) {
 	}
 	defer tmpFile.Close()
 
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+	if _, err := io.Copy(tmpFile, resp.RawBody()); err != nil {
 		os.Remove(tmpFile.Name())
 		return "", fmt.Errorf("writing installer to disk: %w", err)
 	}
@@ -138,18 +126,15 @@ func downloadOneAgentInstaller(apiURL, token string) (string, error) {
 // InstallOneAgent installs Dynatrace OneAgent on the current host.
 //
 // Parameters:
-//   - envURL: Dynatrace environment URL (apps or live)
-//   - token:  API token with installation permissions
-//   - dryRun:    when true, only print what would be done
-//   - quiet:     when true, suppress output and skip confirmation
+//   - c:        Dynatrace Classic API client with auth configured
+//   - dryRun:   when true, only print what would be done
+//   - quiet:    when true, suppress output and skip confirmation
 //   - hostGroup: optional host group name (passed as --set-host-group)
-func InstallOneAgent(envURL, token string, dryRun, quiet bool, hostGroup string) error {
-	apiURL := APIURL(envURL)
-
+func InstallOneAgent(c *client.ClassicClient, dryRun, quiet bool, hostGroup string) error {
 	if dryRun {
 		iType, arch, _ := oneAgentInstallerType()
 		fmt.Println("[dry-run] Would install Dynatrace OneAgent")
-		fmt.Printf("  API URL:          %s\n", apiURL)
+		fmt.Printf("  API URL:          %s\n", c.BaseURL())
 		fmt.Printf("  Installer type:   %s / arch: %s\n", iType, arch)
 		fmt.Printf("  Install mode:     %s\n", InstallModeFullStack)
 		if quiet {
@@ -164,17 +149,17 @@ func InstallOneAgent(envURL, token string, dryRun, quiet bool, hostGroup string)
 	if !quiet {
 		fmt.Println("  Checking API connectivity...")
 	}
-	if err := checkOneAgentConnectivity(apiURL, token); err != nil {
+	if err := checkOneAgentConnectivity(c); err != nil {
 		return err
 	}
 
-	installerPath, err := downloadOneAgentInstaller(apiURL, token)
+	installerPath, err := downloadOneAgentInstaller(c)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(installerPath)
 
-	args := buildOneAgentInstallerArgs(installerPath, apiURL, quiet, hostGroup)
+	args := buildOneAgentInstallerArgs(installerPath, c.BaseURL(), quiet, hostGroup)
 
 	if quiet {
 		if err := RunCommandQuiet(args[0], args[1:]...); err != nil {

--- a/pkg/installer/oneagent.go
+++ b/pkg/installer/oneagent.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -67,10 +68,10 @@ func checkOneAgentConnectivity(c *client.ClassicClient) error {
 		return fmt.Errorf("connectivity check failed — cannot reach %s: %w", c.BaseURL(), err)
 	}
 
-	if resp.StatusCode() == 401 {
+	if resp.StatusCode() == http.StatusUnauthorized {
 		return fmt.Errorf("connectivity check failed: invalid credentials (401 Unauthorized)")
 	}
-	if resp.StatusCode() >= 300 {
+	if resp.StatusCode() >= http.StatusMultipleChoices {
 		return fmt.Errorf("connectivity check returned unexpected status %d", resp.StatusCode())
 	}
 	return nil
@@ -97,7 +98,7 @@ func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 	}
 	defer resp.RawBody().Close()
 
-	if resp.StatusCode() != 200 {
+	if resp.StatusCode() != http.StatusOK {
 		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
 	}
 

--- a/pkg/installer/oneagent_test.go
+++ b/pkg/installer/oneagent_test.go
@@ -1,0 +1,103 @@
+package installer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
+)
+
+// newTestClassicClient creates a ClassicClient pointing at the given test server URL.
+func newTestClassicClient(t *testing.T, serverURL string) *client.ClassicClient {
+	t.Helper()
+	c, err := client.New(serverURL, "dt0c01.test", serverURL, "dt0s16.test", 0)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	return c.Classic
+}
+
+func TestCheckOneAgentConnectivity_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/time" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := checkOneAgentConnectivity(newTestClassicClient(t, srv.URL)); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestCheckOneAgentConnectivity_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	err := checkOneAgentConnectivity(newTestClassicClient(t, srv.URL))
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if want := "invalid credentials"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err.Error(), want)
+	}
+}
+
+func TestCheckOneAgentConnectivity_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := checkOneAgentConnectivity(newTestClassicClient(t, srv.URL))
+	if err == nil {
+		t.Fatal("expected error for 400, got nil")
+	}
+	if want := "400"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain status %q", err.Error(), want)
+	}
+}
+
+func TestDownloadOneAgentInstaller_WritesContentToDisk(t *testing.T) {
+	content := []byte("fake-installer-binary-content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(content) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	path, err := downloadOneAgentInstaller(newTestClassicClient(t, srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(path)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading downloaded file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("file content = %q, want %q", got, content)
+	}
+}
+
+func TestDownloadOneAgentInstaller_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := downloadOneAgentInstaller(newTestClassicClient(t, srv.URL))
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+	if want := "403"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain status %q", err.Error(), want)
+	}
+}

--- a/pkg/installer/oneagent_test.go
+++ b/pkg/installer/oneagent_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -65,6 +66,9 @@ func TestCheckOneAgentConnectivity_UnexpectedStatus(t *testing.T) {
 }
 
 func TestDownloadOneAgentInstaller_WritesContentToDisk(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("OneAgent installer download not supported on macOS")
+	}
 	content := []byte("fake-installer-binary-content")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -88,6 +92,9 @@ func TestDownloadOneAgentInstaller_WritesContentToDisk(t *testing.T) {
 }
 
 func TestDownloadOneAgentInstaller_NonOKStatus(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("OneAgent installer download not supported on macOS")
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))

--- a/pkg/installer/oneagent_test.go
+++ b/pkg/installer/oneagent_test.go
@@ -23,7 +23,7 @@ func newTestClassicClient(t *testing.T, serverURL string) *client.ClassicClient 
 
 func TestCheckOneAgentConnectivity_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/time" {
+		if r.URL.Path != apiV1TimePath {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Replace raw http.DefaultClient usage in pkg/installer/oneagent.go with the configured resty-based *client.ClassicClient from pkg/client. This gives OneAgent HTTP calls automatic retry (3x on 429/5xx), 6-minute timeout, User-Agent headers, and --verbose logging hooks.

To break the resulting circular import (pkg/client → pkg/installer → pkg/client), move the AuthHeader token-type logic into pkg/client as a local authHeader() function.

Closes #39 

## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X ] Other (Refactor):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. Run dtwiz install oneagent

## Which other features are affected?
Only dtwiz install oneagent

## Checklist
- [ X ] Make sure Copilot has reviewed the PR as a preliminary check.
- [ X ] I have tested these changes locally.
- [ X ] I updated OpenSpec and other documentation where necessary.
- [ - ] I added or updated tests where appropriate.
- [ X ] I followed the existing code style and conventions.
