### PR TITLE
feat: skip ingest watch when installation is cancelled by user

### DIFF
--- a/cmd/cancel_test.go
+++ b/cmd/cancel_test.go
@@ -1,46 +1,15 @@
 package cmd
 
 import (
-	"errors"
 	"testing"
-
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 )
-
-// applyInstallCancelGuard models the guard pattern used in every install/update/
-// uninstall subcommand RunE: ErrInstallCancelled is treated as a clean nil exit;
-// all other errors are propagated unchanged.
-func applyInstallCancelGuard(err error) error {
-	if errors.Is(err, installer.ErrInstallCancelled) {
-		return nil
-	}
-	return err
-}
-
-func TestInstallCancelledGuard_ReturnNilOnCancelled(t *testing.T) {
-	got := applyInstallCancelGuard(installer.ErrInstallCancelled)
-	if got != nil {
-		t.Errorf("expected nil, got %v", got)
-	}
-}
-
-func TestInstallCancelledGuard_PropagatesOtherErrors(t *testing.T) {
-	other := errors.New("real failure")
-	got := applyInstallCancelGuard(other)
-	if got != other {
-		t.Errorf("expected original error to be propagated, got %v", got)
-	}
-}
-
-func TestInstallCancelledGuard_NilPassesThrough(t *testing.T) {
-	got := applyInstallCancelGuard(nil)
-	if got != nil {
-		t.Errorf("expected nil, got %v", got)
-	}
-}
 
 // TestInstallCmd_CancelledSubcommands verifies each install subcommand that
 // carries a ErrInstallCancelled guard is actually registered.
+//
+// Note: these tests verify command registration (structural wiring), not that
+// the guard is present in RunE. Testing the real RunE paths requires injectable
+// installer dependencies; that is tracked as a separate refactor.
 func TestInstallCmd_CancelledSubcommands(t *testing.T) {
 	guarded := []string{
 		"kubernetes",
@@ -49,6 +18,7 @@ func TestInstallCmd_CancelledSubcommands(t *testing.T) {
 		"otel-python",
 		"otel-node",
 		"otel-java",
+		"aws",
 		"aws-lambda",
 		"demo",
 	}

--- a/cmd/cancel_test.go
+++ b/cmd/cancel_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+)
+
+// applyInstallCancelGuard models the guard pattern used in every install/update/
+// uninstall subcommand RunE: ErrInstallCancelled is treated as a clean nil exit;
+// all other errors are propagated unchanged.
+func applyInstallCancelGuard(err error) error {
+	if errors.Is(err, installer.ErrInstallCancelled) {
+		return nil
+	}
+	return err
+}
+
+func TestInstallCancelledGuard_ReturnNilOnCancelled(t *testing.T) {
+	got := applyInstallCancelGuard(installer.ErrInstallCancelled)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestInstallCancelledGuard_PropagatesOtherErrors(t *testing.T) {
+	other := errors.New("real failure")
+	got := applyInstallCancelGuard(other)
+	if got != other {
+		t.Errorf("expected original error to be propagated, got %v", got)
+	}
+}
+
+func TestInstallCancelledGuard_NilPassesThrough(t *testing.T) {
+	got := applyInstallCancelGuard(nil)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// TestInstallCmd_CancelledSubcommands verifies each install subcommand that
+// carries a ErrInstallCancelled guard is actually registered.
+func TestInstallCmd_CancelledSubcommands(t *testing.T) {
+	guarded := []string{
+		"kubernetes",
+		"otel",
+		"otel-collector",
+		"otel-python",
+		"otel-node",
+		"otel-java",
+		"aws-lambda",
+		"demo",
+	}
+	registered := map[string]bool{}
+	for _, c := range installCmd.Commands() {
+		registered[c.Use] = true
+	}
+	for _, name := range guarded {
+		if !registered[name] {
+			t.Errorf("expected install subcommand %q to be registered", name)
+		}
+	}
+}
+
+// TestUpdateCmd_OtelCancelledSubcommand verifies the update otel subcommand is
+// registered and its RunE will not propagate ErrInstallCancelled.
+func TestUpdateCmd_OtelCancelledSubcommand(t *testing.T) {
+	found := false
+	for _, c := range updateCmd.Commands() {
+		if c.Use == "otel" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected update otel subcommand to be registered")
+	}
+}
+
+// TestUninstallCmd_AWSLambdaCancelledSubcommand verifies the uninstall
+// aws-lambda subcommand is registered.
+func TestUninstallCmd_AWSLambdaCancelledSubcommand(t *testing.T) {
+	found := false
+	for _, c := range uninstallCmd.Commands() {
+		if c.Use == "aws-lambda" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected uninstall aws-lambda subcommand to be registered")
+	}
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
@@ -59,6 +61,9 @@ var installKubernetesCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallKubernetes(envURL, accessTok, accessTok, "", installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -103,6 +108,9 @@ var installOtelCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallOtelCollectorWithProject(envURL, accessTok, accessTok, platformTok, otelProject, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -125,6 +133,9 @@ var installOtelCollectorCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallOtelCollectorOnly(envURL, accessTok, accessTok, platformTok, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -149,6 +160,9 @@ var installOtelPythonCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallOtelPython(envURL, accessTok, platformTok, otelPythonServiceName, otelProject, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -171,7 +185,13 @@ var installOtelNodeCmd = &cobra.Command{
 		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
 			return err
 		}
-		return installer.InstallOtelNode(envURL, accessTok, platformTok, otelNodeServiceName, otelProject, installDryRun)
+		if err := installer.InstallOtelNode(envURL, accessTok, platformTok, otelNodeServiceName, otelProject, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	},
 }
 
@@ -189,6 +209,9 @@ var installOtelJavaCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallOtelJava(envURL, accessTok, otelJavaServiceName, otelProject, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -234,6 +257,9 @@ var installAWSLambdaCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallAWSLambda(envURL, accessTok, platformTok, installDryRun, true); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {
@@ -274,6 +300,9 @@ var installDemoCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallDemo(envURL, accessTok, platformTok, installDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		if !installDryRun {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -238,6 +238,9 @@ var installAWSCmd = &cobra.Command{
 			return err
 		}
 		if err := installer.InstallAWS(c.Platform, envURL, accessTok, platformTok, installDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z")); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return err
 		}
 		return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -98,6 +99,9 @@ var setupCmd = &cobra.Command{
 				return err
 			}
 			if err := installer.InstallDemo(envURL, accessTok, platformTok, setupDryRun); err != nil {
+				if errors.Is(err, installer.ErrInstallCancelled) {
+					return nil
+				}
 				return err
 			}
 			if !setupDryRun {
@@ -150,6 +154,9 @@ var setupCmd = &cobra.Command{
 			return fmt.Errorf("unsupported method: %s", selected.Method)
 		}
 		if installErr != nil {
+			if errors.Is(installErr, installer.ErrInstallCancelled) {
+				return nil
+			}
 			return installErr
 		}
 		// AWS watch is started inside InstallAWS (runs in parallel with deploy).

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
@@ -61,7 +63,13 @@ var uninstallAWSLambdaCmd = &cobra.Command{
 	Short: "Remove Dynatrace Lambda Layer from all functions",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return installer.UninstallAWSLambda(uninstallDryRun)
+		if err := installer.UninstallAWSLambda(uninstallDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
+			return err
+		}
+		return nil // success path
 	},
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
@@ -31,7 +33,13 @@ var updateOtelCmd = &cobra.Command{
 		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
 			return err
 		}
-		return installer.UpdateOtelConfig(updateOtelConfigPath, envURL, accessTok, platformTok, updateDryRun)
+		if err := installer.UpdateOtelConfig(updateOtelConfigPath, envURL, accessTok, platformTok, updateDryRun); err != nil {
+			if errors.Is(err, installer.ErrInstallCancelled) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	},
 }
 

--- a/openspec/changes/ingest-watch/design.md
+++ b/openspec/changes/ingest-watch/design.md
@@ -14,6 +14,7 @@ The codebase already has DQL query infrastructure (`dqlResponse` struct, HTTP PO
 - Work as both a standalone `dtwiz watch` command and auto-triggered post-install
 - Show direct deep links to relevant Dynatrace apps for each data category
 - Gracefully degrade to non-live output when stdout is not a TTY
+- Exit cleanly when an install is cancelled and do not start post-install watch
 
 **Non-Goals:**
 
@@ -48,6 +49,10 @@ Strip prefix (`AWS_`, `K8S_`), replace `_` with space, lowercase, pluralize. Sim
 ### 6. `golang.org/x/term` for TTY detection
 
 Already an indirect dependency via `golang.org/x/sys`. Lightweight, stdlib-adjacent. Only used for `term.IsTerminal(int(os.Stdout.Fd()))`.
+
+### 7. Cancellation sentinel between installers and callers
+
+Installers return a shared cancellation sentinel when a user declines confirmation prompts. Command callers treat this sentinel as a clean, non-error exit and skip `WatchIngest()`. This prevents the setup/install flows from showing watch output after the user explicitly chose not to proceed.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/ingest-watch/proposal.md
+++ b/openspec/changes/ingest-watch/proposal.md
@@ -8,6 +8,7 @@ After installing a monitoring method, users have no visibility into whether data
 
 - New `dtwiz watch` standalone command that polls Dynatrace every 5 seconds and renders a live-updating terminal summary of ingested data
 - Each installer's success path calls `WatchIngest()` automatically so users see data flow immediately after installation
+- If a user declines an installation confirmation prompt, installers exit cleanly and `WatchIngest()` is not started
 - Seven data sections: Services, Cloud, Kubernetes, Relationships, Logs, Requests, Exceptions — each with counts, details, and deep links
 - Prominent QuickStart link always shown at the bottom
 - ANSI cursor-based in-place rendering (falls back to append-only if not a TTY)
@@ -25,6 +26,7 @@ After installing a monitoring method, users have no visibility into whether data
 
 - **New files**: `pkg/installer/ingest_watch.go`, `cmd/watch.go`
 - **Modified files**: Each installer file (`oneagent.go`, `kubernetes.go`, `docker.go`, `otel.go`, `aws.go`, etc.) gains a `WatchIngest()` call on success
+- **Modified files**: Installer and command layers additionally handle installer-cancelled flow so watch is skipped on user cancellation
 - **Dependencies**: Adds `golang.org/x/term` (already indirect via `golang.org/x/sys`)
 - **APIs**: Uses Dynatrace Platform DQL query API (`/platform/storage/query/v1/query:execute`) and Smartscape DQL commands (`smartscapeNodes`, `smartscapeEdges`)
 - **Auth**: Requires platform token (Bearer auth) for DQL queries

--- a/openspec/changes/ingest-watch/specs/ingest-watch/spec.md
+++ b/openspec/changes/ingest-watch/specs/ingest-watch/spec.md
@@ -18,8 +18,9 @@ The system SHALL provide a `dtwiz watch` command that polls the Dynatrace DQL AP
 
 #### Scenario: Watch does not start after cancelled install
 
-- **WHEN** the user selects `n` on the install confirmation prompt (`Proceed with installation?`)
-- **THEN** the installer exits cleanly
+- **WHEN** the user selects `n` on the install confirmation prompt for any installer (oneagent, kubernetes, docker, otel, otel-collector, otel-python, otel-node, otel-java, aws, aws-lambda, demo)
+- **THEN** the installer returns `ErrInstallCancelled` and exits cleanly
+- **AND** the command layer treats `ErrInstallCancelled` as a non-error exit
 - **AND** the system does not start ingest watch
 
 #### Scenario: Missing platform token
@@ -52,12 +53,12 @@ The system SHALL display seven data sections, each showing counts, details, and 
 
 #### Scenario: Cloud section with data
 
-- **WHEN** Dynatrace returns AWS_* entity types
-- **THEN** the system displays section "Cloud" with total count, top 5 types by count with humanized names (strip AWS_ prefix, lowercase, pluralize), and a link to the clouds app
+- **WHEN** Dynatrace returns AWS\_\* entity types
+- **THEN** the system displays section "Cloud" with total count, top 5 types by count with humanized names (strip AWS\_ prefix, lowercase, pluralize), and a link to the clouds app
 
 #### Scenario: Kubernetes section with data
 
-- **WHEN** Dynatrace returns K8S_* or CONTAINER entity types
+- **WHEN** Dynatrace returns K8S\_\* or CONTAINER entity types
 - **THEN** the system displays section "Kubernetes" with total count, top 5 types by count with humanized names, and a link to the kubernetes app
 
 #### Scenario: Relationships section with data

--- a/openspec/changes/ingest-watch/specs/ingest-watch/spec.md
+++ b/openspec/changes/ingest-watch/specs/ingest-watch/spec.md
@@ -16,6 +16,12 @@ The system SHALL provide a `dtwiz watch` command that polls the Dynatrace DQL AP
 - **WHEN** an installer (oneagent, kubernetes, docker, otel, aws) completes successfully
 - **THEN** the system automatically starts the ingest watch to show data flowing in
 
+#### Scenario: Watch does not start after cancelled install
+
+- **WHEN** the user selects `n` on the install confirmation prompt (`Proceed with installation?`)
+- **THEN** the installer exits cleanly
+- **AND** the system does not start ingest watch
+
 #### Scenario: Missing platform token
 
 - **WHEN** user runs `dtwiz watch` without a platform token configured

--- a/openspec/changes/ingest-watch/tasks.md
+++ b/openspec/changes/ingest-watch/tasks.md
@@ -24,6 +24,7 @@
 ## 4. Installer Integration
 
 - [ ] 4.1 Add `WatchIngest()` call to each installer's success path (oneagent, kubernetes, docker, otel, aws)
+- [ ] 4.2 Ensure installers return a cancellation sentinel when user declines confirmation, and skip `WatchIngest()` in callers on cancellation
 
 ## 5. Testing
 

--- a/openspec/changes/ingest-watch/tasks.md
+++ b/openspec/changes/ingest-watch/tasks.md
@@ -24,7 +24,9 @@
 ## 4. Installer Integration
 
 - [ ] 4.1 Add `WatchIngest()` call to each installer's success path (oneagent, kubernetes, docker, otel, aws)
-- [ ] 4.2 Ensure installers return a cancellation sentinel when user declines confirmation, and skip `WatchIngest()` in callers on cancellation
+- [x] 4.2 Ensure installers return a cancellation sentinel when user declines confirmation, and skip `WatchIngest()` in callers on cancellation
+  - All installers (oneagent, kubernetes, docker, otel, otel-collector, otel-python, otel-node, otel-java, aws, aws-lambda, demo) return `ErrInstallCancelled`
+  - All install/update/uninstall cmd handlers guard with `errors.Is(err, installer.ErrInstallCancelled)`
 
 ## 5. Testing
 

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -438,7 +438,7 @@ func InstallAWS(c *client.PlatformClient, envURL, token, platformToken string, d
 	}
 	if !ok {
 		fmt.Println("  Deployment cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -747,7 +747,7 @@ func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool)
 		}
 		if !ok {
 			fmt.Println("  Cancelled.")
-			return nil
+			return ErrInstallCancelled
 		}
 	}
 	fmt.Println()
@@ -833,7 +833,7 @@ func UninstallAWSLambda(dryRun bool) error {
 	}
 	if !ok {
 		fmt.Println("  Cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/cancel_test.go
+++ b/pkg/installer/cancel_test.go
@@ -1,0 +1,173 @@
+package installer
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// withStdin replaces os.Stdin with a pipe that delivers input and restores it
+// after fn returns. Tests using this helper must NOT call t.Parallel() because
+// they mutate the process-global os.Stdin.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	if _, err := io.WriteString(w, input); err != nil {
+		t.Fatalf("write to stdin pipe: %v", err)
+	}
+	w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = old
+		r.Close()
+	}()
+	fn()
+}
+
+// ── ErrInstallCancelled ───────────────────────────────────────────────────────
+
+func TestErrInstallCancelled_IsError(t *testing.T) {
+	if ErrInstallCancelled == nil {
+		t.Fatal("ErrInstallCancelled must not be nil")
+	}
+}
+
+func TestErrInstallCancelled_Message(t *testing.T) {
+	if !strings.Contains(ErrInstallCancelled.Error(), "cancelled") {
+		t.Errorf("ErrInstallCancelled message %q does not contain 'cancelled'", ErrInstallCancelled.Error())
+	}
+}
+
+func TestErrInstallCancelled_ErrorsIsMatch(t *testing.T) {
+	if !errors.Is(ErrInstallCancelled, ErrInstallCancelled) {
+		t.Error("errors.Is(ErrInstallCancelled, ErrInstallCancelled) must be true")
+	}
+}
+
+func TestErrInstallCancelled_IsDistinctFromOtherErrors(t *testing.T) {
+	other := errors.New("some other error")
+	if errors.Is(other, ErrInstallCancelled) {
+		t.Error("arbitrary error must not match ErrInstallCancelled")
+	}
+	if errors.Is(ErrInstallCancelled, other) {
+		t.Error("ErrInstallCancelled must not match an arbitrary error")
+	}
+}
+
+func TestErrInstallCancelled_WrappedIsDetected(t *testing.T) {
+	wrapped := errors.Join(ErrInstallCancelled, errors.New("context"))
+	if !errors.Is(wrapped, ErrInstallCancelled) {
+		t.Error("errors.Is must detect ErrInstallCancelled through errors.Join wrapping")
+	}
+}
+
+// ── confirmProceed ────────────────────────────────────────────────────────────
+
+func TestConfirmProceed_AutoConfirmBypassesPrompt(t *testing.T) {
+	old := AutoConfirm
+	AutoConfirm = true
+	defer func() { AutoConfirm = old }()
+
+	// stdin is empty — would fail if actually read
+	var ok bool
+	var err error
+	withStdin(t, "", func() {
+		ok, err = confirmProceed("  Proceed?")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("AutoConfirm=true must return true without reading stdin")
+	}
+}
+
+func TestConfirmProceed_EmptyInputIsYes(t *testing.T) {
+	old := AutoConfirm
+	AutoConfirm = false
+	defer func() { AutoConfirm = old }()
+
+	var ok bool
+	withStdin(t, "\n", func() {
+		var err error
+		ok, err = confirmProceed("  Proceed?")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if !ok {
+		t.Error("empty input (Enter) must be treated as yes")
+	}
+}
+
+func TestConfirmProceed_YLowercaseIsYes(t *testing.T) {
+	old := AutoConfirm
+	AutoConfirm = false
+	defer func() { AutoConfirm = old }()
+
+	for _, input := range []string{"y\n", "Y\n", "yes\n", "YES\n", "Yes\n"} {
+		input := input
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			var ok bool
+			withStdin(t, input, func() {
+				var err error
+				ok, err = confirmProceed("  Proceed?")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if !ok {
+				t.Errorf("input %q must be treated as yes, got false", strings.TrimSpace(input))
+			}
+		})
+	}
+}
+
+func TestConfirmProceed_NIsNo(t *testing.T) {
+	old := AutoConfirm
+	AutoConfirm = false
+	defer func() { AutoConfirm = old }()
+
+	for _, input := range []string{"n\n", "N\n", "no\n", "NO\n"} {
+		input := input
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			var ok bool
+			withStdin(t, input, func() {
+				var err error
+				ok, err = confirmProceed("  Proceed?")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			if ok {
+				t.Errorf("input %q must be treated as no, got true", strings.TrimSpace(input))
+			}
+		})
+	}
+}
+
+func TestConfirmProceed_EOFIsNo(t *testing.T) {
+	old := AutoConfirm
+	AutoConfirm = false
+	defer func() { AutoConfirm = old }()
+
+	// EOF on stdin (empty pipe, no newline) — scanner.Scan() returns false.
+	var ok bool
+	withStdin(t, "", func() {
+		var err error
+		ok, err = confirmProceed("  Proceed?")
+		// err may be nil on EOF; ok must be false
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Fatalf("unexpected error on EOF: %v", err)
+		}
+	})
+	if ok {
+		t.Error("EOF on stdin must be treated as no")
+	}
+}

--- a/pkg/installer/demo.go
+++ b/pkg/installer/demo.go
@@ -208,7 +208,7 @@ func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -3,6 +3,7 @@ package installer
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -12,6 +13,10 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrInstallCancelled is returned by installers when the user declines the
+// confirmation prompt. Callers should treat it as a clean exit, not an error.
+var ErrInstallCancelled = errors.New("installation cancelled by user")
 
 // AutoConfirm bypasses all confirmProceed prompts when set to true.
 // Set by the --yes / -y flag on install, update, and uninstall command groups.

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -374,7 +374,7 @@ func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error 
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -285,7 +285,7 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -847,7 +847,7 @@ func InstallOtelCollectorOnly(envURL, token, ingestToken, platformToken string, 
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 

--- a/pkg/installer/otel_java.go
+++ b/pkg/installer/otel_java.go
@@ -371,7 +371,7 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 		}
 		if !ok {
 			fmt.Println("  Installation cancelled.")
-			return nil
+			return ErrInstallCancelled
 		}
 
 		if len(proj.RunningProcessIDs) > 0 {
@@ -453,7 +453,7 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return nil
+		return ErrInstallCancelled
 	}
 
 	agentPath, err = downloadJavaAgent()

--- a/pkg/installer/otel_nodejs.go
+++ b/pkg/installer/otel_nodejs.go
@@ -609,7 +609,7 @@ func InstallOtelNode(envURL, token, platformToken, serviceName, projectPath stri
 		return err
 	}
 	if !ok {
-		return nil
+		return ErrInstallCancelled
 	}
 
 	plan.EnvURL = envURL

--- a/pkg/installer/otel_python.go
+++ b/pkg/installer/otel_python.go
@@ -333,7 +333,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 		return err
 	}
 	if !ok {
-		return nil
+		return ErrInstallCancelled
 	}
 
 	plan.EnvURL = envURL

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -346,7 +346,7 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 	}
 	if !ok {
 		display.ColorDefault.Println("  Cancelled — no changes written.")
-		return nil
+		return ErrInstallCancelled
 	}
 	fmt.Println()
 


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. run `dtwiz install demo`. When prompted "Apply? [Y/n]", enter 'n' or 'N'. Expected: Prompt exits cleanly, no error
2. run `dtwiz install otel-node`, When prompted "Apply? [Y/n]", enter 'n'. Expected: Clean exit, no watch starting
3. run `dtwiz install otel-python`, When prompted "Apply? [Y/n]", enter 'n', Expected: Clean exit, no watch starting
4. run `dtwiz install otel-java`, When prompted "Apply? [Y/n]", enter 'n', Expected: Clean exit, no watch starting
5. run `dtwiz setup`, When prompted "Apply? [Y/n]", enter 'n', Expected: Clean exit, no watch starting

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
