### PR TITLE
feat: split error messages for token validation

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -135,10 +135,13 @@ func checkAccessToken(envURL, token string) error {
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+	if resp.StatusCode == 401 {
 		return fmt.Errorf("✗ Access token: authentication failed")
 	}
-	if resp.StatusCode/100 != 2 {
+	if resp.StatusCode == 403 {
+		return fmt.Errorf("✗ Access token: insufficient permissions")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("✗ Access token: unexpected response %d from %s", resp.StatusCode, lookupURL)
 	}
 	return nil
@@ -200,10 +203,13 @@ func checkPlatformToken(envURL, token string) error {
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+	if resp.StatusCode == 401 {
 		return fmt.Errorf("✗ Platform token: authentication failed")
 	}
-	if resp.StatusCode/100 != 2 {
+	if resp.StatusCode == 403 {
+		return fmt.Errorf("✗ Platform token: insufficient permissions")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("✗ Platform token: unexpected response %d from %s", resp.StatusCode, queryURL)
 	}
 	return nil

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -3,8 +3,107 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestCheckPlatformToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		wantErr     bool
+		wantContain string
+	}{
+		{"200 ok", http.StatusOK, false, ""},
+		{"401 unauthorized", http.StatusUnauthorized, true, "✗ Platform token: authentication failed"},
+		{"403 forbidden", http.StatusForbidden, true, "✗ Platform token: insufficient permissions"},
+		{"500 server error", http.StatusInternalServerError, true, "unexpected response 500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/platform/storage/query/v1/query:execute" {
+					t.Errorf("path = %s, want /platform/storage/query/v1/query:execute", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer dt0s16.testtoken" {
+					t.Errorf("Authorization = %q, want %q", got, "Bearer dt0s16.testtoken")
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			orig := credentialHTTPClient
+			credentialHTTPClient = srv.Client()
+			defer func() { credentialHTTPClient = orig }()
+
+			err := checkPlatformToken(srv.URL, "dt0s16.testtoken")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkPlatformToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContain != "" && err != nil {
+				if tt.statusCode == http.StatusInternalServerError {
+					if !strings.Contains(err.Error(), tt.wantContain) {
+						t.Errorf("checkPlatformToken() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+					}
+				} else if err.Error() != tt.wantContain {
+					t.Errorf("checkPlatformToken() error = %q, want %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckAccessToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		wantErr     bool
+		wantContain string
+	}{
+		{"200 ok", http.StatusOK, false, ""},
+		{"401 unauthorized", http.StatusUnauthorized, true, "✗ Access token: authentication failed"},
+		{"403 forbidden", http.StatusForbidden, true, "✗ Access token: insufficient permissions"},
+		{"500 server error", http.StatusInternalServerError, true, "unexpected response 500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/api/v2/apiTokens/lookup" {
+					t.Errorf("path = %s, want /api/v2/apiTokens/lookup", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Api-Token dt0c01.testtoken" {
+					t.Errorf("Authorization = %q, want %q", got, "Api-Token dt0c01.testtoken")
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			orig := credentialHTTPClient
+			credentialHTTPClient = srv.Client()
+			defer func() { credentialHTTPClient = orig }()
+
+			err := checkAccessToken(srv.URL, "dt0c01.testtoken")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkAccessToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContain != "" && err != nil {
+				if tt.statusCode == http.StatusInternalServerError {
+					if !strings.Contains(err.Error(), tt.wantContain) {
+						t.Errorf("checkAccessToken() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+					}
+				} else if err.Error() != tt.wantContain {
+					t.Errorf("checkAccessToken() error = %q, want %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
 
 func TestCheckClassicAccess(t *testing.T) {
 	tests := []struct {

--- a/openspec/changes/finer-grained-error-messages/.openspec.yaml
+++ b/openspec/changes/finer-grained-error-messages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/finer-grained-error-messages/design.md
+++ b/openspec/changes/finer-grained-error-messages/design.md
@@ -1,0 +1,31 @@
+# Context
+
+`cmd/auth.go` contains two token validation functions: `checkPlatformToken` (validates via DQL) and `checkAccessToken` (validates via `POST /api/v2/apiTokens/lookup`). Both previously mapped both 401 and 403 to the same error string, "authentication failed". The code change splitting these into distinct messages has already landed; what remains is adding the spec scenario and the unit tests that pin the behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a 403 scenario to the `platform-token-primary-auth` spec covering the platform-token "insufficient permissions" message
+- Add a requirement to the `platform-token-primary-auth` spec covering the access-token 401/403 messages surfaced by `dtwiz status`
+- Add direct unit tests for `checkPlatformToken` and `checkAccessToken` that assert the exact error string for 200, 401, 403, and unexpected non-2xx responses
+
+**Non-Goals:**
+
+- Changing any runtime behavior (the code fix is already in place)
+- Updating the archived copies of the spec under `openspec/changes/archive/`
+- Adding tests for `checkPlatformTokenClassicAccess` (already covered by `TestCheckClassicAccess`)
+
+## Decisions
+
+**Test approach: `httptest.NewServer` table-driven tests**
+
+Both functions accept a URL and token string and use the package-level `credentialHTTPClient`. This is the same pattern used in `TestValidateCredentials` and `TestCheckClassicAccess` — swap `credentialHTTPClient` with the test server's client, return the desired status code, assert the error string. No new patterns needed.
+
+**Scope: both `checkPlatformToken` and `checkAccessToken` in the spec update**
+
+The `platform-token-primary-auth` spec covers DQL validation (`checkPlatformToken`), modified to add the 403 scenario. The access-token path (`checkAccessToken`) is a separate, optional flow surfaced by `dtwiz status`; it now gets its own requirement documenting the 401/403 message split. Tests cover both functions.
+
+## Risks / Trade-offs
+
+- [Archived spec copies are stale] → Acceptable: archives are historical snapshots and are not applied during reconciliation.

--- a/openspec/changes/finer-grained-error-messages/proposal.md
+++ b/openspec/changes/finer-grained-error-messages/proposal.md
@@ -1,0 +1,28 @@
+# Why
+
+When token validation fails, dtwiz previously returned the same error message for both 401 (bad/expired token) and 403 (valid token, missing scopes), making it impossible for users to distinguish a credential problem from a permissions problem. The fix has already been implemented; this change captures the spec and test coverage that were missing.
+
+## What Changes
+
+- `checkPlatformToken` now returns `✗ Platform token: insufficient permissions` on 403 (previously: `authentication failed`)
+- `checkAccessToken` now returns `✗ Access token: insufficient permissions` on 403 (previously: `authentication failed`)
+- Unit tests are added to assert the exact error message for each HTTP status code path
+- The `platform-token-primary-auth` spec is updated to cover the 403 scenario
+
+## Capabilities
+
+### New Capabilities
+
+- none
+
+### Modified Capabilities
+
+- `platform-token-primary-auth`:
+  - Add a 403 scenario to the DQL validation requirement, specifying that `✗ Platform token: insufficient permissions` is the expected exit message when the token is valid but lacks the required DQL scope.
+  - Add a requirement covering access-token validation in `dtwiz status`, specifying that 401 yields `✗ Access token: authentication failed` and 403 yields `✗ Access token: insufficient permissions`.
+
+## Impact
+
+- `cmd/auth.go`: already changed (401 and 403 produce distinct messages for both `checkPlatformToken` and `checkAccessToken`)
+- `cmd/auth_test.go`: needs new table-driven tests for `checkPlatformToken` and `checkAccessToken` covering 200, 401, 403, and non-2xx status codes with exact message assertions
+- `openspec/specs/platform-token-primary-auth/spec.md`: needs a second DQL validation scenario for the 403 case, plus a new requirement covering the access-token 401/403 messages surfaced by `dtwiz status`

--- a/openspec/changes/finer-grained-error-messages/specs/platform-token-primary-auth/spec.md
+++ b/openspec/changes/finer-grained-error-messages/specs/platform-token-primary-auth/spec.md
@@ -1,0 +1,39 @@
+# Finer Grained Error Messages
+
+## MODIFIED Requirements
+
+### Requirement: Platform token DQL validation is a hard requirement
+
+At startup, all commands SHALL validate the platform token via DQL query. Failure exits with an error regardless of whether an access token is set. The error message SHALL distinguish authentication failure (401) from insufficient permissions (403).
+
+#### Scenario: Platform token DQL validation fails with invalid or expired token
+
+- **GIVEN** `DT_PLATFORM_TOKEN` is set to an invalid or expired token
+- **WHEN** the user runs any command
+- **THEN** the command exits with `✗ Platform token: authentication failed`
+
+#### Scenario: Platform token DQL validation fails with insufficient permissions
+
+- **GIVEN** `DT_PLATFORM_TOKEN` is set to a valid token that lacks the required DQL scope
+- **WHEN** the user runs any command
+- **THEN** the command exits with `✗ Platform token: insufficient permissions`
+
+## ADDED Requirements
+
+### Requirement: Access token validation distinguishes authentication failure from insufficient permissions
+
+When an access token is configured, `dtwiz status` SHALL validate it via the Classic API token lookup. The error message SHALL distinguish authentication failure (401) from insufficient permissions (403).
+
+#### Scenario: Access token validation fails with invalid or expired token
+
+- **GIVEN** an access token is configured via `--access-token`
+- **AND** the token is invalid or expired
+- **WHEN** the user runs `dtwiz status`
+- **THEN** the access token row shows `✗ Access token: authentication failed`
+
+#### Scenario: Access token validation fails with insufficient permissions
+
+- **GIVEN** an access token is configured via `--access-token`
+- **AND** the token is valid but lacks the required scope
+- **WHEN** the user runs `dtwiz status`
+- **THEN** the access token row shows `✗ Access token: insufficient permissions`

--- a/openspec/changes/finer-grained-error-messages/tasks.md
+++ b/openspec/changes/finer-grained-error-messages/tasks.md
@@ -1,0 +1,5 @@
+# 1. Tests
+
+- [x] 1.1 Add `TestCheckPlatformToken` in `cmd/auth_test.go`: table-driven, using `httptest.NewServer` + `credentialHTTPClient` swap, covering: 200 (no error), 401 (error contains "authentication failed"), 403 (error contains "insufficient permissions"), 500 (error contains status code)
+- [x] 1.2 Add `TestCheckAccessToken` in `cmd/auth_test.go`: same pattern, same cases, asserting the "Access token:" prefix variants
+- [x] 1.3 Run `make test` and confirm all new and existing tests pass


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->
It splits up the permission related errors to allow for finer-grained error messages 
* 401: Malformed/Non-existent token/authentication
* 403: Permission not granted

## How to test
1.

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
