### PR TITLE
chore(e2e-tests): add documentation

### DIFF
--- a/openspec/changes/e2e-testing-infrastructure/.openspec.yaml
+++ b/openspec/changes/e2e-testing-infrastructure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/e2e-testing-infrastructure/design.md
+++ b/openspec/changes/e2e-testing-infrastructure/design.md
@@ -38,10 +38,11 @@ The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cl
 ### 2. `TEST_*` env vars with `.e2e-tests.env` file support
 
 **Choice:** `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` env vars, with two supported loading mechanisms (in precedence order):
+
 1. Shell environment variables / `make VAR=value` overrides (highest precedence — already present in the recipe subshell before any file is loaded)
 2. `.e2e-tests.env` file in the project root
 
-The Makefile recipe uses a shell-based loader — `[ -f .e2e-tests.env ] && export $(grep -v '^#' .e2e-tests.env | xargs) || true` — chained with `&&` to the credential checks that follow. **All steps in the recipe (file load + credential checks + `go test`) MUST be joined by `&&`/`;` in a single shell invocation.** If the file load lives in a separate `if/fi` block and the checks are independent lines, Make runs each block in its own subshell: the `export` from the file block is discarded when that subshell exits, and the checks always see unset variables. The file is plain `KEY=VALUE` shell syntax so developers can also `source .e2e-tests.env` directly.
+The makefile recipe uses a shell-based loader — `[ -f .e2e-tests.env ] && export $(grep -v '^#' .e2e-tests.env | xargs) || true` — chained with `&&` to the credential checks that follow. **All steps in the recipe (file load + credential checks + `go test`) MUST be joined by `&&`/`;` in a single shell invocation.** If the file load lives in a separate `if/fi` block and the checks are independent lines, Make runs each block in its own subshell: the `export` from the file block is discarded when that subshell exits, and the checks always see unset variables. The file is plain `KEY=VALUE` shell syntax so developers can also `source .e2e-tests.env` directly.
 
 Missing credentials produce a clear, actionable error to stderr with copy-paste instructions — no silent skip.
 
@@ -93,7 +94,7 @@ Missing credentials produce a clear, actionable error to stderr with copy-paste 
 
 ### 7. `make test-integration` fails on missing credentials
 
-**Choice:** Makefile target checks `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` before invoking `go test`. If any is missing, print an error to stderr and `exit 1`.
+**Choice:** makefile target checks `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` before invoking `go test`. If any is missing, print an error to stderr and `exit 1`.
 
 **Alternatives considered:**
 

--- a/openspec/changes/e2e-testing-infrastructure/design.md
+++ b/openspec/changes/e2e-testing-infrastructure/design.md
@@ -25,7 +25,7 @@ The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cl
 
 ### 1. Build tag (`//go:build integration`) for test separation
 
-**Choice:** Compile-time exclusion via build tag.
+**Choice:** Compile-time file gating via build tag — used as an exclusion mechanism for default runs (`go test ./...` skips E2E files) and as an inclusion mechanism for explicit integration runs (`go test -tags integration`). Whether the tag acts as exclusion or inclusion depends on the invocation; both perspectives are valid and the tag enables both.
 
 **Alternatives considered:**
 
@@ -37,14 +37,14 @@ The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cl
 
 ### 2. `TEST_*` env vars with `.env` file support
 
-**Choice:** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars, loadable from `.env` via Makefile.
+**Choice:** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars, loadable from `.e2e-tests.env` via Makefile.
 
 **Alternatives considered:**
 
 - *Reusing `DT_ENVIRONMENT`/`DT_ACCESS_TOKEN`* — risk of accidentally running tests against a production tenant configured in the user's shell.
 - *Config file (YAML/JSON)* — over-engineered for two values.
 
-**Rationale:** `TEST_` prefix makes intent explicit and prevents accidental production use. `.env` file avoids repeated exports. Makefile loads it with `include .env` guarded by `ifneq (,$(wildcard .env))`. Missing credentials produce a clear error to stderr and exit non-zero — no silent skip.
+**Rationale:** `TEST_` prefix makes intent explicit and prevents accidental production use. `.e2e-tests.env` file avoids repeated exports. Makefile loads it with `include .e2e-tests.env` guarded by `ifneq (,$(wildcard .e2e-tests.env))`. Missing credentials produce a clear error to stderr and exit non-zero — no silent skip.
 
 ### 3. `NewForTesting()` on `pkg/client/`
 

--- a/openspec/changes/e2e-testing-infrastructure/design.md
+++ b/openspec/changes/e2e-testing-infrastructure/design.md
@@ -54,16 +54,16 @@ Missing credentials produce a clear, actionable error to stderr with copy-paste 
 
 **Rationale:** The shell-based loader keeps `.e2e-tests.env` as plain shell syntax, precedence is correct by default (inherited env wins), and the pattern mirrors dtctl's proven `test-integration` target. All three vars are required: `TEST_DT_ACCESS_TOKEN` (`dt0c01.*`) for Classic API and installer operations; `TEST_DT_PLATFORM_TOKEN` (`dt0s16.*`) for DQL trace queries via `PlatformClient`. A single `TEST_DT_ENVIRONMENT` URL is sufficient — Classic and Platform URLs are both derived from it internally via `APIURL()` and `AppsURL()`.
 
-### 3. `NewForTesting()` on `pkg/client/`
+### 3. Use `New()` directly in E2E tests
 
-**Choice:** Add a `NewForTesting(t *testing.T)` constructor that reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`, calls `t.Fatal` if any is missing, and returns a `*Client` with verbosity off.
+**Choice:** E2E tests call `pkg/client/client.New()` directly, reading `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` in `SetupIntegration` and deriving Classic + Platform URLs via the existing `APIURL()`/`AppsURL()` helpers.
 
 **Alternatives considered:**
 
+- *`NewForTesting(t *testing.T)` constructor in `client.go`* — imports `testing` in production code, which is a Go anti-pattern; adds a constructor that exists solely to wrap URL derivation logic already available via helpers.
 - *Separate test client package* — duplicates resty setup, diverges over time.
-- *Calling `New()` directly in tests* — requires tests to replicate URL family logic (Classic vs Platform).
 
-**Rationale:** Keeps the real client as the single source of truth. `NewForTesting` handles URL family derivation internally (test env URL → Classic URL + Platform URL) and wires `TEST_DT_ACCESS_TOKEN` to `ClassicClient` and `TEST_DT_PLATFORM_TOKEN` to `PlatformClient`. The `testing.T` parameter makes the intent clear and ensures failures are reported through the test framework.
+**Rationale:** Using `New()` directly keeps production code free of test-only dependencies and exercises the same HTTP client path used in production, making E2E tests more representative.
 
 ### 4. `t.TempDir()` for isolation (no CleanupTracker)
 

--- a/openspec/changes/e2e-testing-infrastructure/design.md
+++ b/openspec/changes/e2e-testing-infrastructure/design.md
@@ -35,27 +35,34 @@ The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cl
 
 **Rationale:** Build tags are the standard Go idiom. `go test ./...` never touches E2E files. Zero compile overhead. Matches dtctl's proven pattern.
 
-### 2. `TEST_*` env vars with `.env` file support
+### 2. `TEST_*` env vars with `.e2e-tests.env` file support
 
-**Choice:** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars, loadable from `.e2e-tests.env` via Makefile.
+**Choice:** `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` env vars, with two supported loading mechanisms (in precedence order):
+1. Shell environment variables / `make VAR=value` overrides (highest precedence — already present in the recipe subshell before any file is loaded)
+2. `.e2e-tests.env` file in the project root
+
+The Makefile recipe uses a shell-based loader — `[ -f .e2e-tests.env ] && export $(grep -v '^#' .e2e-tests.env | xargs) || true` — chained with `&&` to the credential checks that follow. **All steps in the recipe (file load + credential checks + `go test`) MUST be joined by `&&`/`;` in a single shell invocation.** If the file load lives in a separate `if/fi` block and the checks are independent lines, Make runs each block in its own subshell: the `export` from the file block is discarded when that subshell exits, and the checks always see unset variables. The file is plain `KEY=VALUE` shell syntax so developers can also `source .e2e-tests.env` directly.
+
+Missing credentials produce a clear, actionable error to stderr with copy-paste instructions — no silent skip.
 
 **Alternatives considered:**
 
-- *Reusing `DT_ENVIRONMENT`/`DT_ACCESS_TOKEN`* — risk of accidentally running tests against a production tenant configured in the user's shell.
-- *Config file (YAML/JSON)* — over-engineered for two values.
+- *`include .e2e-tests.env` (Make syntax)* — Make's `include` with `=` assignment overrides shell env vars unless `make -e` is used; `?=` preserves precedence but forces Make syntax into the file, breaking `source .e2e-tests.env` usage.
+- *Reusing `DT_ENVIRONMENT`/`DT_ACCESS_TOKEN`/`DT_PLATFORM_TOKEN`* — risk of accidentally running tests against a production tenant configured in the user's shell.
+- *Config file (YAML/JSON)* — overengineered for three values.
 
-**Rationale:** `TEST_` prefix makes intent explicit and prevents accidental production use. `.e2e-tests.env` file avoids repeated exports. Makefile loads it with `include .e2e-tests.env` guarded by `ifneq (,$(wildcard .e2e-tests.env))`. Missing credentials produce a clear error to stderr and exit non-zero — no silent skip.
+**Rationale:** The shell-based loader keeps `.e2e-tests.env` as plain shell syntax, precedence is correct by default (inherited env wins), and the pattern mirrors dtctl's proven `test-integration` target. All three vars are required: `TEST_DT_ACCESS_TOKEN` (`dt0c01.*`) for Classic API and installer operations; `TEST_DT_PLATFORM_TOKEN` (`dt0s16.*`) for DQL trace queries via `PlatformClient`. A single `TEST_DT_ENVIRONMENT` URL is sufficient — Classic and Platform URLs are both derived from it internally via `APIURL()` and `AppsURL()`.
 
 ### 3. `NewForTesting()` on `pkg/client/`
 
-**Choice:** Add a `NewForTesting(t *testing.T)` constructor that reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`, calls `t.Fatal` if missing, and returns a `*Client` with verbosity off.
+**Choice:** Add a `NewForTesting(t *testing.T)` constructor that reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`, calls `t.Fatal` if any is missing, and returns a `*Client` with verbosity off.
 
 **Alternatives considered:**
 
 - *Separate test client package* — duplicates resty setup, diverges over time.
 - *Calling `New()` directly in tests* — requires tests to replicate URL family logic (Classic vs Platform).
 
-**Rationale:** Keeps the real client as the single source of truth. `NewForTesting` handles URL family derivation internally (test env URL → Classic URL + Platform URL). The `testing.T` parameter makes the intent clear and ensures failures are reported through the test framework.
+**Rationale:** Keeps the real client as the single source of truth. `NewForTesting` handles URL family derivation internally (test env URL → Classic URL + Platform URL) and wires `TEST_DT_ACCESS_TOKEN` to `ClassicClient` and `TEST_DT_PLATFORM_TOKEN` to `PlatformClient`. The `testing.T` parameter makes the intent clear and ensures failures are reported through the test framework.
 
 ### 4. `t.TempDir()` for isolation (no CleanupTracker)
 
@@ -86,7 +93,7 @@ The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cl
 
 ### 7. `make test-integration` fails on missing credentials
 
-**Choice:** Makefile target checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` before invoking `go test`. If either is missing, print an error to stderr and `exit 1`.
+**Choice:** Makefile target checks `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` before invoking `go test`. If any is missing, print an error to stderr and `exit 1`.
 
 **Alternatives considered:**
 

--- a/openspec/changes/e2e-testing-infrastructure/design.md
+++ b/openspec/changes/e2e-testing-infrastructure/design.md
@@ -1,0 +1,109 @@
+# Context
+
+dtwiz currently has unit tests only (`make test` runs `go test ./pkg/...`). All installer tests mock `RunCommand`, meaning the actual shell execution, package installation, and DT API communication are never exercised. The `pkg/client/` package provides a dual HTTP client (`ClassicClient` + `PlatformClient`) built on resty, with a single `New()` constructor that takes pre-resolved URLs and tokens. There is no test-specific client constructor.
+
+The sibling project dtctl uses a similar E2E pattern (build tags, env gating, cleanup tracker, fixtures) but keeps E2E tests local-only — not in CI. We follow the same approach.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reusable E2E test infrastructure that future runtime tests (Node, Java, Go) can plug into with minimal effort
+- One proven E2E test (Python OTel auto-instrumentation) that exercises the full install → run → verify-traces → cleanup cycle
+- Clear separation: `make test` stays fast, `make test-integration` is opt-in and requires credentials
+- DQL-based trace verification against a real Dynatrace tenant
+
+**Non-Goals:**
+
+- Node.js, Java, or Go runtime E2E tests (follow-up changes)
+- OTel Collector, Kubernetes, or cloud provider E2E tests
+- CI/CD pipeline integration
+- Performance or load testing
+- Changes to existing unit tests or test infrastructure
+
+## Decisions
+
+### 1. Build tag (`//go:build integration`) for test separation
+
+**Choice:** Compile-time exclusion via build tag.
+
+**Alternatives considered:**
+
+- *Env var gating with `t.Skip()`* — simpler, but tests still compile into the binary, appear as SKIP in output, and add parse-time overhead.
+- *`-run` flag convention* — fragile, not enforced, easy to forget.
+- *Separate Go module in `test/`* — heavyweight, adds module maintenance burden.
+
+**Rationale:** Build tags are the standard Go idiom. `go test ./...` never touches E2E files. Zero compile overhead. Matches dtctl's proven pattern.
+
+### 2. `TEST_*` env vars with `.env` file support
+
+**Choice:** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars, loadable from `.env` via Makefile.
+
+**Alternatives considered:**
+
+- *Reusing `DT_ENVIRONMENT`/`DT_ACCESS_TOKEN`* — risk of accidentally running tests against a production tenant configured in the user's shell.
+- *Config file (YAML/JSON)* — over-engineered for two values.
+
+**Rationale:** `TEST_` prefix makes intent explicit and prevents accidental production use. `.env` file avoids repeated exports. Makefile loads it with `include .env` guarded by `ifneq (,$(wildcard .env))`. Missing credentials produce a clear error to stderr and exit non-zero — no silent skip.
+
+### 3. `NewForTesting()` on `pkg/client/`
+
+**Choice:** Add a `NewForTesting(t *testing.T)` constructor that reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`, calls `t.Fatal` if missing, and returns a `*Client` with verbosity off.
+
+**Alternatives considered:**
+
+- *Separate test client package* — duplicates resty setup, diverges over time.
+- *Calling `New()` directly in tests* — requires tests to replicate URL family logic (Classic vs Platform).
+
+**Rationale:** Keeps the real client as the single source of truth. `NewForTesting` handles URL family derivation internally (test env URL → Classic URL + Platform URL). The `testing.T` parameter makes the intent clear and ensures failures are reported through the test framework.
+
+### 4. `t.TempDir()` for isolation (no CleanupTracker)
+
+**Choice:** Each test creates a temp directory for its fixture app. Go's `t.TempDir()` auto-cleans on test completion, even on failure.
+
+**Alternatives considered:**
+
+- *dtctl-style CleanupTracker with LIFO deletion* — needed for API resources with dependencies (workflows, dashboards). dtwiz E2E tests create local filesystem artifacts and short-lived processes, not persistent API resources.
+
+**Rationale:** Auto-instrumentation tests modify a temp project directory, not the host system. The instrumented process is killed when the test ends. No persistent resources to track.
+
+### 5. DQL polling for trace verification
+
+**Choice:** Query the DT Grail/DQL API (`/platform/storage/query/v1/query:execute`) for traces matching the unique test service name. Poll with configurable interval and timeout.
+
+**Alternatives considered:**
+
+- *Local-only verification (check installed packages, env vars)* — misses the most important assertion: did traces actually reach Dynatrace?
+- *Classic API v2 metrics/traces endpoints* — DQL is the current standard for Grail-based environments.
+
+**Rationale:** The whole point of E2E is verifying the data pipeline end-to-end. The PlatformClient already has Bearer auth and the `.apps.` URL needed for DQL. Polling handles ingestion latency naturally.
+
+### 6. Unique service naming: `dtwiz-test-{unix-ts}-{random}`
+
+**Choice:** Each test run generates a unique service name used as `OTEL_SERVICE_NAME`. DQL queries filter by this name.
+
+**Rationale:** Prevents conflicts between parallel test runs or leftover data from previous runs. The timestamp component aids debugging (map test run to traces).
+
+### 7. `make test-integration` fails on missing credentials
+
+**Choice:** Makefile target checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` before invoking `go test`. If either is missing, print an error to stderr and `exit 1`.
+
+**Alternatives considered:**
+
+- *`t.Skip()` in Go* — exit 0 masks misconfiguration; developer thinks tests passed when they didn't run.
+
+**Rationale:** `make test-integration` is an explicit opt-in. If the developer runs it, they expect it to work. Silent skipping defeats the purpose.
+
+### 8. Fixtures in `test/fixtures/` (sibling to `test/e2e/`)
+
+**Choice:** Static fixture apps live in `test/fixtures/<runtime>/` (e.g., `test/fixtures/python-flask/`). Test helpers copy them into `t.TempDir()` at runtime.
+
+**Rationale:** Keeps fixture code separate from test logic. Future runtimes add a new directory under `test/fixtures/` without touching existing tests. Copying into temp dir ensures isolation.
+
+## Risks / Trade-offs
+
+- **[Tenant dependency]** → E2E tests require a live Dynatrace tenant with `openTelemetryTrace.ingest` and DQL query scopes on the token. Mitigation: clear error message with required scopes when auth fails.
+- **[Python availability]** → Python E2E test requires Python 3 + pip on the test machine. Mitigation: test checks for `python3` and skips with a descriptive message if missing.
+- **[Ingestion latency]** → Traces may take 5-30 seconds to appear in DQL results. Mitigation: configurable poll timeout (default 60s), 2s poll interval.
+- **[Flakiness from DT API]** → DQL endpoint could be temporarily unavailable. Mitigation: resty retry (already in client) + generous timeout. Accept that E2E tests are inherently less stable than unit tests.
+- **[No CI]** → E2E tests only run locally. Risk of regressions between releases. Mitigation: document in CONTRIBUTING.md that `make test-integration` should be run before releasing installer changes. CI integration is a follow-up.

--- a/openspec/changes/e2e-testing-infrastructure/proposal.md
+++ b/openspec/changes/e2e-testing-infrastructure/proposal.md
@@ -1,0 +1,31 @@
+# Why
+
+dtwiz unit tests mock all shell execution (`RunCommand`) and external dependencies, which means the most failure-prone code paths — real package installations, actual trace ingestion, DT API auth — are never exercised. The Python OTel auto-instrumentation installer alone has ~150 lines of `Execute()` logic (venv detection, pip install, opentelemetry-bootstrap) that is entirely mocked in tests. We need an E2E test foundation that verifies the full install → instrument → trace-ingestion → cleanup cycle against a real Dynatrace tenant.
+
+## What Changes
+
+- Add `test/e2e/` directory with `//go:build integration` build tag for compile-time separation from unit tests
+- Add `test/integration/` with shared setup (env gating, unique naming) and DQL trace polling helper
+- Add `test/fixtures/` with reusable test app scaffolds (starting with a minimal Flask app)
+- Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars
+- Add `make test-integration` Makefile target that loads `.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
+- Add `.env` to `.gitignore`
+- Implement one real E2E test: Python OTel auto-instrumentation lifecycle (install → run instrumented app → verify traces in DT via DQL → cleanup via `t.TempDir()`)
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-test-infra`: Shared E2E test infrastructure — env var gating, unique test naming, `t.TempDir()` isolation, `.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
+
+### Modified Capabilities
+
+_None — all changes are additive._
+
+## Impact
+
+- **`pkg/client/`**: New `NewForTesting()` constructor added. Existing API unchanged.
+- **`Makefile`**: New `test-integration` target. Existing `test` target unchanged.
+- **`.gitignore`**: `.env` added.
+- **Test runtime**: `make test` stays fast (~2 sec). `make test-integration` requires a live DT tenant and takes 30-60 sec.
+- **Dependencies**: No new Go dependencies. Test fixtures require Python 3 + pip available on the test machine.

--- a/openspec/changes/e2e-testing-infrastructure/proposal.md
+++ b/openspec/changes/e2e-testing-infrastructure/proposal.md
@@ -8,15 +8,16 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 - Add `test/integration/` with shared setup (env gating, unique naming) and DQL trace polling helper
 - Add `test/fixtures/` with reusable test app scaffolds (starting with a minimal Flask app)
 - Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars
-- Add `make test-integration` Makefile target that loads `.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
-- Add `.env` to `.gitignore`
+- Add `make test-integration` Makefile target that loads `.e2e-tests.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
+- Add `.e2e-tests.env` to `.gitignore`
+- Add `.e2e-tests.env.example` to VCS with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` placeholder values
 - Implement one real E2E test: Python OTel auto-instrumentation lifecycle (install → run instrumented app → verify traces in DT via DQL → cleanup via `t.TempDir()`)
 
 ## Capabilities
 
 ### New Capabilities
 
-- `e2e-test-infra`: Shared E2E test infrastructure — env var gating, unique test naming, `t.TempDir()` isolation, `.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
+- `e2e-test-infra`: Shared E2E test infrastructure — env var gating, unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
 
 ### Modified Capabilities
 
@@ -26,6 +27,6 @@ _None — all changes are additive._
 
 - **`pkg/client/`**: New `NewForTesting()` constructor added. Existing API unchanged.
 - **`Makefile`**: New `test-integration` target. Existing `test` target unchanged.
-- **`.gitignore`**: `.env` added.
+- **`.gitignore`**: `.e2e-tests.env` added. `.e2e-tests.env.example` added (committed to VCS).
 - **Test runtime**: `make test` stays fast (~2 sec). `make test-integration` requires a live DT tenant and takes 30-60 sec.
 - **Dependencies**: No new Go dependencies. Test fixtures require Python 3 + pip available on the test machine.

--- a/openspec/changes/e2e-testing-infrastructure/proposal.md
+++ b/openspec/changes/e2e-testing-infrastructure/proposal.md
@@ -7,7 +7,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 - Add `test/e2e/` directory with `//go:build integration` build tag for compile-time separation from unit tests
 - Add `test/integration/` with shared setup (env gating, unique naming) and DQL trace polling helper
 - Add `test/fixtures/` with reusable test app scaffolds (starting with a minimal Flask app)
-- Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` env vars
+- Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` env vars
 - Add `make test-integration` Makefile target that loads `.e2e-tests.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
 - Add `.e2e-tests.env` to `.gitignore`
 - Add `.e2e-tests.env.example` to VCS with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` placeholder values
@@ -17,7 +17,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 
 ### New Capabilities
 
-- `e2e-test-infra`: Shared E2E test infrastructure — env var gating, unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
+- `e2e-test-infra`: Shared E2E test infrastructure — env var gating (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, `TEST_DT_PLATFORM_TOKEN`), unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
 
 ### Modified Capabilities
 

--- a/openspec/changes/e2e-testing-infrastructure/proposal.md
+++ b/openspec/changes/e2e-testing-infrastructure/proposal.md
@@ -8,7 +8,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 - Add `test/integration/` with shared setup (env gating, unique naming) and DQL trace polling helper
 - Add `test/fixtures/` with reusable test app scaffolds (starting with a minimal Flask app)
 - Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` env vars
-- Add `make test-integration` Makefile target that loads `.e2e-tests.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
+- Add `make test-integration` makefile target that loads `.e2e-tests.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
 - Add `.e2e-tests.env` to `.gitignore`
 - Add `.e2e-tests.env.example` to VCS with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` placeholder values
 - Implement one real E2E test: Python OTel auto-instrumentation lifecycle (install → run instrumented app → verify traces in DT via DQL → cleanup via `t.TempDir()`)
@@ -17,7 +17,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 
 ### New Capabilities
 
-- `e2e-test-infra`: Shared E2E test infrastructure — env var gating (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, `TEST_DT_PLATFORM_TOKEN`), unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via Makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
+- `e2e-test-infra`: Shared E2E test infrastructure — env var gating (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, `TEST_DT_PLATFORM_TOKEN`), unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
 
 ### Modified Capabilities
 
@@ -26,7 +26,7 @@ _None — all changes are additive._
 ## Impact
 
 - **`pkg/client/`**: New `NewForTesting()` constructor added. Existing API unchanged.
-- **`Makefile`**: New `test-integration` target. Existing `test` target unchanged.
+- **`makefile`**: New `test-integration` target. Existing `test` target unchanged.
 - **`.gitignore`**: `.e2e-tests.env` added. `.e2e-tests.env.example` added (committed to VCS).
 - **Test runtime**: `make test` stays fast (~2 sec). `make test-integration` requires a live DT tenant and takes 30-60 sec.
 - **Dependencies**: No new Go dependencies. Test fixtures require Python 3 + pip available on the test machine.

--- a/openspec/changes/e2e-testing-infrastructure/proposal.md
+++ b/openspec/changes/e2e-testing-infrastructure/proposal.md
@@ -7,7 +7,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 - Add `test/e2e/` directory with `//go:build integration` build tag for compile-time separation from unit tests
 - Add `test/integration/` with shared setup (env gating, unique naming) and DQL trace polling helper
 - Add `test/fixtures/` with reusable test app scaffolds (starting with a minimal Flask app)
-- Add `NewForTesting()` constructor to `pkg/client/` that reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` env vars
+- E2E tests call `client.New()` directly with URLs derived from `TEST_DT_ENVIRONMENT` via `APIURL()`/`AppsURL()` helpers and tokens from `TEST_DT_ACCESS_TOKEN`/`TEST_DT_PLATFORM_TOKEN` — no test-specific constructor needed
 - Add `make test-integration` makefile target that loads `.e2e-tests.env` if present and runs integration tests; fails with a descriptive error to stderr if credentials are missing
 - Add `.e2e-tests.env` to `.gitignore`
 - Add `.e2e-tests.env.example` to VCS with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` placeholder values
@@ -17,7 +17,7 @@ dtwiz unit tests mock all shell execution (`RunCommand`) and external dependenci
 
 ### New Capabilities
 
-- `e2e-test-infra`: Shared E2E test infrastructure — env var gating (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, `TEST_DT_PLATFORM_TOKEN`), unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via makefile, `make test-integration` target, `NewForTesting()` client constructor, and DQL-based trace polling helper
+- `e2e-test-infra`: Shared E2E test infrastructure — env var gating (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, `TEST_DT_PLATFORM_TOKEN`), unique test naming, `t.TempDir()` isolation, `.e2e-tests.env` loading via makefile, `make test-integration` target, direct `client.New()` construction with URL derivation via `APIURL()`/`AppsURL()`, and DQL-based trace polling helper
 
 ### Modified Capabilities
 
@@ -25,7 +25,7 @@ _None — all changes are additive._
 
 ## Impact
 
-- **`pkg/client/`**: New `NewForTesting()` constructor added. Existing API unchanged.
+- **`pkg/client/`**: No changes — E2E tests use existing `New()` constructor directly. Existing API unchanged.
 - **`makefile`**: New `test-integration` target. Existing `test` target unchanged.
 - **`.gitignore`**: `.e2e-tests.env` added. `.e2e-tests.env.example` added (committed to VCS).
 - **Test runtime**: `make test` stays fast (~2 sec). `make test-integration` requires a live DT tenant and takes 30-60 sec.

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -116,17 +116,17 @@ E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artif
 
 ### Requirement: URL family derivation
 
-`NewForTesting` SHALL derive both the Classic URL and Platform URL from the single `TEST_DT_ENVIRONMENT` value, using the existing URL family logic (strip `.apps.` for Classic, insert `.apps.` for Platform).
+`NewForTesting` SHALL derive both the Classic URL and Platform URL from the single `TEST_DT_ENVIRONMENT` value, using the existing URL family logic: `.apps.dynatrace.com` maps to `.live.dynatrace.com` for Classic, `.live.dynatrace.com` maps to `.apps.dynatrace.com` for Platform, `.apps.dynatracelabs.com` maps to `.dynatracelabs.com` for Classic, and `.dynatracelabs.com` maps to `.apps.dynatracelabs.com` for Platform.
 
 #### Scenario: Classic URL input
 
-- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.live.com`
-- **THEN** Classic URL is `https://abc123.live.com` and Platform URL is `https://abc123.apps.com`
+- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.live.dynatrace.com`
+- **THEN** Classic URL is `https://abc123.live.dynatrace.com` and Platform URL is `https://abc123.apps.dynatrace.com`
 
 #### Scenario: Platform URL input
 
-- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.apps.com`
-- **THEN** Classic URL is `https://abc123.live.com` and Platform URL is `https://abc123.apps.com`
+- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.apps.dynatrace.com`
+- **THEN** Classic URL is `https://abc123.live.dynatrace.com` and Platform URL is `https://abc123.apps.dynatrace.com`
 
 ### Requirement: No changes to existing client API
 

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -1,0 +1,152 @@
+# E2E Test Infrastructure
+
+## ADDED Requirements
+
+### Requirement: Build tag separation
+
+All E2E test files in `test/e2e/` SHALL use the `//go:build integration` build tag. Running `go test ./...` without `-tags integration` SHALL NOT compile or execute any E2E test.
+
+#### Scenario: Default test run excludes E2E
+
+- **WHEN** a developer runs `go test ./...` or `make test`
+- **THEN** no files under `test/e2e/` are compiled or executed
+
+#### Scenario: Integration tag includes E2E
+
+- **WHEN** a developer runs `go test -tags integration ./test/e2e/...`
+- **THEN** all E2E test files are compiled and executed
+
+### Requirement: Environment variable gating
+
+The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` to be set. If either is missing, the target SHALL print a descriptive error message to stderr and exit with a non-zero status code.
+
+#### Scenario: Missing TEST_DT_ENVIRONMENT
+
+- **WHEN** `make test-integration` is run without `TEST_DT_ENVIRONMENT` set
+- **THEN** an error message naming the missing variable is printed to stderr and the process exits non-zero
+
+#### Scenario: Missing TEST_DT_ACCESS_TOKEN
+
+- **WHEN** `make test-integration` is run without `TEST_DT_ACCESS_TOKEN` set
+- **THEN** an error message naming the missing variable is printed to stderr and the process exits non-zero
+
+#### Scenario: Both variables set
+
+- **WHEN** `make test-integration` is run with both `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` set
+- **THEN** `go test -tags integration ./test/e2e/...` is executed
+
+### Requirement: .env file loading
+
+The `make test-integration` target SHALL load variables from a `.env` file in the project root if it exists. Shell environment variables SHALL take precedence over `.env` values. The `.env` file SHALL be listed in `.gitignore`.
+
+#### Scenario: .env file present
+
+- **WHEN** a `.env` file exists with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`
+- **THEN** the Makefile loads those values and runs the integration tests
+
+#### Scenario: Shell overrides .env
+
+- **WHEN** `TEST_DT_ENVIRONMENT` is set in the shell and a different value exists in `.env`
+- **THEN** the shell value is used
+
+#### Scenario: No .env file
+
+- **WHEN** no `.env` file exists and env vars are set in the shell
+- **THEN** the Makefile proceeds using shell env vars without error
+
+### Requirement: Unique test naming
+
+Each E2E test run SHALL generate a unique identifier in the format `dtwiz-test-{unix-timestamp}-{random-string}`. This identifier SHALL be used as the `OTEL_SERVICE_NAME` for instrumented test apps to prevent data collisions.
+
+#### Scenario: Parallel test runs
+
+- **WHEN** two E2E test runs execute simultaneously
+- **THEN** each generates a distinct service name and queries only its own traces
+
+### Requirement: Temporary directory isolation
+
+E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artifacts SHALL persist after the test completes (pass or fail).
+
+#### Scenario: Test failure cleanup
+
+- **WHEN** an E2E test fails mid-execution
+- **THEN** the temp directory and its contents are automatically removed by `t.TempDir()`
+
+### Requirement: NewForTesting constructor
+
+`pkg/client/` SHALL expose a `NewForTesting(t *testing.T) *Client` function that creates a fully configured `Client` by reading `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` environment variables.
+
+#### Scenario: Valid credentials
+
+- **WHEN** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set
+- **THEN** `NewForTesting` returns a `*Client` with both `ClassicClient` and `PlatformClient` configured
+
+#### Scenario: Missing environment variable
+
+- **WHEN** `TEST_DT_ENVIRONMENT` is not set
+- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+
+#### Scenario: Missing token variable
+
+- **WHEN** `TEST_DT_ACCESS_TOKEN` is not set
+- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+
+### Requirement: URL family derivation
+
+`NewForTesting` SHALL derive both the Classic URL and Platform URL from the single `TEST_DT_ENVIRONMENT` value, using the existing URL family logic (strip `.apps.` for Classic, insert `.apps.` for Platform).
+
+#### Scenario: Classic URL input
+
+- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.live.com`
+- **THEN** Classic URL is `https://abc123.live.com` and Platform URL is `https://abc123.apps.com`
+
+#### Scenario: Platform URL input
+
+- **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.apps.com`
+- **THEN** Classic URL is `https://abc123.live.com` and Platform URL is `https://abc123.apps.com`
+
+### Requirement: No changes to existing client API
+
+`NewForTesting` SHALL be an additive function. The existing `New()` constructor and all existing types SHALL remain unchanged.
+
+#### Scenario: Existing code unaffected
+
+- **WHEN** `NewForTesting` is added to `pkg/client/`
+- **THEN** all existing unit tests for `pkg/client/` continue to pass without modification
+
+### Requirement: DQL trace query
+
+The test infrastructure SHALL provide a helper function that queries the Dynatrace DQL API for traces matching a given service name. The function SHALL use the `PlatformClient` from `pkg/client/`.
+
+#### Scenario: Traces found
+
+- **WHEN** the helper queries DQL with a service name that has ingested traces
+- **THEN** it returns the matching trace records
+
+#### Scenario: No traces found
+
+- **WHEN** the helper queries DQL with a service name that has no traces
+- **THEN** it returns an empty result set without error
+
+### Requirement: Polling with timeout
+
+The trace verification helper SHALL poll the DQL API at a configurable interval until traces are found or a timeout is reached. The default timeout SHALL be 60 seconds with a 2-second poll interval.
+
+#### Scenario: Traces arrive within timeout
+
+- **WHEN** traces are ingested after a delay but before the timeout
+- **THEN** the helper returns successfully once traces are found
+
+#### Scenario: Timeout exceeded
+
+- **WHEN** no traces appear within the configured timeout
+- **THEN** the helper returns an error indicating the timeout was exceeded and the service name that was queried
+
+### Requirement: DQL query scope
+
+The DQL query SHALL filter traces by `service.name` attribute matching the unique test identifier. The query SHALL target the `dt.entity.spans` or equivalent Grail table.
+
+#### Scenario: Query specificity
+
+- **WHEN** multiple services are sending traces to the same tenant
+- **THEN** the query returns only traces matching the exact test service name

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -43,6 +43,7 @@ The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT`, `TEST_DT
 ### Requirement: .e2e-tests.env file loading
 
 The `make test-integration` target SHALL support two credential loading mechanisms, in precedence order:
+
 1. Shell environment variables / `make VAR=value` overrides (highest — already inherited by the recipe subshell)
 2. `.e2e-tests.env` file in the project root, loaded via `[ -f .e2e-tests.env ] && export $(grep -v '^#' .e2e-tests.env | xargs) || true`
 
@@ -55,7 +56,7 @@ If any required variable is missing after loading, the target SHALL print a desc
 #### Scenario: .e2e-tests.env file present, no shell vars
 
 - **WHEN** a `.e2e-tests.env` file exists with all three vars and none are set in the shell
-- **THEN** the Makefile loads those values and runs the integration tests
+- **THEN** the makefile loads those values and runs the integration tests
 
 #### Scenario: Shell vars take precedence over file
 
@@ -65,7 +66,7 @@ If any required variable is missing after loading, the target SHALL print a desc
 #### Scenario: No .e2e-tests.env file, vars set in shell
 
 - **WHEN** no `.e2e-tests.env` file exists and all three vars are set in the shell
-- **THEN** the Makefile proceeds using shell env vars without error
+- **THEN** the makefile proceeds using shell env vars without error
 
 #### Scenario: Missing variable after loading
 

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -91,33 +91,33 @@ E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artif
 - **WHEN** an E2E test fails mid-execution
 - **THEN** the temp directory and its contents are automatically removed by `t.TempDir()`
 
-### Requirement: NewForTesting constructor
+### Requirement: Client construction via `New()`
 
-`pkg/client/` SHALL expose a `NewForTesting(t *testing.T) *Client` function that creates a fully configured `Client` by reading `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` environment variables. `TEST_DT_ACCESS_TOKEN` is wired to `ClassicClient` (Classic API and installer operations); `TEST_DT_PLATFORM_TOKEN` is wired to `PlatformClient` (DQL queries and Platform APIs). Both URLs are derived from the single `TEST_DT_ENVIRONMENT` value.
+`SetupIntegration` SHALL construct the client by calling `client.New()` directly with URLs derived from `TEST_DT_ENVIRONMENT` via the existing `APIURL()`/`AppsURL()` helpers, exercising the same HTTP client used in production. `TEST_DT_ACCESS_TOKEN` is wired to `ClassicClient` (Classic API and installer operations); `TEST_DT_PLATFORM_TOKEN` is wired to `PlatformClient` (DQL queries and Platform APIs).
 
 #### Scenario: Valid credentials
 
 - **WHEN** `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set
-- **THEN** `NewForTesting` returns a `*Client` with both `ClassicClient` and `PlatformClient` configured
+- **THEN** `SetupIntegration` returns a `TestEnv` with a `*Client` having both `ClassicClient` and `PlatformClient` configured
 
 #### Scenario: Missing environment variable
 
 - **WHEN** `TEST_DT_ENVIRONMENT` is not set
-- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+- **THEN** `SetupIntegration` calls `t.Fatal` with a message naming the missing variable
 
 #### Scenario: Missing access token variable
 
 - **WHEN** `TEST_DT_ACCESS_TOKEN` is not set
-- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+- **THEN** `SetupIntegration` calls `t.Fatal` with a message naming the missing variable
 
 #### Scenario: Missing platform token variable
 
 - **WHEN** `TEST_DT_PLATFORM_TOKEN` is not set
-- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+- **THEN** `SetupIntegration` calls `t.Fatal` with a message naming the missing variable
 
 ### Requirement: URL family derivation
 
-`NewForTesting` SHALL derive both the Classic URL and Platform URL from the single `TEST_DT_ENVIRONMENT` value, using the existing URL family logic: `.apps.dynatrace.com` maps to `.live.dynatrace.com` for Classic, `.live.dynatrace.com` maps to `.apps.dynatrace.com` for Platform, `.apps.dynatracelabs.com` maps to `.dynatracelabs.com` for Classic, and `.dynatracelabs.com` maps to `.apps.dynatracelabs.com` for Platform.
+`SetupIntegration` SHALL derive both the Classic URL and Platform URL from the single `TEST_DT_ENVIRONMENT` value, using the existing URL family helpers (`APIURL()`/`AppsURL()`).
 
 #### Scenario: Classic URL input
 
@@ -128,15 +128,6 @@ E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artif
 
 - **WHEN** `TEST_DT_ENVIRONMENT` is `https://abc123.apps.dynatrace.com`
 - **THEN** Classic URL is `https://abc123.live.dynatrace.com` and Platform URL is `https://abc123.apps.dynatrace.com`
-
-### Requirement: No changes to existing client API
-
-`NewForTesting` SHALL be an additive function. The existing `New()` constructor and all existing types SHALL remain unchanged.
-
-#### Scenario: Existing code unaffected
-
-- **WHEN** `NewForTesting` is added to `pkg/client/`
-- **THEN** all existing unit tests for `pkg/client/` continue to pass without modification
 
 ### Requirement: DQL trace query
 

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -18,7 +18,7 @@ All E2E test files in `test/e2e/` SHALL use the `//go:build integration` build t
 
 ### Requirement: Environment variable gating
 
-The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` to be set. If either is missing, the target SHALL print a descriptive error message to stderr and exit with a non-zero status code.
+The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` to be set. If any is missing, the target SHALL print a descriptive error message to stderr and exit with a non-zero status code.
 
 #### Scenario: Missing TEST_DT_ENVIRONMENT
 
@@ -30,29 +30,47 @@ The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT` and `TEST
 - **WHEN** `make test-integration` is run without `TEST_DT_ACCESS_TOKEN` set
 - **THEN** an error message naming the missing variable is printed to stderr and the process exits non-zero
 
-#### Scenario: Both variables set
+#### Scenario: Missing TEST_DT_PLATFORM_TOKEN
 
-- **WHEN** `make test-integration` is run with both `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` set
+- **WHEN** `make test-integration` is run without `TEST_DT_PLATFORM_TOKEN` set
+- **THEN** an error message naming the missing variable is printed to stderr and the process exits non-zero
+
+#### Scenario: All variables set
+
+- **WHEN** `make test-integration` is run with `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` set
 - **THEN** `go test -tags integration ./test/e2e/...` is executed
 
-### Requirement: .env file loading
+### Requirement: .e2e-tests.env file loading
 
-The `make test-integration` target SHALL load variables from a `.e2e-tests.env` file in the project root if it exists. Shell environment variables SHALL take precedence over `.e2e-tests.env` values. The `.e2e-tests.env` file SHALL be listed in `.gitignore`. A `.e2e-tests.env.example` file with placeholder values for `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` SHALL be committed to VCS as a reference.
+The `make test-integration` target SHALL support two credential loading mechanisms, in precedence order:
+1. Shell environment variables / `make VAR=value` overrides (highest — already inherited by the recipe subshell)
+2. `.e2e-tests.env` file in the project root, loaded via `[ -f .e2e-tests.env ] && export $(grep -v '^#' .e2e-tests.env | xargs) || true`
 
-#### Scenario: .e2e-tests.env file present
+**Implementation constraint:** The file-load step and all subsequent credential checks MUST be chained in a single shell invocation using `&&` or `;`. Each Make recipe line runs in a separate subshell; if the file-load `if` block is a standalone recipe step, the `export` is discarded when that subshell exits and the variables are invisible to subsequent lines.
 
-- **WHEN** a `.e2e-tests.env` file exists with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`
+The `.e2e-tests.env` file SHALL use plain `KEY=VALUE` shell syntax. It SHALL be listed in `.gitignore`. A `.e2e-tests.env.example` file with placeholder values for all three vars SHALL be committed to VCS, with instructions to `cp .e2e-tests.env.example .e2e-tests.env` and fill in credentials.
+
+If any required variable is missing after loading, the target SHALL print a descriptive error to stderr — including copy-paste setup instructions — and exit non-zero.
+
+#### Scenario: .e2e-tests.env file present, no shell vars
+
+- **WHEN** a `.e2e-tests.env` file exists with all three vars and none are set in the shell
 - **THEN** the Makefile loads those values and runs the integration tests
 
-#### Scenario: Shell overrides .e2e-tests.env
+#### Scenario: Shell vars take precedence over file
 
 - **WHEN** `TEST_DT_ENVIRONMENT` is set in the shell and a different value exists in `.e2e-tests.env`
-- **THEN** the shell value is used
+- **THEN** the shell value is used, because shell env vars are already present in the recipe subshell and `export` only sets a variable if it is not already set (or the file value is simply ignored for pre-set vars)
 
-#### Scenario: No .e2e-tests.env file
+#### Scenario: No .e2e-tests.env file, vars set in shell
 
-- **WHEN** no `.e2e-tests.env` file exists and env vars are set in the shell
+- **WHEN** no `.e2e-tests.env` file exists and all three vars are set in the shell
 - **THEN** the Makefile proceeds using shell env vars without error
+
+#### Scenario: Missing variable after loading
+
+- **WHEN** a required variable is not set in the shell or in `.e2e-tests.env`
+- **THEN** the target prints an error to stderr with copy-paste setup instructions and exits non-zero
 
 ### Requirement: Unique test naming
 
@@ -74,11 +92,11 @@ E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artif
 
 ### Requirement: NewForTesting constructor
 
-`pkg/client/` SHALL expose a `NewForTesting(t *testing.T) *Client` function that creates a fully configured `Client` by reading `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` environment variables.
+`pkg/client/` SHALL expose a `NewForTesting(t *testing.T) *Client` function that creates a fully configured `Client` by reading `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` environment variables. `TEST_DT_ACCESS_TOKEN` is wired to `ClassicClient` (Classic API and installer operations); `TEST_DT_PLATFORM_TOKEN` is wired to `PlatformClient` (DQL queries and Platform APIs). Both URLs are derived from the single `TEST_DT_ENVIRONMENT` value.
 
 #### Scenario: Valid credentials
 
-- **WHEN** `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set
+- **WHEN** `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set
 - **THEN** `NewForTesting` returns a `*Client` with both `ClassicClient` and `PlatformClient` configured
 
 #### Scenario: Missing environment variable
@@ -86,9 +104,14 @@ E2E tests SHALL use `t.TempDir()` for all fixture app directories. No test artif
 - **WHEN** `TEST_DT_ENVIRONMENT` is not set
 - **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
 
-#### Scenario: Missing token variable
+#### Scenario: Missing access token variable
 
 - **WHEN** `TEST_DT_ACCESS_TOKEN` is not set
+- **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
+
+#### Scenario: Missing platform token variable
+
+- **WHEN** `TEST_DT_PLATFORM_TOKEN` is not set
 - **THEN** `NewForTesting` calls `t.Fatal` with a message naming the missing variable
 
 ### Requirement: URL family derivation

--- a/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
+++ b/openspec/changes/e2e-testing-infrastructure/specs/e2e-test-infra/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Build tag separation
 
-All E2E test files in `test/e2e/` SHALL use the `//go:build integration` build tag. Running `go test ./...` without `-tags integration` SHALL NOT compile or execute any E2E test.
+All E2E test files in `test/e2e/` SHALL use the `//go:build integration` build tag. The tag acts as a gating mechanism: it excludes E2E files from default builds (`go test ./...` without `-tags integration`) and includes them when explicitly requested (`go test -tags integration`). Whether it operates as exclusion or inclusion depends on the invocation — both are intentional behaviors of the same tag.
 
 #### Scenario: Default test run excludes E2E
 
@@ -37,21 +37,21 @@ The `make test-integration` target SHALL require `TEST_DT_ENVIRONMENT` and `TEST
 
 ### Requirement: .env file loading
 
-The `make test-integration` target SHALL load variables from a `.env` file in the project root if it exists. Shell environment variables SHALL take precedence over `.env` values. The `.env` file SHALL be listed in `.gitignore`.
+The `make test-integration` target SHALL load variables from a `.e2e-tests.env` file in the project root if it exists. Shell environment variables SHALL take precedence over `.e2e-tests.env` values. The `.e2e-tests.env` file SHALL be listed in `.gitignore`. A `.e2e-tests.env.example` file with placeholder values for `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` SHALL be committed to VCS as a reference.
 
-#### Scenario: .env file present
+#### Scenario: .e2e-tests.env file present
 
-- **WHEN** a `.env` file exists with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`
+- **WHEN** a `.e2e-tests.env` file exists with `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`
 - **THEN** the Makefile loads those values and runs the integration tests
 
-#### Scenario: Shell overrides .env
+#### Scenario: Shell overrides .e2e-tests.env
 
-- **WHEN** `TEST_DT_ENVIRONMENT` is set in the shell and a different value exists in `.env`
+- **WHEN** `TEST_DT_ENVIRONMENT` is set in the shell and a different value exists in `.e2e-tests.env`
 - **THEN** the shell value is used
 
-#### Scenario: No .env file
+#### Scenario: No .e2e-tests.env file
 
-- **WHEN** no `.env` file exists and env vars are set in the shell
+- **WHEN** no `.e2e-tests.env` file exists and env vars are set in the shell
 - **THEN** the Makefile proceeds using shell env vars without error
 
 ### Requirement: Unique test naming

--- a/openspec/changes/e2e-testing-infrastructure/tasks.md
+++ b/openspec/changes/e2e-testing-infrastructure/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: E2E Testing Infrastructure
+
+## 1. Client Test Constructor (`pkg/client/`)
+
+- [ ] 1.1 Add `NewForTesting(t *testing.T) *Client` to `pkg/client/client.go` — reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`, calls `t.Fatal` if either is missing, derives Classic + Platform URLs from the single env URL, returns `*Client` with verbosity 0
+- [ ] 1.2 Add unit test for `NewForTesting` in `pkg/client/client_test.go` — test cases: both vars set (success), missing environment (fatal), missing token (fatal), Classic URL input derives correct Platform URL, Platform URL input derives correct Classic URL
+
+## 2. Test Infrastructure (`test/integration/`)
+
+- [ ] 2.1 Create `test/integration/setup.go` — `SetupE2ETest(t *testing.T)` function that validates `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (calls `t.Fatal` if not), generates unique test ID `dtwiz-test-{unix-ts}-{random}`, returns a `TestEnv` struct with client (`NewForTesting`), test ID, and temp dir (`t.TempDir()`)
+- [ ] 2.2 Create `test/integration/dtquery.go` — `WaitForTraces(ctx context.Context, client *client.Client, serviceName string, opts ...PollOption) ([]TraceRecord, error)` function that polls DQL endpoint via `PlatformClient` filtering by `service.name`, default 60s timeout / 2s interval, returns traces or timeout error with the queried service name
+
+## 3. Fixture App (`test/fixtures/`)
+
+- [ ] 3.1 Create `test/fixtures/python-flask/app.py` — minimal Flask app with one GET endpoint (`/`) that returns a simple response; app listens on a configurable port (env var or default 18080)
+- [ ] 3.2 Create `test/fixtures/python-flask/requirements.txt` — contains `flask` (pinned or unpinned, minimal)
+
+## 4. Python E2E Test (`test/e2e/`)
+
+- [ ] 4.1 Create `test/e2e/suite_test.go` with `//go:build integration` — shared test helpers: `copyFixture(t, fixtureDir, destDir)` to copy fixture app into temp dir, `startApp(t, dir, port)` to run the instrumented app as a subprocess with `t.Cleanup` kill, `triggerRequest(url)` HTTP GET helper
+- [ ] 4.2 Create `test/e2e/python_test.go` with `//go:build integration` — `TestPythonOTelAutoInstrumentation`: checks `python3` available (skip if not), calls `SetupE2ETest`, copies flask fixture, runs `dtwiz install otel-python` on the temp dir, starts the app with `opentelemetry-instrument`, sends HTTP request, calls `WaitForTraces` with unique service name, asserts trace count > 0
+
+## 5. Makefile & Gitignore
+
+- [ ] 5.1 Add `test-integration` target to `Makefile` — loads `.env` if present (`ifneq (,$(wildcard .env))` / `include .env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
+- [ ] 5.2 Add `.env` to `.gitignore`
+- [ ] 5.3 Update `.PHONY` in `Makefile` to include `test-integration`
+
+## 6. Verification
+
+- [ ] 6.1 Run `make test` — confirm it completes in ~2 sec with no E2E test output
+- [ ] 6.2 Run `make test-integration` without credentials — confirm descriptive error to stderr and non-zero exit
+- [ ] 6.3 Run `make lint` — confirm no new lint issues in added code

--- a/openspec/changes/e2e-testing-infrastructure/tasks.md
+++ b/openspec/changes/e2e-testing-infrastructure/tasks.md
@@ -1,34 +1,29 @@
 # Tasks: E2E Testing Infrastructure
 
-## 1. Client Test Constructor (`pkg/client/`)
+## 1. Test Infrastructure (`test/integration/`)
 
-- [ ] 1.1 Add `NewForTesting(t *testing.T) *Client` to `pkg/client/client.go` — reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`, calls `t.Fatal` if any is missing, derives Classic + Platform URLs from the single env URL, wires access token to `ClassicClient` and platform token to `PlatformClient`, returns `*Client` with verbosity 0
-- [ ] 1.2 Add unit test for `NewForTesting` in `pkg/client/client_test.go` — test cases: all three vars set (success), missing environment (fatal), missing access token (fatal), missing platform token (fatal), Classic URL input derives correct Platform URL, Platform URL input derives correct Classic URL
+- [ ] 1.1 Create `test/integration/setup.go` — `SetupIntegration(t *testing.T)` function that validates `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set (calls `t.Fatal` if not), constructs a `*client.Client` via `client.New()` with URLs derived from `TEST_DT_ENVIRONMENT` and tokens from `TEST_DT_ACCESS_TOKEN`/`TEST_DT_PLATFORM_TOKEN`, generates unique test ID `dtwiz-test-{unix-ts}-{random}`, returns a `TestEnv` struct with client, test ID, and temp dir (`t.TempDir()`)
+- [ ] 1.2 Create `test/integration/dtquery.go` — `WaitForTraces(ctx context.Context, client *client.Client, serviceName string, opts ...PollOption) ([]TraceRecord, error)` function that polls DQL endpoint via `PlatformClient` filtering by `service.name`, default 60s timeout / 2s interval, returns traces or timeout error with the queried service name
 
-## 2. Test Infrastructure (`test/integration/`)
+## 2. Fixture App (`test/fixtures/`)
 
-- [ ] 2.1 Create `test/integration/setup.go` — `SetupE2ETest(t *testing.T)` function that validates `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set (calls `t.Fatal` if not), generates unique test ID `dtwiz-test-{unix-ts}-{random}`, returns a `TestEnv` struct with client (`NewForTesting`), test ID, and temp dir (`t.TempDir()`)
-- [ ] 2.2 Create `test/integration/dtquery.go` — `WaitForTraces(ctx context.Context, client *client.Client, serviceName string, opts ...PollOption) ([]TraceRecord, error)` function that polls DQL endpoint via `PlatformClient` filtering by `service.name`, default 60s timeout / 2s interval, returns traces or timeout error with the queried service name
+- [ ] 2.1 Create `test/fixtures/python-flask/app.py` — minimal Flask app with one GET endpoint (`/`) that returns a simple response; app listens on a configurable port (env var or default 18080)
+- [ ] 2.2 Create `test/fixtures/python-flask/requirements.txt` — contains `flask` (pinned or unpinned, minimal)
 
-## 3. Fixture App (`test/fixtures/`)
+## 3. Python E2E Test (`test/e2e/`)
 
-- [ ] 3.1 Create `test/fixtures/python-flask/app.py` — minimal Flask app with one GET endpoint (`/`) that returns a simple response; app listens on a configurable port (env var or default 18080)
-- [ ] 3.2 Create `test/fixtures/python-flask/requirements.txt` — contains `flask` (pinned or unpinned, minimal)
+- [ ] 3.1 Create `test/e2e/suite_test.go` with `//go:build integration` — shared test helpers: `copyFixture(t, fixtureDir, destDir)` to copy fixture app into temp dir, `startApp(t, dir, port)` to run the instrumented app as a subprocess with `t.Cleanup` kill, `triggerRequest(url)` HTTP GET helper
+- [ ] 3.2 Create `test/e2e/python_test.go` with `//go:build integration` — `TestPythonOTelAutoInstrumentation`: checks `python3` available (skip if not), calls `SetupIntegration`, copies flask fixture, runs `dtwiz install otel-python` on the temp dir, starts the app with `opentelemetry-instrument`, sends HTTP request, calls `WaitForTraces` with unique service name, asserts trace count > 0
 
-## 4. Python E2E Test (`test/e2e/`)
+## 4. makefile & Gitignore
 
-- [ ] 4.1 Create `test/e2e/suite_test.go` with `//go:build integration` — shared test helpers: `copyFixture(t, fixtureDir, destDir)` to copy fixture app into temp dir, `startApp(t, dir, port)` to run the instrumented app as a subprocess with `t.Cleanup` kill, `triggerRequest(url)` HTTP GET helper
-- [ ] 4.2 Create `test/e2e/python_test.go` with `//go:build integration` — `TestPythonOTelAutoInstrumentation`: checks `python3` available (skip if not), calls `SetupE2ETest`, copies flask fixture, runs `dtwiz install otel-python` on the temp dir, starts the app with `opentelemetry-instrument`, sends HTTP request, calls `WaitForTraces` with unique service name, asserts trace count > 0
+- [ ] 4.1 Add `test-integration` target to `makefile` — loads `.e2e-tests.env` if present (`ifneq (,$(wildcard .e2e-tests.env))` / `include .e2e-tests.env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
+- [ ] 4.2 Add `.e2e-tests.env` to `.gitignore`
+- [ ] 4.3 Add `.e2e-tests.env.example` to the repo — contains the three required env vars (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`) with placeholder values and a comment instructing contributors to `cp .e2e-tests.env.example .e2e-tests.env` and fill in their credentials; committed to VCS
+- [ ] 4.4 Update `.PHONY` in `makefile` to include `test-integration`
 
-## 5. makefile & Gitignore
+## 5. Verification
 
-- [ ] 5.1 Add `test-integration` target to `makefile` — loads `.e2e-tests.env` if present (`ifneq (,$(wildcard .e2e-tests.env))` / `include .e2e-tests.env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
-- [ ] 5.2 Add `.e2e-tests.env` to `.gitignore`
-- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the two required env vars (`TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`) with placeholder values, committed to VCS as a reference for contributors
-- [ ] 5.4 Update `.PHONY` in `makefile` to include `test-integration`
-
-## 6. Verification
-
-- [ ] 6.1 Run `make test` — confirm it completes in ~2 sec with no E2E test output
-- [ ] 6.2 Run `make test-integration` without credentials — confirm descriptive error to stderr and non-zero exit
-- [ ] 6.3 Run `make lint` — confirm no new lint issues in added code
+- [ ] 5.1 Run `make test`
+- [ ] 5.2 Run `make test-integration` without credentials — confirm descriptive error to stderr and non-zero exit
+- [ ] 5.3 Run `make lint` — confirm no new lint issues in added code

--- a/openspec/changes/e2e-testing-infrastructure/tasks.md
+++ b/openspec/changes/e2e-testing-infrastructure/tasks.md
@@ -20,12 +20,12 @@
 - [ ] 4.1 Create `test/e2e/suite_test.go` with `//go:build integration` — shared test helpers: `copyFixture(t, fixtureDir, destDir)` to copy fixture app into temp dir, `startApp(t, dir, port)` to run the instrumented app as a subprocess with `t.Cleanup` kill, `triggerRequest(url)` HTTP GET helper
 - [ ] 4.2 Create `test/e2e/python_test.go` with `//go:build integration` — `TestPythonOTelAutoInstrumentation`: checks `python3` available (skip if not), calls `SetupE2ETest`, copies flask fixture, runs `dtwiz install otel-python` on the temp dir, starts the app with `opentelemetry-instrument`, sends HTTP request, calls `WaitForTraces` with unique service name, asserts trace count > 0
 
-## 5. Makefile & Gitignore
+## 5. makefile & Gitignore
 
-- [ ] 5.1 Add `test-integration` target to `Makefile` — the entire recipe MUST be a single shell invocation with all steps joined by `&&` or `;` so that variable exports persist across checks. Pattern: `[ -f .e2e-tests.env ] && export $$(grep -v '^#' .e2e-tests.env | xargs) || true` then check `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set (each in its own `[ -z "$$VAR" ]` guard), printing an actionable error with copy-paste setup instructions to stderr and `exit 1` if any is missing; then run `go test -v -tags integration -timeout 5m ./test/e2e/...`. Do NOT use a separate `if [ -f .e2e-tests.env ]; then export ...; fi` block followed by independent `if` checks — the export subshell exits before the checks run, so variables from the file are always lost.
+- [ ] 5.1 Add `test-integration` target to `makefile` — loads `.e2e-tests.env` if present (`ifneq (,$(wildcard .e2e-tests.env))` / `include .e2e-tests.env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
 - [ ] 5.2 Add `.e2e-tests.env` to `.gitignore`
-- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the three required env vars (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`) with placeholder values and a comment instructing contributors to `cp .e2e-tests.env.example .e2e-tests.env` and fill in their credentials; committed to VCS
-- [ ] 5.4 Update `.PHONY` in `Makefile` to include `test-integration`
+- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the two required env vars (`TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`) with placeholder values, committed to VCS as a reference for contributors
+- [ ] 5.4 Update `.PHONY` in `makefile` to include `test-integration`
 
 ## 6. Verification
 

--- a/openspec/changes/e2e-testing-infrastructure/tasks.md
+++ b/openspec/changes/e2e-testing-infrastructure/tasks.md
@@ -2,12 +2,12 @@
 
 ## 1. Client Test Constructor (`pkg/client/`)
 
-- [ ] 1.1 Add `NewForTesting(t *testing.T) *Client` to `pkg/client/client.go` — reads `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`, calls `t.Fatal` if either is missing, derives Classic + Platform URLs from the single env URL, returns `*Client` with verbosity 0
-- [ ] 1.2 Add unit test for `NewForTesting` in `pkg/client/client_test.go` — test cases: both vars set (success), missing environment (fatal), missing token (fatal), Classic URL input derives correct Platform URL, Platform URL input derives correct Classic URL
+- [ ] 1.1 Add `NewForTesting(t *testing.T) *Client` to `pkg/client/client.go` — reads `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`, calls `t.Fatal` if any is missing, derives Classic + Platform URLs from the single env URL, wires access token to `ClassicClient` and platform token to `PlatformClient`, returns `*Client` with verbosity 0
+- [ ] 1.2 Add unit test for `NewForTesting` in `pkg/client/client_test.go` — test cases: all three vars set (success), missing environment (fatal), missing access token (fatal), missing platform token (fatal), Classic URL input derives correct Platform URL, Platform URL input derives correct Classic URL
 
 ## 2. Test Infrastructure (`test/integration/`)
 
-- [ ] 2.1 Create `test/integration/setup.go` — `SetupE2ETest(t *testing.T)` function that validates `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (calls `t.Fatal` if not), generates unique test ID `dtwiz-test-{unix-ts}-{random}`, returns a `TestEnv` struct with client (`NewForTesting`), test ID, and temp dir (`t.TempDir()`)
+- [ ] 2.1 Create `test/integration/setup.go` — `SetupE2ETest(t *testing.T)` function that validates `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set (calls `t.Fatal` if not), generates unique test ID `dtwiz-test-{unix-ts}-{random}`, returns a `TestEnv` struct with client (`NewForTesting`), test ID, and temp dir (`t.TempDir()`)
 - [ ] 2.2 Create `test/integration/dtquery.go` — `WaitForTraces(ctx context.Context, client *client.Client, serviceName string, opts ...PollOption) ([]TraceRecord, error)` function that polls DQL endpoint via `PlatformClient` filtering by `service.name`, default 60s timeout / 2s interval, returns traces or timeout error with the queried service name
 
 ## 3. Fixture App (`test/fixtures/`)
@@ -22,9 +22,9 @@
 
 ## 5. Makefile & Gitignore
 
-- [ ] 5.1 Add `test-integration` target to `Makefile` — loads `.e2e-tests.env` if present (`ifneq (,$(wildcard .e2e-tests.env))` / `include .e2e-tests.env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
+- [ ] 5.1 Add `test-integration` target to `Makefile` — the entire recipe MUST be a single shell invocation with all steps joined by `&&` or `;` so that variable exports persist across checks. Pattern: `[ -f .e2e-tests.env ] && export $$(grep -v '^#' .e2e-tests.env | xargs) || true` then check `TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN` are set (each in its own `[ -z "$$VAR" ]` guard), printing an actionable error with copy-paste setup instructions to stderr and `exit 1` if any is missing; then run `go test -v -tags integration -timeout 5m ./test/e2e/...`. Do NOT use a separate `if [ -f .e2e-tests.env ]; then export ...; fi` block followed by independent `if` checks — the export subshell exits before the checks run, so variables from the file are always lost.
 - [ ] 5.2 Add `.e2e-tests.env` to `.gitignore`
-- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the two required env vars (`TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`) with placeholder values, committed to VCS as a reference for contributors
+- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the three required env vars (`TEST_DT_ENVIRONMENT`, `TEST_DT_ACCESS_TOKEN`, and `TEST_DT_PLATFORM_TOKEN`) with placeholder values and a comment instructing contributors to `cp .e2e-tests.env.example .e2e-tests.env` and fill in their credentials; committed to VCS
 - [ ] 5.4 Update `.PHONY` in `Makefile` to include `test-integration`
 
 ## 6. Verification

--- a/openspec/changes/e2e-testing-infrastructure/tasks.md
+++ b/openspec/changes/e2e-testing-infrastructure/tasks.md
@@ -22,9 +22,10 @@
 
 ## 5. Makefile & Gitignore
 
-- [ ] 5.1 Add `test-integration` target to `Makefile` — loads `.env` if present (`ifneq (,$(wildcard .env))` / `include .env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
-- [ ] 5.2 Add `.env` to `.gitignore`
-- [ ] 5.3 Update `.PHONY` in `Makefile` to include `test-integration`
+- [ ] 5.1 Add `test-integration` target to `Makefile` — loads `.e2e-tests.env` if present (`ifneq (,$(wildcard .e2e-tests.env))` / `include .e2e-tests.env` / `export`), checks `TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN` are set (prints error to stderr + `exit 1` if missing), runs `go test -v -tags integration -timeout 5m ./test/e2e/...`
+- [ ] 5.2 Add `.e2e-tests.env` to `.gitignore`
+- [ ] 5.3 Add `.e2e-tests.env.example` to the repo — contains the two required env vars (`TEST_DT_ENVIRONMENT` and `TEST_DT_ACCESS_TOKEN`) with placeholder values, committed to VCS as a reference for contributors
+- [ ] 5.4 Update `.PHONY` in `Makefile` to include `test-integration`
 
 ## 6. Verification
 


### PR DESCRIPTION
## Feature Description

Adds the complete OpenSpec for the E2E testing infrastructure change — proposal, design, spec, and tasks.

## How to test
-

## Which other features are affected?
None

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I followed the existing code style and conventions.
