### PR TITLE
feature: initialize one agent v2

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -321,7 +321,7 @@ func init() {
 
 	installOneAgentCmd.Flags().Bool("quiet", false, "Run a silent/unattended installation with no output")
 	installOneAgentCmd.Flags().String("host-group", "", "Assign the host to a host group (--set-host-group)")
-	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", "fullstack", "OneAgent monitoring mode to pass to the installer")
+	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", string(installer.InstallModeFullStack), "OneAgent monitoring mode to pass to the installer")
 	installOneAgentCmd.Flags().BoolVar(&flagNoVerifySignature, "no-verify-signature", false, "Skip installer signature verification (Linux only)")
 	installOneAgentCmd.Flags().BoolVar(&flagSkipConnectivityCheck, "skip-connectivity-check", false, "Skip endpoint connectivity probe before installation")
 	installOneAgentCmd.Flags().BoolVar(&flagConnectivityCheckOnly, "connectivity-check-only", false, "Run connectivity probe and exit without installing")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -3,11 +3,22 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
 
 var installDryRun bool
 var installAutoConfirm bool
+
+// OneAgent v2 flags (used when DTWIZ_ONEAGENT_POC is enabled)
+var (
+	flagForce                 bool
+	flagMonitoringMode        string
+	flagNoVerifySignature     bool
+	flagSkipConnectivityCheck bool
+	flagConnectivityCheckOnly bool
+	flagPrintEndpoints        bool
+)
 
 var installCmd = &cobra.Command{
 	Use:   "install <method>",
@@ -36,6 +47,23 @@ var installOneAgentCmd = &cobra.Command{
 		}
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		hostGroup, _ := cmd.Flags().GetString("host-group")
+
+		opts := installer.InstallOptions{
+			DryRun:                installDryRun,
+			Force:                 flagForce,
+			MonitoringMode:        flagMonitoringMode,
+			NoVerifySignature:     flagNoVerifySignature,
+			SkipConnectivityCheck: flagSkipConnectivityCheck,
+			ConnectivityCheckOnly: flagConnectivityCheckOnly,
+			PrintEndpoints:        flagPrintEndpoints,
+			HostGroup:             hostGroup,
+			Quiet:                 quiet,
+		}
+
+		if featureflags.IsEnabled(featureflags.OneAgentPoC) {
+			return installer.InstallOneAgentV2(c, opts)
+		}
+
 		if err := installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup); err != nil {
 			return err
 		}
@@ -297,6 +325,12 @@ func init() {
 
 	installOneAgentCmd.Flags().Bool("quiet", false, "Run a silent/unattended installation with no output")
 	installOneAgentCmd.Flags().String("host-group", "", "Assign the host to a host group (--set-host-group)")
+	installOneAgentCmd.Flags().BoolVar(&flagForce, "force", false, "Override existing-OneAgent preflight check")
+	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", "fullstack", "OneAgent monitoring mode (fullstack, infra, discovery)")
+	installOneAgentCmd.Flags().BoolVar(&flagNoVerifySignature, "no-verify-signature", false, "Skip installer signature verification (Linux only)")
+	installOneAgentCmd.Flags().BoolVar(&flagSkipConnectivityCheck, "skip-connectivity-check", false, "Skip endpoint connectivity probe before installation")
+	installOneAgentCmd.Flags().BoolVar(&flagConnectivityCheckOnly, "connectivity-check-only", false, "Run connectivity probe and exit without installing")
+	installOneAgentCmd.Flags().BoolVar(&flagPrintEndpoints, "print-endpoints", false, "Print resolved communication endpoints and exit")
 	installCmd.AddCommand(installOneAgentCmd)
 	installCmd.AddCommand(installKubernetesCmd)
 	installCmd.AddCommand(installDockerCmd)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -12,7 +12,6 @@ var installAutoConfirm bool
 
 // OneAgent v2 flags (used when DTWIZ_ONEAGENT_POC is enabled)
 var (
-	flagForce                 bool
 	flagMonitoringMode        string
 	flagNoVerifySignature     bool
 	flagSkipConnectivityCheck bool
@@ -50,13 +49,11 @@ var installOneAgentCmd = &cobra.Command{
 
 		opts := installer.InstallOptions{
 			DryRun:                installDryRun,
-			Force:                 flagForce,
 			MonitoringMode:        flagMonitoringMode,
 			NoVerifySignature:     flagNoVerifySignature,
 			SkipConnectivityCheck: flagSkipConnectivityCheck,
 			ConnectivityCheckOnly: flagConnectivityCheckOnly,
 			PrintEndpoints:        flagPrintEndpoints,
-			HostGroup:             hostGroup,
 			Quiet:                 quiet,
 		}
 
@@ -325,7 +322,6 @@ func init() {
 
 	installOneAgentCmd.Flags().Bool("quiet", false, "Run a silent/unattended installation with no output")
 	installOneAgentCmd.Flags().String("host-group", "", "Assign the host to a host group (--set-host-group)")
-	installOneAgentCmd.Flags().BoolVar(&flagForce, "force", false, "Override existing-OneAgent preflight check")
 	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", "fullstack", "OneAgent monitoring mode (fullstack, infra, discovery)")
 	installOneAgentCmd.Flags().BoolVar(&flagNoVerifySignature, "no-verify-signature", false, "Skip installer signature verification (Linux only)")
 	installOneAgentCmd.Flags().BoolVar(&flagSkipConnectivityCheck, "skip-connectivity-check", false, "Skip endpoint connectivity probe before installation")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,7 +10,6 @@ import (
 var installDryRun bool
 var installAutoConfirm bool
 
-// OneAgent v2 flags (used when DTWIZ_ONEAGENT_POC is enabled)
 var (
 	flagMonitoringMode        string
 	flagNoVerifySignature     bool
@@ -322,7 +321,7 @@ func init() {
 
 	installOneAgentCmd.Flags().Bool("quiet", false, "Run a silent/unattended installation with no output")
 	installOneAgentCmd.Flags().String("host-group", "", "Assign the host to a host group (--set-host-group)")
-	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", "fullstack", "OneAgent monitoring mode (fullstack, infra, discovery)")
+	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", "fullstack", "OneAgent monitoring mode to pass to the installer")
 	installOneAgentCmd.Flags().BoolVar(&flagNoVerifySignature, "no-verify-signature", false, "Skip installer signature verification (Linux only)")
 	installOneAgentCmd.Flags().BoolVar(&flagSkipConnectivityCheck, "skip-connectivity-check", false, "Skip endpoint connectivity probe before installation")
 	installOneAgentCmd.Flags().BoolVar(&flagConnectivityCheckOnly, "connectivity-check-only", false, "Run connectivity probe and exit without installing")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -135,7 +135,7 @@ var setupCmd = &cobra.Command{
 			if featureflags.IsEnabled(featureflags.OneAgentPoC) {
 				installErr = installer.InstallOneAgentV2(c, installer.InstallOptions{
 					DryRun:         setupDryRun,
-					MonitoringMode: "fullstack",
+					MonitoringMode: string(installer.InstallModeFullStack),
 				})
 			} else {
 				installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
 )
@@ -131,7 +132,14 @@ var setupCmd = &cobra.Command{
 		var installErr error
 		switch selected.Method {
 		case recommender.MethodOneAgent:
-			installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")
+			if featureflags.IsEnabled(featureflags.OneAgentPoC) {
+				installErr = installer.InstallOneAgentV2(c, installer.InstallOptions{
+					DryRun:         setupDryRun,
+					MonitoringMode: "fullstack",
+				})
+			} else {
+				installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")
+			}
 		case recommender.MethodKubernetes:
 			installErr = installer.InstallKubernetes(envURL, accessTok, accessTok, "" /* name */, setupDryRun)
 		case recommender.MethodDocker:

--- a/openspec/changes/oneagent-analyze/design.md
+++ b/openspec/changes/oneagent-analyze/design.md
@@ -152,8 +152,7 @@ Pre-flights run in a single function that returns either a fully-populated conte
 
    ```go
    type AgentConfig struct {
-       MonitoringMode      string // default "fullstack"
-       AppLogContentAccess bool   // default true
+       MonitoringMode string // default "fullstack"
    }
    ```
 
@@ -231,7 +230,6 @@ Logging: the token value is never written to logs, stdout, or files. Only the fa
 
 ```bash
 --set-monitoring-mode=<cfg.MonitoringMode>
---set-app-log-content-access=<cfg.AppLogContentAccess>
 ```
 
 `--set-host-group=<opts.HostGroup>` is appended when `opts.HostGroup != ""`. On Linux, `--set-server=<apiURL>` is also passed (preserves current behavior — the installer needs the server explicitly).

--- a/openspec/changes/oneagent-analyze/design.md
+++ b/openspec/changes/oneagent-analyze/design.md
@@ -291,7 +291,7 @@ Logging is layered:
 | Env detection | Debug | `"detected environment"` | `os`, `arch`, `supported`, `reason` |
 | Existing-agent check | Debug | `"existing oneagent detected"` | `path`, `force_override` |
 | Privilege check | Debug | `"privilege check"` | `privileged`, `os` |
-| Agent config | Debug | `"resolved agent config"` | `monitoring_mode`, `app_log_content_access` |
+| Agent config | Debug | `"resolved agent config"` | `monitoring-mode`, `app_log_content_access` |
 | Tenant ID | Debug | `"extracted tenant id"` | `tenant_id` (NOT the full URL if it contains credentials) |
 | Endpoint API call | Debug | `"resolving tenant endpoints"` | `url` |
 | Endpoint resolution | Verbose | `"resolved tenant endpoints"` | `count` |

--- a/openspec/changes/oneagent-analyze/proposal.md
+++ b/openspec/changes/oneagent-analyze/proposal.md
@@ -9,11 +9,11 @@ The new flow is gated behind `ONEAGENT_POC` during development. Once Task 8 land
 ## What Changes
 
 - Pre-flight validation (OS/arch detection, existing-OneAgent check, privilege check) runs before any network work.
-- Agent configuration (`MonitoringMode`, `AppLogContentAccess`) resolved early from defaults and `--monitoring-mode`/related flags.
+- Agent configuration (`MonitoringMode`) resolved early from defaults and `--monitoring-mode` flag.
 - Tenant endpoints resolved dynamically from `GET /api/v1/deployment/installer/agent/connectioninfo/endpoints` — no hardcoded IPs.
 - Short-lived `InstallerDownload`-scoped token minted via `POST /api/v2/tokens` (1h expiry); the user's long-lived `--access-token` is never passed to the installer binary.
 - Linux installer signature verified against `https://ca.dynatrace.com/dt-root.cert.pem` using `openssl cms -verify`; skippable via `--no-verify-signature`.
-- OS-specific install command built from the resolved `AgentConfig` (`--set-monitoring-mode=...`, `--set-app-log-content-access=...`) and executed with sudo/UAC; `--dry-run` prints the command without executing.
+- OS-specific install command built from the resolved `AgentConfig` (`--set-monitoring-mode=...`) and executed with sudo/UAC; `--dry-run` prints the command without executing.
 - Post-install verification polls Grail via the Platform API (`POST <apps-url>/platform/storage/query/v1/query:execute`) with a DQL `smartscapeNodes HOST` query filtered on the local hostname, for up to 2 minutes; timeout is a warning, not a failure. This matches the existing `WatchIngest` post-install flow (`pkg/installer/ingest_watch.go`) rather than introducing a parallel classic-API call path.
 - Optional parallel TCP connectivity probe of all resolved endpoints; failures are warnings, not blockers.
 - New flags on `dtwiz install oneagent`: `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`. `--dry-run` already exists on the parent `install` command.

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/spec.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/spec.md
@@ -88,25 +88,25 @@
 
 ### Requirement: Agent configuration resolved before network work
 
-`InstallOneAgentV2` SHALL resolve agent configuration before any HTTP request. The resolved `AgentConfig` SHALL contain `MonitoringMode` (default `"fullstack"`) and `AppLogContentAccess` (default `true`). The `--monitoring-mode` CLI flag, when provided, SHALL override the default `MonitoringMode` and be passed through to the installer as `--set-monitoring-mode=<value>` without dtwiz-side allow-list validation.
+`InstallOneAgentV2` SHALL resolve agent configuration before any HTTP request. The resolved `AgentConfig` SHALL contain `MonitoringMode` (default `"fullstack"`). The `--monitoring-mode` CLI flag, when provided, SHALL override the default `MonitoringMode` and be passed through to the installer as `--set-monitoring-mode=<value>` without dtwiz-side allow-list validation.
 
 #### Scenario: Default configuration
 
 - **GIVEN** no `--monitoring-mode` flag is passed
 - **WHEN** `ResolveAgentConfig(opts)` is called
-- **THEN** it returns `{MonitoringMode: "fullstack", AppLogContentAccess: true}`
+- **THEN** it returns `{MonitoringMode: "fullstack"}`
 
 #### Scenario: Monitoring mode override
 
 - **GIVEN** `--monitoring-mode=infra-only` is passed
 - **WHEN** `ResolveAgentConfig(opts)` is called
-- **THEN** it returns `{MonitoringMode: "infra-only", AppLogContentAccess: true}`
+- **THEN** it returns `{MonitoringMode: "infra-only"}`
 
 #### Scenario: Empty override preserves default
 
 - **GIVEN** `--monitoring-mode=""` (empty string)
 - **WHEN** `ResolveAgentConfig(opts)` is called
-- **THEN** it returns `{MonitoringMode: "fullstack", AppLogContentAccess: true}`
+- **THEN** it returns `{MonitoringMode: "fullstack"}`
 
 ### Requirement: Pre-flight debug logging
 

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/spec.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/spec.md
@@ -142,7 +142,7 @@ Each pre-flight stage SHALL emit a `logger.Debug` line at completion using the p
 
 - **GIVEN** `--debug` is enabled
 - **WHEN** `ResolveAgentConfig` returns
-- **THEN** stderr contains a Debug line with message `"resolved agent config"` and keys `monitoring_mode`, `app_log_content_access`
+- **THEN** stderr contains a Debug line with message `"resolved agent config"` and keys `monitoring-mode`, `app_log_content_access`
 
 #### Scenario: Pre-flight logs suppressed without --debug
 

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
@@ -57,7 +57,7 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 
 **Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1), `cmd/install.go` (modify — wire `--monitoring-mode`)
 
-- [ ] 2.5.1 Define the `AgentConfig` struct in `oneagent_v2.go`:
+- [x] 2.5.1 Define the `AgentConfig` struct in `oneagent_v2.go`:
 
   ```go
   type AgentConfig struct {
@@ -66,17 +66,17 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
   }
   ```
 
-- [ ] 2.5.2 Implement `DefaultAgentConfig() AgentConfig` returning `{MonitoringMode: "fullstack", AppLogContentAccess: true}` — this is the canonical zero-config default and the only construction path callers should use
-- [ ] 2.5.3 Implement `ResolveAgentConfig(opts InstallOptions) AgentConfig`:
+- [x] 2.5.2 Implement `DefaultAgentConfig() AgentConfig` returning `{MonitoringMode: "fullstack", AppLogContentAccess: true}` — this is the canonical zero-config default and the only construction path callers should use
+- [x] 2.5.3 Implement `ResolveAgentConfig(opts InstallOptions) AgentConfig`:
   - Start with `DefaultAgentConfig()`
-  - If `opts.MonitoringMode != ""`, override `cfg.MonitoringMode = opts.MonitoringMode` (no validation, pass-through)
+  - Always assign `cfg.MonitoringMode = opts.MonitoringMode` (no validation, pass-through; CLI default guarantees it is never empty)
   - Return the resolved config
-- [ ] 2.5.4 Add `MonitoringMode string` to the `InstallOptions` struct in Task 1's scaffold (if not already present — Task 1.8 includes it)
-- [ ] 2.5.5 Wire the cobra flag in `cmd/install.go`: `installOneAgentCmd.Flags().StringVar(&installOneAgentMonitoringMode, "monitoring-mode", "", "override the OneAgent monitoring mode (default: fullstack)")` and populate `opts.MonitoringMode` from the parsed value
-- [ ] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring_mode", cfg.MonitoringMode, "app_log_content_access", cfg.AppLogContentAccess, "override_set", opts.MonitoringMode != "")` once the config is resolved
-- [ ] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{})` returns exactly `{"fullstack", true}`
-- [ ] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only", true}`
-- [ ] 2.5.9 Unit test — **empty-string override preserves default**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: ""})` returns `{"fullstack", true}` (whitespace-only is NOT treated as override; pass-through preserves "no flag passed" semantics)
+- [x] 2.5.4 `MonitoringMode string` already present in `InstallOptions` (no change needed)
+- [x] 2.5.5 `--monitoring-mode` flag already wired on `installOneAgentCmd` with default `"fullstack"` (no change needed)
+- [x] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring_mode", cfg.MonitoringMode, "app_log_content_access", cfg.AppLogContentAccess, "override_set", opts.MonitoringMode != "fullstack")` once the config is resolved
+- [x] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})` returns exactly `{"fullstack", true}`
+- [x] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only", true}`
+- [x] 2.5.9 Unit test — **default constant matches flag default**: `DefaultAgentConfig().MonitoringMode == "fullstack"` (documents that the struct default and the CLI flag default are in sync)
 - [ ] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring_mode` and `override_set` field values
 - [ ] 2.5.11 Manual: `dtwiz install oneagent --oneagent-poc --monitoring-mode=infra-only --dry-run --debug` produces a dry-run command containing `--set-monitoring-mode=infra-only` and a Debug log line confirming the override
 

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
@@ -76,8 +76,7 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 - [x] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})` returns `{"fullstack"}`
 - [x] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only"}`
 - [x] 2.5.9 Unit test — **default constant matches flag default**: `DefaultAgentConfig().MonitoringMode == "fullstack"` (documents that the struct default and the CLI flag default are in sync)
-- [ ] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring-mode` and `override_set` field values
-- [ ] 2.5.11 Manual: `dtwiz install oneagent --oneagent-poc --monitoring-mode=infra-only --dry-run --debug` produces a dry-run command containing `--set-monitoring-mode=infra-only` and a Debug log line confirming the override
+- [x] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring-mode` and `override_set` field values
 
 ---
 

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
@@ -52,8 +52,8 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 
 **Goals:**
 
-- **Default path** — when no flag is passed, `ResolveAgentConfig` returns `{MonitoringMode: "fullstack", AppLogContentAccess: true}` exactly. This is the zero-config default for OneAgent installs per `AGENTS.md`.
-- **Override path** — when `--monitoring-mode <value>` is passed (or `opts.MonitoringMode != ""`), the field is overridden. No allow-list — the value is passed through verbatim to the installer's `--set-monitoring-mode=<value>` flag in Task 6. `AppLogContentAccess` stays `true` regardless (no flag exposed yet; can be added later if needed).
+- **Default path** — when no flag is passed, `ResolveAgentConfig` returns `{MonitoringMode: "fullstack"}` exactly. This is the zero-config default for OneAgent installs per `AGENTS.md`.
+- **Override path** — when `--monitoring-mode <value>` is passed (or `opts.MonitoringMode != ""`), the field is overridden. No allow-list — the value is passed through verbatim to the installer's `--set-monitoring-mode=<value>` flag in Task 6.
 
 **Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1), `cmd/install.go` (modify — wire `--monitoring-mode`)
 
@@ -61,21 +61,20 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 
   ```go
   type AgentConfig struct {
-      MonitoringMode      string // installer flag: --set-monitoring-mode
-      AppLogContentAccess bool   // installer flag: --set-app-log-content-access
+      MonitoringMode string // installer flag: --set-monitoring-mode
   }
   ```
 
-- [x] 2.5.2 Implement `DefaultAgentConfig() AgentConfig` returning `{MonitoringMode: "fullstack", AppLogContentAccess: true}` — this is the canonical zero-config default and the only construction path callers should use
+- [x] 2.5.2 Implement `DefaultAgentConfig() AgentConfig` returning `{MonitoringMode: "fullstack"}` — this is the canonical zero-config default and the only construction path callers should use
 - [x] 2.5.3 Implement `ResolveAgentConfig(opts InstallOptions) AgentConfig`:
   - Start with `DefaultAgentConfig()`
   - Always assign `cfg.MonitoringMode = opts.MonitoringMode` (no validation, pass-through; CLI default guarantees it is never empty)
   - Return the resolved config
 - [x] 2.5.4 `MonitoringMode string` already present in `InstallOptions` (no change needed)
 - [x] 2.5.5 `--monitoring-mode` flag already wired on `installOneAgentCmd` with default `"fullstack"` (no change needed)
-- [x] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring_mode", cfg.MonitoringMode, "app_log_content_access", cfg.AppLogContentAccess, "override_set", opts.MonitoringMode != "fullstack")` once the config is resolved
-- [x] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})` returns exactly `{"fullstack", true}`
-- [x] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only", true}`
+- [x] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring_mode", cfg.MonitoringMode, "override_set", opts.MonitoringMode != "fullstack")` once the config is resolved
+- [x] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})` returns `{"fullstack"}`
+- [x] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only"}`
 - [x] 2.5.9 Unit test — **default constant matches flag default**: `DefaultAgentConfig().MonitoringMode == "fullstack"` (documents that the struct default and the CLI flag default are in sync)
 - [ ] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring_mode` and `override_set` field values
 - [ ] 2.5.11 Manual: `dtwiz install oneagent --oneagent-poc --monitoring-mode=infra-only --dry-run --debug` produces a dry-run command containing `--set-monitoring-mode=infra-only` and a Debug log line confirming the override

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
@@ -72,11 +72,11 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
   - Return the resolved config
 - [x] 2.5.4 `MonitoringMode string` already present in `InstallOptions` (no change needed)
 - [x] 2.5.5 `--monitoring-mode` flag already wired on `installOneAgentCmd` with default `"fullstack"` (no change needed)
-- [x] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring_mode", cfg.MonitoringMode, "override_set", opts.MonitoringMode != "fullstack")` once the config is resolved
+- [x] 2.5.6 Emit `logger.Debug("resolved agent config", "monitoring-mode", cfg.MonitoringMode, "override_set", opts.MonitoringMode != "fullstack")` once the config is resolved
 - [x] 2.5.7 Unit test — **default path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})` returns `{"fullstack"}`
 - [x] 2.5.8 Unit test — **override path**: `cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})` returns `{"infra-only"}`
 - [x] 2.5.9 Unit test — **default constant matches flag default**: `DefaultAgentConfig().MonitoringMode == "fullstack"` (documents that the struct default and the CLI flag default are in sync)
-- [ ] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring_mode` and `override_set` field values
+- [ ] 2.5.10 Unit test — **debug log captures both default and override paths**: with `--debug`, run the function twice (default + override) and assert two separate `"resolved agent config"` Debug lines appear with the correct `monitoring-mode` and `override_set` field values
 - [ ] 2.5.11 Manual: `dtwiz install oneagent --oneagent-poc --monitoring-mode=infra-only --dry-run --debug` produces a dry-run command containing `--set-monitoring-mode=infra-only` and a Debug log line confirming the override
 
 ---

--- a/openspec/changes/oneagent-init/design.md
+++ b/openspec/changes/oneagent-init/design.md
@@ -66,8 +66,7 @@ type Environment struct {
 }
 
 type AgentConfig struct {
-    MonitoringMode      string
-    AppLogContentAccess bool
+    MonitoringMode string
 }
 
 type InstallOptions struct {
@@ -112,7 +111,7 @@ All new flags are added to the `installOneAgentCmd` Cobra command definition (no
 | `--connectivity-check-only` | bool | `false` |
 | `--print-endpoints` | bool | `false` |
 
-Pre-existing flags (`--dry-run`, `--quiet`) remain unchanged on their current parent command.
+ Pre-existing flags (`--dry-run`, `--quiet`, `--host-group`) remain unchanged on their current parent command(s). `--host-group` continues to apply to the existing v1 installer flow; the v2 scaffolding in this change does not model it in `InstallOptions` yet.
 
 ### 5. InstallOptions struct from CLI
 

--- a/openspec/changes/oneagent-init/design.md
+++ b/openspec/changes/oneagent-init/design.md
@@ -71,15 +71,13 @@ type AgentConfig struct {
 }
 
 type InstallOptions struct {
-    DryRun                 bool
-    Force                  bool
-    MonitoringMode         string
-    NoVerifySignature      bool
-    SkipConnectivityCheck  bool
-    ConnectivityCheckOnly  bool
-    PrintEndpoints         bool
-    HostGroup              string
-    Quiet                  bool
+    DryRun                bool
+    MonitoringMode        string
+    NoVerifySignature     bool
+    SkipConnectivityCheck bool
+    ConnectivityCheckOnly bool
+    PrintEndpoints        bool
+    Quiet                 bool
 }
 
 type Endpoint struct {
@@ -108,14 +106,13 @@ All new flags are added to the `installOneAgentCmd` Cobra command definition (no
 
 | Flag | Type | Default |
 |---|---|---|
-| `--force` | bool | `false` |
 | `--monitoring-mode` | string | `"fullstack"` |
 | `--no-verify-signature` | bool | `false` |
 | `--skip-connectivity-check` | bool | `false` |
 | `--connectivity-check-only` | bool | `false` |
 | `--print-endpoints` | bool | `false` |
 
-Pre-existing flags (`--dry-run`, `--quiet`, `--host-group`) remain unchanged on their current parent command.
+Pre-existing flags (`--dry-run`, `--quiet`) remain unchanged on their current parent command.
 
 ### 5. InstallOptions struct from CLI
 
@@ -123,15 +120,13 @@ Pre-existing flags (`--dry-run`, `--quiet`, `--host-group`) remain unchanged on 
 
 ```go
 opts := installer.InstallOptions{
-    DryRun:                 installDryRun,
-    Force:                  flagForce,
-    MonitoringMode:         flagMonitoringMode,
-    NoVerifySignature:      flagNoVerifySignature,
-    SkipConnectivityCheck:  flagSkipConnectivityCheck,
-    ConnectivityCheckOnly:  flagConnectivityCheckOnly,
-    PrintEndpoints:         flagPrintEndpoints,
-    HostGroup:              hostGroup,
-    Quiet:                  quiet,
+    DryRun:                installDryRun,
+    MonitoringMode:        flagMonitoringMode,
+    NoVerifySignature:     flagNoVerifySignature,
+    SkipConnectivityCheck: flagSkipConnectivityCheck,
+    ConnectivityCheckOnly: flagConnectivityCheckOnly,
+    PrintEndpoints:        flagPrintEndpoints,
+    Quiet:                 quiet,
 }
 ```
 

--- a/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
@@ -89,7 +89,7 @@ New flags SHALL be defined on `installOneAgentCmd` (not on the parent `installCm
 
 | Flag | Type | Default | Purpose | Task |
 |---|---|---|---|---|
-| `--monitoring-mode` | string | `"fullstack"` | Passed through as `--set-monitoring-mode` | 2 |
+| `--monitoring-mode` | string | `"fullstack"` | Passed through as `--set-monitoring-mode`; value is not validated — the caller is responsible for passing a value that OneAgent accepts | 2 |
 | `--no-verify-signature` | bool | `false` | Skip Linux signature verification | 5 |
 | `--skip-connectivity-check` | bool | `false` | Skip connectivity probe | 9 |
 | `--connectivity-check-only` | bool | `false` | Run only probe, then exit | 9 |

--- a/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
@@ -89,19 +89,18 @@ New flags SHALL be defined on `installOneAgentCmd` (not on the parent `installCm
 
 | Flag | Type | Default | Purpose | Task |
 |---|---|---|---|---|
-| `--force` | bool | `false` | Override existing-OneAgent preflight | 2 |
 | `--monitoring-mode` | string | `"fullstack"` | Passed through as `--set-monitoring-mode` | 2 |
 | `--no-verify-signature` | bool | `false` | Skip Linux signature verification | 5 |
 | `--skip-connectivity-check` | bool | `false` | Skip connectivity probe | 9 |
 | `--connectivity-check-only` | bool | `false` | Run only probe, then exit | 9 |
 | `--print-endpoints` | bool | `false` | Print resolved endpoints, then exit | 9 |
 
-Pre-existing flags (`--dry-run`, `--quiet`, `--host-group`) remain unchanged.
+Pre-existing flags (`--dry-run`, `--quiet`) remain unchanged.
 
 #### Scenario: Flags are available on install-oneagent subcommand
 
 - **GIVEN** `--help` text is displayed for `dtwiz install oneagent`
-- **THEN** the flag list includes `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
+- **THEN** the flag list includes `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
 
 ### Requirement: InstallOptions struct carries all CLI-derived inputs
 
@@ -109,15 +108,13 @@ Pre-existing flags (`--dry-run`, `--quiet`, `--host-group`) remain unchanged.
 
 ```go
 type InstallOptions struct {
-    DryRun                 bool
-    Force                  bool
-    MonitoringMode         string
-    NoVerifySignature      bool
-    SkipConnectivityCheck  bool
-    ConnectivityCheckOnly  bool
-    PrintEndpoints         bool
-    HostGroup              string
-    Quiet                  bool
+    DryRun                bool
+    MonitoringMode        string
+    NoVerifySignature     bool
+    SkipConnectivityCheck bool
+    ConnectivityCheckOnly bool
+    PrintEndpoints        bool
+    Quiet                 bool
 }
 ```
 

--- a/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
@@ -28,7 +28,7 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 
 - [x] 1.5 Create `pkg/installer/oneagent_v2.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
 - [x] 1.6 Define `InstallOptions` struct carrying `DryRun`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `Quiet`
-- [x] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that returns `errors.New("oneagent v2 not yet implemented")`
+- [x] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that prints a "under development" warning and returns `nil` (not an error, to avoid showing help output in the setup flow)
 - [x] 1.8 Add stub function signatures (not implemented) for: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
 - [x] 1.9 Ensure code compiles with `go build ./...`
 
@@ -57,4 +57,4 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 
 - [x] 1.17 Add a comment marking the branching point: `// Task 1 — feature-flag branching; remove at Task 8`
 - [x] 1.18 Verify existing `InstallOneAgent` call path is unchanged when the flag is disabled (default)
-- [x] 1.19 Integration test: with `DTWIZ_ONEAGENT_POC=true`, verify `InstallOneAgentV2` is called (and returns "not yet implemented")
+- [x] 1.19 Integration test: with `DTWIZ_ONEAGENT_POC=true`, verify `InstallOneAgentV2` is called (prints "under development" warning and returns `nil`; setup flow skips `WatchIngest`)

--- a/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
@@ -6,10 +6,10 @@ Before implementing, review the design and spec documents to understand the requ
 
 **Files:** `design.md`, `spec.md`
 
-- [ ] 0.1 Read `design.md` and `spec.md` to understand the scaffolding strategy and requirements
-- [ ] 0.2 Identify and document any unclear assumptions about type definitions or feature-flag behavior
-- [ ] 0.3 Verify that the feature-flag implementation pattern matches existing flags in `pkg/featureflags/featureflags.go`
-- [ ] 0.4 Confirm that the CLI flag structure and defaults align with the specification
+- [x] 0.1 Read `design.md` and `spec.md` to understand the scaffolding strategy and requirements
+- [x] 0.2 Identify and document any unclear assumptions about type definitions or feature-flag behavior
+- [x] 0.3 Verify that the feature-flag implementation pattern matches existing flags in `pkg/featureflags/featureflags.go`
+- [x] 0.4 Confirm that the CLI flag structure and defaults align with the specification
 
 ## 1. Scaffolding and Feature Flag
 
@@ -19,34 +19,34 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 
 ### Feature Flag
 
-- [ ] 1.1 Add `OneAgentPoC` constant to the flag enum in `pkg/featureflags/featureflags.go`
-- [ ] 1.2 Add a registry entry for `ONEAGENT_POC` with env var `DTWIZ_ONEAGENT_POC`, default `false`
-- [ ] 1.3 Unit test: `IsEnabled(featureflags.OneAgentPoC)` returns `false` by default
-- [ ] 1.4 Unit test: set `DTWIZ_ONEAGENT_POC=true` and verify `IsEnabled` returns `true`
+- [x] 1.1 Add `OneAgentPoC` constant to the flag enum in `pkg/featureflags/featureflags.go`
+- [x] 1.2 Add a registry entry for `ONEAGENT_POC` with env var `DTWIZ_ONEAGENT_POC`, default `false`
+- [x] 1.3 Unit test: `IsEnabled(featureflags.OneAgentPoC)` returns `false` by default
+- [x] 1.4 Unit test: set `DTWIZ_ONEAGENT_POC=true` and verify `IsEnabled` returns `true`
 
 ### Scaffolding: pkg/installer/oneagent_v2.go
 
-- [ ] 1.5 Create `pkg/installer/oneagent_v2.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
-- [ ] 1.6 Define `InstallOptions` struct carrying `DryRun`, `Force`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `HostGroup`, `Quiet`
-- [ ] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that returns `errors.New("oneagent v2 not yet implemented")`
-- [ ] 1.8 Add stub function signatures (not implemented) for: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
-- [ ] 1.9 Ensure code compiles with `go build ./...`
+- [x] 1.5 Create `pkg/installer/oneagent_v2.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
+- [x] 1.6 Define `InstallOptions` struct carrying `DryRun`, `Force`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `HostGroup`, `Quiet`
+- [x] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that returns `errors.New("oneagent v2 not yet implemented")`
+- [x] 1.8 Add stub function signatures (not implemented) for: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
+- [x] 1.9 Ensure code compiles with `go build ./...`
 
 ### Scaffolding: pkg/installer/oneagent_v2_test.go
 
-- [ ] 1.10 Create `pkg/installer/oneagent_v2_test.go` with skeleton structure
-- [ ] 1.11 Add test helper functions for mocking HTTP responses (placeholder comments for Tasks 2–7)
-- [ ] 1.12 Ensure tests compile with `go test ./... -v` (mark pending tests with `t.Skip()` if needed)
+- [x] 1.10 Create `pkg/installer/oneagent_v2_test.go` with skeleton structure
+- [x] 1.11 Add test helper functions for mocking HTTP responses (placeholder comments for Tasks 2–7)
+- [x] 1.12 Ensure tests compile with `go test ./... -v` (mark pending tests with `t.Skip()` if needed)
 
 ### CLI Flags
 
-- [ ] 1.13 Add flag definitions on `installOneAgentCmd`: `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
-- [ ] 1.14 Each flag is properly documented in the cobra command definition
-- [ ] 1.15 Unit test: flags parse correctly from the command line
+- [x] 1.13 Add flag definitions on `installOneAgentCmd`: `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
+- [x] 1.14 Each flag is properly documented in the cobra command definition
+- [x] 1.15 Unit test: flags parse correctly from the command line
 
 ### Feature-Flag Branching
 
-- [ ] 1.16 In `cmd/install.go`'s `installOneAgentCmd.RunE`, add branching:
+- [x] 1.16 In `cmd/install.go`'s `installOneAgentCmd.RunE`, add branching:
 
   ```go
   if featureflags.IsEnabled(featureflags.OneAgentPoC) {
@@ -55,6 +55,6 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
   return installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup)
   ```
 
-- [ ] 1.17 Add a comment marking the branching point: `// Task 1 — feature-flag branching; remove at Task 8`
-- [ ] 1.18 Verify existing `InstallOneAgent` call path is unchanged when the flag is disabled (default)
-- [ ] 1.19 Integration test: with `DTWIZ_ONEAGENT_POC=true`, verify `InstallOneAgentV2` is called (and returns "not yet implemented")
+- [x] 1.17 Add a comment marking the branching point: `// Task 1 — feature-flag branching; remove at Task 8`
+- [x] 1.18 Verify existing `InstallOneAgent` call path is unchanged when the flag is disabled (default)
+- [x] 1.19 Integration test: with `DTWIZ_ONEAGENT_POC=true`, verify `InstallOneAgentV2` is called (and returns "not yet implemented")

--- a/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
@@ -27,7 +27,7 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 ### Scaffolding: pkg/installer/oneagent_v2.go
 
 - [x] 1.5 Create `pkg/installer/oneagent_v2.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
-- [x] 1.6 Define `InstallOptions` struct carrying `DryRun`, `Force`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `HostGroup`, `Quiet`
+- [x] 1.6 Define `InstallOptions` struct carrying `DryRun`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `Quiet`
 - [x] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that returns `errors.New("oneagent v2 not yet implemented")`
 - [x] 1.8 Add stub function signatures (not implemented) for: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
 - [x] 1.9 Ensure code compiles with `go build ./...`
@@ -40,7 +40,7 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 
 ### CLI Flags
 
-- [x] 1.13 Add flag definitions on `installOneAgentCmd`: `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
+- [x] 1.13 Add flag definitions on `installOneAgentCmd`: `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints`
 - [x] 1.14 Each flag is properly documented in the cobra command definition
 - [x] 1.15 Unit test: flags parse correctly from the command line
 

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -13,6 +13,7 @@ type Flag int
 
 const (
 	AllRuntimes Flag = iota
+	OneAgentPoC
 )
 
 // CLIFeatureFlag defines a single feature flag with its metadata.
@@ -32,6 +33,14 @@ var registry = []CLIFeatureFlag{
 		"DTWIZ_ALL_RUNTIMES",
 		false,
 		"enable all runtimes for OTel auto-instrumentation",
+		false,
+	},
+	{
+		OneAgentPoC,
+		"oneagent-poc",
+		"DTWIZ_ONEAGENT_POC",
+		false,
+		"enable the new OneAgent PoC installer flow (development only)",
 		false,
 	},
 }

--- a/pkg/featureflags/featureflags_test.go
+++ b/pkg/featureflags/featureflags_test.go
@@ -62,6 +62,20 @@ func TestIsEnabled_UnknownFlag(t *testing.T) {
 	}
 }
 
+func TestIsEnabled_OneAgentPoC_DefaultFalse(t *testing.T) {
+	t.Setenv("DTWIZ_ONEAGENT_POC", "")
+	if IsEnabled(OneAgentPoC) {
+		t.Error("expected OneAgentPoC to be disabled by default")
+	}
+}
+
+func TestIsEnabled_OneAgentPoC_EnvTrue(t *testing.T) {
+	t.Setenv("DTWIZ_ONEAGENT_POC", "true")
+	if !IsEnabled(OneAgentPoC) {
+		t.Error("expected OneAgentPoC to be enabled with DTWIZ_ONEAGENT_POC=true")
+	}
+}
+
 func TestSetCLIOverrideForTest_OverridesAndRestores(t *testing.T) {
 	t.Setenv("DTWIZ_ALL_RUNTIMES", "")
 

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -28,10 +28,12 @@ func DefaultAgentConfig() AgentConfig {
 
 func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 	cfg := DefaultAgentConfig()
-	cfg.MonitoringMode = opts.MonitoringMode
+	if opts.MonitoringMode != "" {
+		cfg.MonitoringMode = opts.MonitoringMode
+	}
 	logger.Debug("resolved agent config",
 		"monitoring-mode", cfg.MonitoringMode,
-		"override_set", opts.MonitoringMode != string(InstallModeFullStack),
+		"override_set", cfg.MonitoringMode != string(InstallModeFullStack),
 	)
 	return cfg
 }

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -1,6 +1,8 @@
 package installer
 
 import (
+	"fmt"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
@@ -35,6 +37,6 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 }
 
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
-	display.PrintStatusLine("oneagent", "under development — set DTWIZ_ONEAGENT_POC=false to use the stable installer", display.ColorWarning)
+	display.PrintStatusLine("oneagent", fmt.Sprintf("under development (monitoring-mode=%s) — set DTWIZ_ONEAGENT_POC=false to use the stable installer", opts.MonitoringMode), display.ColorWarning)
 	return nil
 }

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -1,0 +1,50 @@
+package installer
+
+import (
+	"errors"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
+)
+
+// InstallOptions carries all CLI-derived inputs for the v2 installer flow.
+type InstallOptions struct {
+	DryRun                bool
+	Force                 bool
+	MonitoringMode        string
+	NoVerifySignature     bool
+	SkipConnectivityCheck bool
+	ConnectivityCheckOnly bool
+	PrintEndpoints        bool
+	HostGroup             string
+	Quiet                 bool
+}
+
+// AgentConfig holds OneAgent configuration resolved from CLI options.
+type AgentConfig struct {
+	MonitoringMode string // installer flag: --set-monitoring-mode
+}
+
+// DefaultAgentConfig returns the canonical zero-config defaults for a OneAgent install.
+func DefaultAgentConfig() AgentConfig {
+	return AgentConfig{MonitoringMode: "fullstack"}
+}
+
+// ResolveAgentConfig builds the agent configuration from CLI options.
+// Callers should always go through this function rather than constructing AgentConfig directly.
+func ResolveAgentConfig(opts InstallOptions) AgentConfig {
+	cfg := DefaultAgentConfig()
+	cfg.MonitoringMode = opts.MonitoringMode
+	logger.Debug("resolved agent config",
+		"monitoring_mode", cfg.MonitoringMode,
+		"override_set", opts.MonitoringMode != "fullstack",
+	)
+	return cfg
+}
+
+// InstallOneAgentV2 is the entry point for the new OneAgent installer flow.
+func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
+	display.PrintStatusLine("oneagent", "under development — set DTWIZ_ONEAGENT_POC=false to use the stable installer", display.ColorWarning)
+	return errors.New("oneagent v2 not yet implemented")
+}

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -1,8 +1,6 @@
 package installer
 
 import (
-	"errors"
-
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
@@ -46,5 +44,5 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 // InstallOneAgentV2 is the entry point for the new OneAgent installer flow.
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 	display.PrintStatusLine("oneagent", "under development — set DTWIZ_ONEAGENT_POC=false to use the stable installer", display.ColorWarning)
-	return errors.New("oneagent v2 not yet implemented")
+	return nil
 }

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
-// InstallOptions carries all CLI-derived inputs for the v2 installer flow.
 type InstallOptions struct {
 	DryRun                bool
 	MonitoringMode        string
@@ -17,18 +16,14 @@ type InstallOptions struct {
 	Quiet                 bool
 }
 
-// AgentConfig holds OneAgent configuration resolved from CLI options.
 type AgentConfig struct {
-	MonitoringMode string // installer flag: --set-monitoring-mode
+	MonitoringMode string
 }
 
-// DefaultAgentConfig returns the canonical zero-config defaults for a OneAgent install.
 func DefaultAgentConfig() AgentConfig {
 	return AgentConfig{MonitoringMode: "fullstack"}
 }
 
-// ResolveAgentConfig builds the agent configuration from CLI options.
-// Callers should always go through this function rather than constructing AgentConfig directly.
 func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 	cfg := DefaultAgentConfig()
 	cfg.MonitoringMode = opts.MonitoringMode
@@ -39,7 +34,6 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 	return cfg
 }
 
-// InstallOneAgentV2 is the entry point for the new OneAgent installer flow.
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 	display.PrintStatusLine("oneagent", "under development — set DTWIZ_ONEAGENT_POC=false to use the stable installer", display.ColorWarning)
 	return nil

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -9,13 +9,11 @@ import (
 // InstallOptions carries all CLI-derived inputs for the v2 installer flow.
 type InstallOptions struct {
 	DryRun                bool
-	Force                 bool
 	MonitoringMode        string
 	NoVerifySignature     bool
 	SkipConnectivityCheck bool
 	ConnectivityCheckOnly bool
 	PrintEndpoints        bool
-	HostGroup             string
 	Quiet                 bool
 }
 

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -23,20 +23,20 @@ type AgentConfig struct {
 }
 
 func DefaultAgentConfig() AgentConfig {
-	return AgentConfig{MonitoringMode: "fullstack"}
+	return AgentConfig{MonitoringMode: string(InstallModeFullStack)}
 }
 
 func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 	cfg := DefaultAgentConfig()
 	cfg.MonitoringMode = opts.MonitoringMode
 	logger.Debug("resolved agent config",
-		"monitoring_mode", cfg.MonitoringMode,
-		"override_set", opts.MonitoringMode != "fullstack",
+		"monitoring-mode", cfg.MonitoringMode,
+		"override_set", opts.MonitoringMode != string(InstallModeFullStack),
 	)
 	return cfg
 }
 
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
-	display.PrintStatusLine("oneagent", fmt.Sprintf("under development (monitoring-mode=%s) — set DTWIZ_ONEAGENT_POC=false to use the stable installer", opts.MonitoringMode), display.ColorWarning)
+	display.PrintStatusLine("oneagent", fmt.Sprintf("under development (monitoring-mode=%s) — use --oneagent-poc=false or set DTWIZ_ONEAGENT_POC=false to use the stable installer", opts.MonitoringMode), display.ColorWarning)
 	return nil
 }

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -1,0 +1,63 @@
+package installer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
+)
+
+func newMockTenantServer(t *testing.T, path string, status int, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	return httptest.NewServer(mux)
+}
+
+func newMockClient(t *testing.T, serverURL string) *client.Client {
+	t.Helper()
+	c, err := client.New(serverURL, "dt0c01.testtoken", serverURL, "dt0s16.testtoken", 0)
+	if err != nil {
+		t.Fatalf("newMockClient: %v", err)
+	}
+	return c
+}
+
+func TestDefaultAgentConfig(t *testing.T) {
+	cfg := DefaultAgentConfig()
+	if cfg.MonitoringMode != "fullstack" {
+		t.Errorf("expected MonitoringMode fullstack, got %q", cfg.MonitoringMode)
+	}
+}
+
+func TestResolveAgentConfig_Default(t *testing.T) {
+	cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "fullstack"})
+	if cfg.MonitoringMode != "fullstack" {
+		t.Errorf("expected MonitoringMode fullstack, got %q", cfg.MonitoringMode)
+	}
+}
+
+func TestResolveAgentConfig_Override(t *testing.T) {
+	cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})
+	if cfg.MonitoringMode != "infra-only" {
+		t.Errorf("expected MonitoringMode infra-only, got %q", cfg.MonitoringMode)
+	}
+}
+
+func TestInstallOneAgentV2_ReturnsNotImplemented(t *testing.T) {
+	srv := newMockTenantServer(t, "/", http.StatusOK, `{}`)
+	defer srv.Close()
+
+	c := newMockClient(t, srv.URL)
+	err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"})
+	if err == nil {
+		t.Fatal("expected error from stub, got nil")
+	}
+	if err.Error() != "oneagent v2 not yet implemented" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -48,16 +48,12 @@ func TestResolveAgentConfig_Override(t *testing.T) {
 	}
 }
 
-func TestInstallOneAgentV2_ReturnsNotImplemented(t *testing.T) {
+func TestInstallOneAgentV2_ExitsCleanly(t *testing.T) {
 	srv := newMockTenantServer(t, "/", http.StatusOK, `{}`)
 	defer srv.Close()
 
 	c := newMockClient(t, srv.URL)
-	err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"})
-	if err == nil {
-		t.Fatal("expected error from stub, got nil")
-	}
-	if err.Error() != "oneagent v2 not yet implemented" {
-		t.Errorf("unexpected error: %v", err)
+	if err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"}); err != nil {
+		t.Errorf("expected clean exit, got error: %v", err)
 	}
 }

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -1,8 +1,11 @@
 package installer
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
@@ -45,6 +48,28 @@ func TestResolveAgentConfig_Override(t *testing.T) {
 	cfg := ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})
 	if cfg.MonitoringMode != "infra-only" {
 		t.Errorf("expected MonitoringMode infra-only, got %q", cfg.MonitoringMode)
+	}
+}
+
+func TestResolveAgentConfig_DebugLog(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	ResolveAgentConfig(InstallOptions{})
+	ResolveAgentConfig(InstallOptions{MonitoringMode: "infra-only"})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 debug lines, got %d:\n%s", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "resolved agent config") || !strings.Contains(lines[0], "monitoring-mode=fullstack") || !strings.Contains(lines[0], "override_set=false") {
+		t.Errorf("default path: unexpected log line: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "resolved agent config") || !strings.Contains(lines[1], "monitoring-mode=infra-only") || !strings.Contains(lines[1], "override_set=true") {
+		t.Errorf("override path: unexpected log line: %s", lines[1])
 	}
 }
 


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Initial scaffolding for the OneAgent v2 installer, gated behind the DTWIZ_ONEAGENT_POC feature flag. Adds new CLI flags (--monitoring-mode, --no-verify-signature, --skip-connectivity-check, --connectivity-check-only, --print-endpoints), updates InstallOptions accordingly, and stubs out the v2 code path with a placeholder. The setup and install oneagent commands branch to v2 when the flag is set. Spec and design docs updated to match.

## How to test
1. open terminal on your device
2. go to the linux machine using https://secretserver.dynatrace.org/app/#/secrets/50110/general
3. use the install command from this PR
4. set up env variables (DT_ENVIRONMENT, etc)
5. set the feature flag to true: `export DTWIZ_ONEAGENT_POC="true"`
6. when you run both `dtwiz setup` and `dtwiz install oneagent` you should see `under development — set DTWIZ_ONEAGENT_POC=false to use the stable installer`
7. if you run with `dtwiz install oneagent --monitoring-mode=free` - you see the output: `  oneagent:  under development (monitoring-mode=free) — set DTWIZ_ONEAGENT_POC=false to use the stable installer`
8. turn the feature flag off `unset DTWIZ_ONEAGENT_POC`
9. test 6-7 again, the installer should fail due to 403 issue (the installer can't be downloaded due to firewall settings)

## Which other features are affected?
1. v1 one agent install

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
