### PR TITLE
feat: platform token as primary auth

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -44,7 +44,8 @@ func platformToken() string {
 }
 
 // getDtEnvironment resolves the environment URL and raw tokens from flags/env vars.
-// platformTok is required. accessTok is optional (empty string when not set).
+// platformTok is required. accessTok is optional — when not set, the platform token
+// is used in its place.
 func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
 	envURL = environmentHint()
 	if envURL == "" {
@@ -64,7 +65,13 @@ func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
 		)
 	}
 
-	return envURL, accessToken(), platformTok, nil
+	accessTok = accessToken()
+	if accessTok == "" {
+		fmt.Println("  Using platform token")
+		accessTok = platformTok
+	}
+
+	return envURL, accessTok, platformTok, nil
 }
 
 var credentialHTTPClient = &http.Client{Timeout: 5 * time.Second}
@@ -91,23 +98,25 @@ func checkClassicAccess(envURL, token string) error {
 }
 
 // validateCredentials validates the platform token via DQL (required) and
-// determines the Classic API token. Tries the platform token against the Classic
-// API first; falls back to the access token if authentication fails there.
+// determines the Classic API token. When an explicit access token is provided
+// (old customers), it takes precedence for Classic API calls. Otherwise the
+// platform token is used for both Platform and Classic APIs.
 // Returns the classicTok to use for Classic API calls.
 func validateCredentials(envURL, accessTok, platformTok string) (classicTok string, err error) {
 	if err := checkPlatformToken(envURL, platformTok); err != nil {
 		return "", err
 	}
+	// When an explicit access token is set (different from platform token),
+	// it takes precedence for Classic API calls.
+	if accessTok != "" && accessTok != platformTok {
+		logger.Debug("classic API auth: using explicit access token")
+		return accessTok, nil
+	}
 	if err := checkClassicAccess(envURL, platformTok); err == nil {
 		logger.Debug("classic API auth: platform token accepted")
 		return platformTok, nil
 	}
-	logger.Debug("classic API auth: platform token rejected, trying access token fallback")
-	if accessTok != "" {
-		logger.Debug("classic API auth: using access token as fallback")
-		return accessTok, nil
-	}
-	logger.Debug("classic API auth: no access token configured, proceeding with platform token")
+	logger.Debug("classic API auth: platform token rejected by Classic API, proceeding anyway")
 	return platformTok, nil
 }
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // environmentHint returns the Dynatrace environment URL from the --environment
@@ -43,10 +43,10 @@ func platformToken() string {
 	return os.Getenv("DT_PLATFORM_TOKEN")
 }
 
-// getDtEnvironment returns the environment URL, access token, and platform
-// token. All three must be configured or an error is returned.
-func getDtEnvironment() (environmentURL, accessTok, platformTok string, err error) {
-	envURL := environmentHint()
+// getDtEnvironment resolves the environment URL and raw tokens from flags/env vars.
+// platformTok is required. accessTok is optional (empty string when not set).
+func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
+	envURL = environmentHint()
 	if envURL == "" {
 		return "", "", "", fmt.Errorf(
 			"no Dynatrace environment URL configured\n\n" +
@@ -55,17 +55,8 @@ func getDtEnvironment() (environmentURL, accessTok, platformTok string, err erro
 		)
 	}
 
-	aTok := accessToken()
-	if aTok == "" {
-		return "", "", "", fmt.Errorf(
-			"no Dynatrace access token configured\n\n" +
-				"Set one with --access-token or the DT_ACCESS_TOKEN env var:\n" +
-				"  export DT_ACCESS_TOKEN=dt0c01.****",
-		)
-	}
-
-	pTok := platformToken()
-	if pTok == "" {
+	platformTok = platformToken()
+	if platformTok == "" {
 		return "", "", "", fmt.Errorf(
 			"no Dynatrace platform token configured\n\n" +
 				"Set one with --platform-token or the DT_PLATFORM_TOKEN env var:\n" +
@@ -73,48 +64,54 @@ func getDtEnvironment() (environmentURL, accessTok, platformTok string, err erro
 		)
 	}
 
-	return envURL, aTok, pTok, nil
+	return envURL, accessToken(), platformTok, nil
 }
 
 var credentialHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
-// validateCredentials checks that the Dynatrace environment is reachable and
-// both the access token and platform token are valid. Both checks run in
-// parallel. Returns a combined error listing all failures.
-func validateCredentials(envURL, accessTok, platformTok string) error {
-	var mu sync.Mutex
-	var errs []string
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		if err := checkAccessToken(envURL, accessTok); err != nil {
-			mu.Lock()
-			errs = append(errs, err.Error())
-			mu.Unlock()
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		if err := checkPlatformToken(envURL, platformTok); err != nil {
-			mu.Lock()
-			errs = append(errs, err.Error())
-			mu.Unlock()
-		}
-	}()
-
-	wg.Wait()
-
-	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+// checkClassicAccess probes the Classic API to determine whether token can
+// authenticate. Returns nil if any non-401/403 response is received.
+func checkClassicAccess(envURL, token string) error {
+	classicURL := strings.TrimRight(installer.APIURL(envURL), "/")
+	req, err := http.NewRequest(http.MethodGet, classicURL+"/api/v2/settings/schemas", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", installer.AuthHeader(token))
+	resp, err := credentialHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Classic API not reachable (%s)", classicURL)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fmt.Errorf("authentication failed")
 	}
 	return nil
 }
 
-// checkAccessToken validates the access token via POST /api/v2/apiTokens/lookup.
+// validateCredentials validates the platform token via DQL (required) and
+// determines the Classic API token. Tries the platform token against the Classic
+// API first; falls back to the access token if authentication fails there.
+// Returns the classicTok to use for Classic API calls.
+func validateCredentials(envURL, accessTok, platformTok string) (classicTok string, err error) {
+	if err := checkPlatformToken(envURL, platformTok); err != nil {
+		return "", err
+	}
+	if err := checkClassicAccess(envURL, platformTok); err == nil {
+		logger.Debug("classic API auth: platform token accepted")
+		return platformTok, nil
+	}
+	logger.Debug("classic API auth: platform token rejected, trying access token fallback")
+	if accessTok != "" {
+		logger.Debug("classic API auth: using access token as fallback")
+		return accessTok, nil
+	}
+	logger.Debug("classic API auth: no access token configured, proceeding with platform token")
+	return platformTok, nil
+}
+
+// checkAccessToken validates an access token via POST /api/v2/apiTokens/lookup.
 func checkAccessToken(envURL, token string) error {
 	classicURL := strings.TrimRight(installer.APIURL(envURL), "/")
 	lookupURL := classicURL + "/api/v2/apiTokens/lookup"

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -80,7 +80,7 @@ func checkClassicAccess(envURL, token string) error {
 	req.Header.Set("Authorization", installer.AuthHeader(token))
 	resp, err := credentialHTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("Classic API not reachable (%s)", classicURL)
+		return fmt.Errorf("classic API not reachable (%s)", classicURL)
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -76,9 +76,9 @@ func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
 
 var credentialHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
-// checkClassicAccess probes the Classic API to determine whether token can
+// checkPlatformTokenClassicAccess probes the Classic API to determine whether token can
 // authenticate. Returns nil if any non-401/403 response is received.
-func checkClassicAccess(envURL, token string) error {
+func checkPlatformTokenClassicAccess(envURL, token string) error {
 	classicURL := strings.TrimRight(installer.APIURL(envURL), "/")
 	req, err := http.NewRequest(http.MethodGet, classicURL+"/api/v2/settings/schemas", nil)
 	if err != nil {
@@ -112,7 +112,7 @@ func validateCredentials(envURL, accessTok, platformTok string) (classicTok stri
 		logger.Debug("classic API auth: using explicit access token")
 		return accessTok, nil
 	}
-	if err := checkClassicAccess(envURL, platformTok); err == nil {
+	if err := checkPlatformTokenClassicAccess(envURL, platformTok); err == nil {
 		logger.Debug("classic API auth: platform token accepted")
 		return platformTok, nil
 	}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -44,8 +44,7 @@ func platformToken() string {
 }
 
 // getDtEnvironment resolves the environment URL and raw tokens from flags/env vars.
-// platformTok is required. accessTok is optional — when not set, the platform token
-// is used in its place.
+// platformTok is required. accessTok may be empty when not configured.
 func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
 	envURL = environmentHint()
 	if envURL == "" {
@@ -66,10 +65,6 @@ func getDtEnvironment() (envURL, accessTok, platformTok string, err error) {
 	}
 
 	accessTok = accessToken()
-	if accessTok == "" {
-		fmt.Println("  Using platform token")
-		accessTok = platformTok
-	}
 
 	return envURL, accessTok, platformTok, nil
 }
@@ -112,6 +107,7 @@ func validateCredentials(envURL, accessTok, platformTok string) (classicTok stri
 		logger.Debug("classic API auth: using explicit access token")
 		return accessTok, nil
 	}
+	fmt.Println("  Using platform token")
 	if err := checkPlatformTokenClassicAccess(envURL, platformTok); err == nil {
 		logger.Debug("classic API auth: platform token accepted")
 		return platformTok, nil

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -29,9 +29,9 @@ func TestCheckClassicAccess(t *testing.T) {
 			credentialHTTPClient = srv.Client()
 			defer func() { credentialHTTPClient = orig }()
 
-			err := checkClassicAccess(srv.URL, "dt0s16.testtoken")
+			err := checkPlatformTokenClassicAccess(srv.URL, "dt0s16.testtoken")
 			if (err != nil) != tt.wantErr {
-				t.Errorf("checkClassicAccess() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("checkPlatformTokenClassicAccess() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -46,7 +46,7 @@ func TestCheckClassicAccess_NetworkFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
 	srv.Close()
 
-	if err := checkClassicAccess(srv.URL, "dt0s16.testtoken"); err == nil {
+	if err := checkPlatformTokenClassicAccess(srv.URL, "dt0s16.testtoken"); err == nil {
 		t.Error("expected error for unreachable server, got nil")
 	}
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckClassicAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{"200 ok", http.StatusOK, false},
+		{"404 not found — auth ok endpoint absent", http.StatusNotFound, false},
+		{"500 server error — auth ok", http.StatusInternalServerError, false},
+		{"401 unauthorized", http.StatusUnauthorized, true},
+		{"403 forbidden", http.StatusForbidden, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			orig := credentialHTTPClient
+			credentialHTTPClient = srv.Client()
+			defer func() { credentialHTTPClient = orig }()
+
+			err := checkClassicAccess(srv.URL, "dt0s16.testtoken")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkClassicAccess() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckClassicAccess_NetworkFailure(t *testing.T) {
+	orig := credentialHTTPClient
+	credentialHTTPClient = &http.Client{}
+	defer func() { credentialHTTPClient = orig }()
+
+	// Point at a closed server so the TCP dial fails immediately.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv.Close()
+
+	if err := checkClassicAccess(srv.URL, "dt0s16.testtoken"); err == nil {
+		t.Error("expected error for unreachable server, got nil")
+	}
+}
+
+func TestValidateCredentials(t *testing.T) {
+	const platformTok = "dt0s16.platform"
+	const accessTok = "dt0c01.access"
+
+	tests := []struct {
+		name           string
+		dqlStatus      int
+		classicStatus  int
+		accessTok      string
+		wantClassicTok string
+		wantErr        bool
+	}{
+		{
+			name:           "platform token accepted by Classic API — no fallback",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusOK,
+			accessTok:      "",
+			wantClassicTok: platformTok,
+		},
+		{
+			name:           "platform token accepted even when access token is also set",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusOK,
+			accessTok:      accessTok,
+			wantClassicTok: platformTok,
+		},
+		{
+			name:           "platform token rejected by Classic API, falls back to access token",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusUnauthorized,
+			accessTok:      accessTok,
+			wantClassicTok: accessTok,
+		},
+		{
+			name:           "403 from Classic API also triggers fallback",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusForbidden,
+			accessTok:      accessTok,
+			wantClassicTok: accessTok,
+		},
+		{
+			name:           "platform token rejected, no access token — platform token used as best effort",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusUnauthorized,
+			accessTok:      "",
+			wantClassicTok: platformTok,
+		},
+		{
+			name:      "DQL validation fails — hard error regardless of access token",
+			dqlStatus: http.StatusUnauthorized,
+			// classicStatus is irrelevant here
+			classicStatus: http.StatusOK,
+			accessTok:     accessTok,
+			wantErr:       true,
+		},
+		{
+			name:      "DQL 403 is also a hard error",
+			dqlStatus: http.StatusForbidden,
+			accessTok: "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/platform/storage/query/v1/query:execute" {
+					w.WriteHeader(tt.dqlStatus)
+				} else {
+					w.WriteHeader(tt.classicStatus)
+				}
+			}))
+			defer srv.Close()
+
+			orig := credentialHTTPClient
+			credentialHTTPClient = srv.Client()
+			defer func() { credentialHTTPClient = orig }()
+
+			classicTok, err := validateCredentials(srv.URL, tt.accessTok, platformTok)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && classicTok != tt.wantClassicTok {
+				t.Errorf("validateCredentials() classicTok = %q, want %q", classicTok, tt.wantClassicTok)
+			}
+		})
+	}
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -64,37 +64,30 @@ func TestValidateCredentials(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "platform token accepted by Classic API — no fallback",
+			name:           "no access token, platform token accepted by Classic API",
 			dqlStatus:      http.StatusOK,
 			classicStatus:  http.StatusOK,
 			accessTok:      "",
 			wantClassicTok: platformTok,
 		},
 		{
-			name:           "platform token accepted even when access token is also set",
+			name:           "access token set — takes precedence over platform token for Classic API",
 			dqlStatus:      http.StatusOK,
-			classicStatus:  http.StatusOK,
+			classicStatus:  http.StatusUnauthorized, // irrelevant, access token wins
 			accessTok:      accessTok,
+			wantClassicTok: accessTok,
+		},
+		{
+			name:           "no access token, platform token rejected by Classic API — still used",
+			dqlStatus:      http.StatusOK,
+			classicStatus:  http.StatusUnauthorized,
+			accessTok:      "",
 			wantClassicTok: platformTok,
 		},
 		{
-			name:           "platform token rejected by Classic API, falls back to access token",
-			dqlStatus:      http.StatusOK,
-			classicStatus:  http.StatusUnauthorized,
-			accessTok:      accessTok,
-			wantClassicTok: accessTok,
-		},
-		{
-			name:           "403 from Classic API also triggers fallback",
+			name:           "no access token, 403 from Classic API — platform token still used",
 			dqlStatus:      http.StatusOK,
 			classicStatus:  http.StatusForbidden,
-			accessTok:      accessTok,
-			wantClassicTok: accessTok,
-		},
-		{
-			name:           "platform token rejected, no access token — platform token used as best effort",
-			dqlStatus:      http.StatusOK,
-			classicStatus:  http.StatusUnauthorized,
 			accessTok:      "",
 			wantClassicTok: platformTok,
 		},

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -337,7 +337,7 @@ var installDemoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := installer.InstallDemo(envURL, classicTok, installDryRun); err != nil {
+		if err := installer.InstallDemo(envURL, classicTok, platformTok, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -38,10 +38,11 @@ var installOneAgentCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		c, err := setupClient()
+		c, err := setupClientFromCreds(envURL, classicTok, platformTok)
 		if err != nil {
 			return err
 		}
@@ -81,10 +82,11 @@ var installKubernetesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallKubernetes(envURL, accessTok, accessTok, "", installDryRun); err != nil {
+		if err := installer.InstallKubernetes(envURL, classicTok, "", installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -106,10 +108,11 @@ var installDockerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallDocker(envURL, accessTok, installDryRun); err != nil {
+		if err := installer.InstallDocker(envURL, classicTok, installDryRun); err != nil {
 			return err
 		}
 		if !installDryRun {
@@ -128,10 +131,11 @@ var installOtelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallOtelCollectorWithProject(envURL, accessTok, accessTok, platformTok, otelProject, installDryRun); err != nil {
+		if err := installer.InstallOtelCollectorWithProject(envURL, classicTok, platformTok, otelProject, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -153,10 +157,11 @@ var installOtelCollectorCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallOtelCollectorOnly(envURL, accessTok, accessTok, platformTok, installDryRun); err != nil {
+		if err := installer.InstallOtelCollectorOnly(envURL, classicTok, platformTok, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -180,10 +185,11 @@ var installOtelPythonCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallOtelPython(envURL, accessTok, platformTok, otelPythonServiceName, otelProject, installDryRun); err != nil {
+		if err := installer.InstallOtelPython(envURL, classicTok, platformTok, otelPythonServiceName, otelProject, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -206,10 +212,11 @@ var installOtelNodeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallOtelNode(envURL, accessTok, platformTok, otelNodeServiceName, otelProject, installDryRun); err != nil {
+		if err := installer.InstallOtelNode(envURL, classicTok, platformTok, otelNodeServiceName, otelProject, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -229,10 +236,11 @@ var installOtelJavaCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallOtelJava(envURL, accessTok, otelJavaServiceName, otelProject, installDryRun); err != nil {
+		if err := installer.InstallOtelJava(envURL, classicTok, otelJavaServiceName, otelProject, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -254,14 +262,15 @@ var installAWSCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
-			return err
-		}
-		c, err := setupClient()
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
 		if err != nil {
 			return err
 		}
-		if err := installer.InstallAWS(c.Platform, envURL, accessTok, platformTok, installDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z")); err != nil {
+		c, err := setupClientFromCreds(envURL, classicTok, platformTok)
+		if err != nil {
+			return err
+		}
+		if err := installer.InstallAWS(c.Platform, envURL, platformTok, installDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z")); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -280,10 +289,11 @@ var installAWSLambdaCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallAWSLambda(envURL, accessTok, platformTok, installDryRun, true); err != nil {
+		if err := installer.InstallAWSLambda(envURL, classicTok, installDryRun, true); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
@@ -323,10 +333,11 @@ var installDemoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.InstallDemo(envURL, accessTok, platformTok, installDryRun); err != nil {
+		if err := installer.InstallDemo(envURL, classicTok, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ var rootCmd = &cobra.Command{
 Set your Dynatrace credentials via environment variables:
 
   export DT_ENVIRONMENT=https://<your-tenant-domain>
-  export DT_ACCESS_TOKEN=dt0c01.****
-  export DT_PLATFORM_TOKEN=dt0s16.****
+  export DT_PLATFORM_TOKEN=dt0s16.****      # preferred
+  export DT_ACCESS_TOKEN=dt0c01.****        # optional fallback
 
 Then use dtwiz commands to analyze and instrument your system.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -55,17 +55,26 @@ func printBanner() {
 	fmt.Printf("\n HASTA LA VISTA - BLIND SPOTS!\n\n")
 }
 
-// setupClient creates a Dynatrace API client from the current flag/env credentials.
-func setupClient() (*client.Client, error) {
-	envURL, aTok, pTok, err := getDtEnvironment()
-	if err != nil {
-		return nil, err
-	}
+// setupClientFromCreds creates a Dynatrace API client from already-resolved credentials.
+func setupClientFromCreds(envURL, classicTok, platformTok string) (*client.Client, error) {
 	level := verbosityFlag
 	if debugFlag {
 		level = 2
 	}
-	return client.New(installer.APIURL(envURL), aTok, installer.AppsURL(envURL), pTok, level)
+	return client.New(installer.APIURL(envURL), installer.AppsURL(envURL), classicTok, platformTok, level)
+}
+
+// setupClient creates a Dynatrace API client by resolving and validating credentials.
+func setupClient() (*client.Client, error) {
+	envURL, accessTok, platformTok, err := getDtEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+	if err != nil {
+		return nil, err
+	}
+	return setupClientFromCreds(envURL, classicTok, platformTok)
 }
 
 // Execute runs the root command.
@@ -93,8 +102,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().CountVarP(&verbosityFlag, "verbose", "v", "verbose output")
 	rootCmd.PersistentFlags().StringVar(&environmentFlag, "environment", "", "Dynatrace environment URL (also read from DT_ENVIRONMENT)")
-	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token (also read from DT_ACCESS_TOKEN)")
-	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token (dt0s16.*) for AWS installer (also read from DT_PLATFORM_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token, preferred (also read from DT_PLATFORM_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token, fallback (also read from DT_ACCESS_TOKEN)")
 
 	featureflags.RegisterFlags(rootCmd.PersistentFlags())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ var rootCmd = &cobra.Command{
 Set your Dynatrace credentials via environment variables:
 
   export DT_ENVIRONMENT=https://<your-tenant-domain>
-  export DT_PLATFORM_TOKEN=dt0s16.****      # preferred
-  export DT_ACCESS_TOKEN=dt0c01.****        # optional fallback
+  export DT_PLATFORM_TOKEN=dt0s16.****
+  export DT_ACCESS_TOKEN=dt0c01.****        # optional, for legacy environments
 
 Then use dtwiz commands to analyze and instrument your system.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -102,8 +102,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().CountVarP(&verbosityFlag, "verbose", "v", "verbose output")
 	rootCmd.PersistentFlags().StringVar(&environmentFlag, "environment", "", "Dynatrace environment URL (also read from DT_ENVIRONMENT)")
-	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token, preferred (also read from DT_PLATFORM_TOKEN)")
-	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token, fallback (also read from DT_ACCESS_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token (also read from DT_PLATFORM_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token for legacy environments (also read from DT_ACCESS_TOKEN)")
 
 	featureflags.RegisterFlags(rootCmd.PersistentFlags())
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -96,10 +96,11 @@ var setupCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+			classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+			if err != nil {
 				return err
 			}
-			if err := installer.InstallDemo(envURL, accessTok, platformTok, setupDryRun); err != nil {
+			if err := installer.InstallDemo(envURL, classicTok, setupDryRun); err != nil {
 				if errors.Is(err, installer.ErrInstallCancelled) {
 					return nil
 				}
@@ -124,11 +125,12 @@ var setupCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
 
-		c, err := setupClient()
+		c, err := setupClientFromCreds(envURL, classicTok, platformTok)
 		if err != nil {
 			return err
 		}
@@ -145,19 +147,19 @@ var setupCmd = &cobra.Command{
 				installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")
 			}
 		case recommender.MethodKubernetes:
-			installErr = installer.InstallKubernetes(envURL, accessTok, accessTok, "" /* name */, setupDryRun)
+			installErr = installer.InstallKubernetes(envURL, classicTok, "" /* name */, setupDryRun)
 		case recommender.MethodDocker:
-			installErr = installer.InstallDocker(envURL, accessTok, setupDryRun)
+			installErr = installer.InstallDocker(envURL, classicTok, setupDryRun)
 		case recommender.MethodOtelCollector:
-			installErr = installer.InstallOtelCollector(envURL, accessTok, accessTok, platformTok, setupDryRun)
+			installErr = installer.InstallOtelCollector(envURL, classicTok, platformTok, setupDryRun)
 		case recommender.MethodOtelUpdate:
 			cfgPath := selected.ConfigPath
 			if cfgPath == "" {
 				cfgPath = "config.yaml" // fall back to CWD default
 			}
-			installErr = installer.UpdateOtelConfig(cfgPath, envURL, accessTok, platformTok, setupDryRun)
+			installErr = installer.UpdateOtelConfig(cfgPath, envURL, classicTok, setupDryRun)
 		case recommender.MethodAWS:
-			installErr = installer.InstallAWS(c.Platform, envURL, accessTok, platformTok, setupDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
+			installErr = installer.InstallAWS(c.Platform, envURL, platformTok, setupDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		default:
 			return fmt.Errorf("unsupported method: %s", selected.Method)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -100,7 +100,7 @@ var setupCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if err := installer.InstallDemo(envURL, classicTok, setupDryRun); err != nil {
+			if err := installer.InstallDemo(envURL, classicTok, platformTok, setupDryRun); err != nil {
 				if errors.Is(err, installer.ErrInstallCancelled) {
 					return nil
 				}
@@ -157,7 +157,7 @@ var setupCmd = &cobra.Command{
 			if cfgPath == "" {
 				cfgPath = "config.yaml" // fall back to CWD default
 			}
-			installErr = installer.UpdateOtelConfig(cfgPath, envURL, classicTok, setupDryRun)
+			installErr = installer.UpdateOtelConfig(cfgPath, envURL, classicTok, platformTok, setupDryRun)
 		case recommender.MethodAWS:
 			installErr = installer.InstallAWS(c.Platform, envURL, platformTok, setupDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		default:

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -41,8 +41,8 @@ var statusCmd = &cobra.Command{
 		display.Header("Connection Status")
 
 		envURL := environmentHint()
-		accessTok := accessToken()
 		platformTok := platformToken()
+		accessTok := accessToken()
 
 		if envURL == "" {
 			display.PrintStatusLine(envLabel, "✗ not set (use --environment or DT_ENVIRONMENT)", display.ColorError)
@@ -50,20 +50,20 @@ var statusCmd = &cobra.Command{
 			display.PrintStatusLine(envLabel, fmt.Sprintf("✓ %s", envURL), display.ColorOK)
 		}
 
-		printCredentialStatus("Access Token", envURL, CredentialToken{
-			value:         accessTok,
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
-			tokenVerifyFn: checkAccessToken,
-			getUrlFn:      installer.APIURL,
-		})
-
 		printCredentialStatus("Platform Token", envURL, CredentialToken{
 			value:         platformTok,
 			cliName:       "platform-token",
 			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: checkPlatformToken,
 			getUrlFn:      installer.AppsURL,
+		})
+
+		printCredentialStatus("Access Token (fallback)", envURL, CredentialToken{
+			value:         accessTok,
+			cliName:       "access-token",
+			envName:       "DT_ACCESS_TOKEN",
+			tokenVerifyFn: checkAccessToken,
+			getUrlFn:      installer.APIURL,
 		})
 
 		if clientFlag {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -58,13 +58,15 @@ var statusCmd = &cobra.Command{
 			getUrlFn:      installer.AppsURL,
 		})
 
-		printCredentialStatus("Access Token (fallback)", envURL, CredentialToken{
-			value:         accessTok,
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
-			tokenVerifyFn: checkAccessToken,
-			getUrlFn:      installer.APIURL,
-		})
+		if accessTok != "" {
+			printCredentialStatus("Access Token", envURL, CredentialToken{
+				value:         accessTok,
+				cliName:       "access-token",
+				envName:       "DT_ACCESS_TOKEN",
+				tokenVerifyFn: checkAccessToken,
+				getUrlFn:      installer.APIURL,
+			})
+		}
 
 		if clientFlag {
 			printExtensionsStatus()

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -42,16 +42,16 @@ func okVerify(_, _ string) error { return nil }
 // Auth Credential Status Printing
 func TestPrintCredentialStatus_TokenNotSet(t *testing.T) {
 	got := captureOutput(t, func() {
-		printCredentialStatus("Access Token", "https://abc.live.com", CredentialToken{
+		printCredentialStatus("Platform Token", "https://abc.apps.dynatrace.com", CredentialToken{
 			value:         "",
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: okVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 
-	want := "✗ not set (use --access-token or DT_ACCESS_TOKEN)"
+	want := "✗ not set (use --platform-token or DT_PLATFORM_TOKEN)"
 	if !strings.Contains(got, want) {
 		t.Errorf("expected output to contain %q, got %q", want, got)
 	}
@@ -59,12 +59,12 @@ func TestPrintCredentialStatus_TokenNotSet(t *testing.T) {
 
 func TestPrintCredentialStatus_TokenSetNoEnvURL(t *testing.T) {
 	got := captureOutput(t, func() {
-		printCredentialStatus("Access Token", "", CredentialToken{
-			value:         "dt0c01.some-token",
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+		printCredentialStatus("Platform Token", "", CredentialToken{
+			value:         "dt0s16.some-token",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: errVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 
@@ -76,31 +76,31 @@ func TestPrintCredentialStatus_TokenSetNoEnvURL(t *testing.T) {
 
 func TestPrintCredentialStatus_TokenSetEnvURLVerifyOK(t *testing.T) {
 	got := captureOutput(t, func() {
-		printCredentialStatus("Access Token", "https://abc.live.com", CredentialToken{
-			value:         "dt0c01.some-token",
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+		printCredentialStatus("Platform Token", "https://abc.apps.dynatrace.com", CredentialToken{
+			value:         "dt0s16.some-token",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: okVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 
 	if !strings.Contains(got, "✓ valid") {
 		t.Errorf("expected output to contain %q, got %q", "✓ valid", got)
 	}
-	if !strings.Contains(got, "abc.live.com") {
+	if !strings.Contains(got, "abc.apps.dynatrace.com") {
 		t.Errorf("expected output to contain the environment URL, got %q", got)
 	}
 }
 
 func TestPrintCredentialStatus_TokenSetEnvURLVerifyFails(t *testing.T) {
 	got := captureOutput(t, func() {
-		printCredentialStatus("Access Token", "https://abc.live.com", CredentialToken{
-			value:         "dt0c01.bad-token",
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+		printCredentialStatus("Platform Token", "https://abc.apps.dynatrace.com", CredentialToken{
+			value:         "dt0s16.bad-token",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: errVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 
@@ -134,12 +134,12 @@ func TestPrintCredentialStatus_VerifyNotCalledWhenNoEnvURL(t *testing.T) {
 	}
 
 	captureOutput(t, func() {
-		printCredentialStatus("Access Token", "", CredentialToken{
-			value:         "dt0c01.some-token",
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+		printCredentialStatus("Platform Token", "", CredentialToken{
+			value:         "dt0s16.some-token",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: spyVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 
@@ -149,8 +149,8 @@ func TestPrintCredentialStatus_VerifyNotCalledWhenNoEnvURL(t *testing.T) {
 }
 
 func TestPrintCredentialStatus_VerifyCalledWithCorrectArgs(t *testing.T) {
-	const wantEnvURL = "https://abc.live.com"
-	const wantToken = "dt0c01.my-token"
+	const wantEnvURL = "https://abc.apps.dynatrace.com"
+	const wantToken = "dt0s16.my-token"
 
 	var gotEnvURL, gotToken string
 	spyVerify := func(envURL, token string) error {
@@ -160,12 +160,12 @@ func TestPrintCredentialStatus_VerifyCalledWithCorrectArgs(t *testing.T) {
 	}
 
 	captureOutput(t, func() {
-		printCredentialStatus("Access Token", wantEnvURL, CredentialToken{
+		printCredentialStatus("Platform Token", wantEnvURL, CredentialToken{
 			value:         wantToken,
-			cliName:       "access-token",
-			envName:       "DT_ACCESS_TOKEN",
+			cliName:       "platform-token",
+			envName:       "DT_PLATFORM_TOKEN",
 			tokenVerifyFn: spyVerify,
-			getUrlFn:      installer.APIURL,
+			getUrlFn:      installer.AppsURL,
 		})
 	})
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,10 +47,11 @@ var uninstallAWSCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		c, err := setupClient()
+		c, err := setupClientFromCreds(envURL, classicTok, platformTok)
 		if err != nil {
 			return err
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -30,10 +30,11 @@ var updateOtelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+		classicTok, err := validateCredentials(envURL, accessTok, platformTok)
+		if err != nil {
 			return err
 		}
-		if err := installer.UpdateOtelConfig(updateOtelConfigPath, envURL, accessTok, platformTok, updateDryRun); err != nil {
+		if err := installer.UpdateOtelConfig(updateOtelConfigPath, envURL, classicTok, updateDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ var updateOtelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := installer.UpdateOtelConfig(updateOtelConfigPath, envURL, classicTok, updateDryRun); err != nil {
+		if err := installer.UpdateOtelConfig(updateOtelConfigPath, envURL, classicTok, platformTok, updateDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}

--- a/openspec/changes/platform-token-primary-auth/design.md
+++ b/openspec/changes/platform-token-primary-auth/design.md
@@ -1,0 +1,60 @@
+# Design: Platform Token Primary Authentication
+
+## Context
+
+Dynatrace is migrating from access tokens (`dt0c01.*`) to platform tokens (`dt0s16.*`). New tenants can no longer create access tokens. Platform tokens already work for all ingest endpoints, and Classic API endpoints are being updated to accept platform tokens as well.
+
+The two token families:
+
+| Token | Prefix | Auth header | APIs |
+|---|---|---|---|
+| Platform token | `dt0s16.*` | `Bearer` | Platform API (DQL/Grail), ingest endpoints |
+| Access token | `dt0c01.*` | `Api-Token` | Classic API (being phased out) |
+
+This change makes platform token the primary credential. Access token stays as a fallback for Classic API calls that don't yet accept platform tokens.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- dtwiz works with platform token only — no access token needed
+- Access token remains as a silent fallback for Classic API
+- Clear debug logging when fallback is applied
+- Probe-based fallback resolved once at startup — no per-request retry
+
+**Non-Goals:**
+
+- Removing access token support entirely — that is a follow-up
+- Changing which URLs are used for Classic vs Platform API
+
+## Decisions
+
+### 1. Startup probe for Classic API token selection
+
+At credential validation time (`validateCredentials`), a `GET /api/v2/settings/schemas` request is made with the platform token. If this returns 401 or 403, the access token is used instead for Classic API calls. Any other response means authentication was accepted.
+
+**Why not per-request retry**: requires thread-safe token storage and retry logic in the HTTP client — significant complexity for a gap that will close once all Classic API endpoints accept platform tokens.
+
+### 2. `GET /api/v2/settings/schemas` as the probe endpoint
+
+Read-only metadata endpoint, no data-access scope requirements. Any non-401/403 response confirms authentication regardless of the token's data permissions.
+
+**Risk**: if this endpoint requires `settings.read` scope and the token lacks it, the probe returns 403 for the wrong reason (scope, not auth), causing an unnecessary fallback. Acceptable trade-off.
+
+### 3. DQL validation is a hard requirement
+
+`checkPlatformToken` DQL call always runs and failure is always a hard error. No fallback — if the platform token can't authenticate Platform API, dtwiz cannot function.
+
+### 4. `getDtEnvironment` returns raw tokens; `validateCredentials` returns resolved `classicTok`
+
+`getDtEnvironment` resolves tokens from flags/env vars without HTTP calls. `validateCredentials` does the probe and returns `(classicTok string, err error)`. Commands use `classicTok` for Classic API installers and `platformTok` for DQL/Platform API.
+
+### 5. `setupClientFromCreds` avoids double-probing
+
+Commands needing both resolved tokens and a `*client.Client` call `setupClientFromCreds(envURL, classicTok, platformTok)` directly after `validateCredentials`, skipping a second call to `getDtEnvironment` inside `setupClient`.
+
+## Risks / Trade-offs
+
+- **[Probe latency]** → Extra HTTP round-trip at startup. Acceptable for a startup credential check.
+- **[False fallback on scope 403]** → Access token used unnecessarily if probe endpoint returns 403 due to missing scope rather than auth failure. Low risk in practice.
+- **[Incomplete Classic API coverage]** → Only authentication is probed, not specific endpoint permissions. Some operations may still fail mid-install if the platform token lacks the required Classic API scopes. Users can set `DT_ACCESS_TOKEN` as a workaround in the meantime.

--- a/openspec/changes/platform-token-primary-auth/design.md
+++ b/openspec/changes/platform-token-primary-auth/design.md
@@ -29,17 +29,17 @@ This change makes platform token the primary credential. Access token stays as a
 
 ## Decisions
 
-### 1. Startup probe for Classic API token selection
+### 1. Access token takes precedence when set; platform token fills in when absent
 
-At credential validation time (`validateCredentials`), a `GET /api/v2/settings/schemas` request is made with the platform token. If this returns 401 or 403, the access token is used instead for Classic API calls. Any other response means authentication was accepted.
+At credential validation time (`validateCredentials`), if an explicit access token is set (different from the platform token), it is returned directly as `classicTok` for Classic API calls — no probe needed. When no explicit access token is configured, `getDtEnvironment` sets `accessTok = platformTok` and prints `"  Using platform token"`. `validateCredentials` then probes `GET /api/v2/settings/schemas` with the platform token; regardless of whether the probe passes or fails, the platform token is used for Classic API calls.
 
-**Why not per-request retry**: requires thread-safe token storage and retry logic in the HTTP client — significant complexity for a gap that will close once all Classic API endpoints accept platform tokens.
+**Why explicit access token wins without probing**: legacy customers who set `DT_ACCESS_TOKEN` know they need it — there is no value in probing the platform token first and potentially falling through to the access token anyway.
 
-### 2. `GET /api/v2/settings/schemas` as the probe endpoint
+**Why platform token is used even when the probe fails**: the probe failure may be transient or due to scope rather than auth. Using the platform token as best-effort is better than failing hard when no access token is available.
 
-Read-only metadata endpoint, no data-access scope requirements. Any non-401/403 response confirms authentication regardless of the token's data permissions.
+### 2. `GET /api/v2/settings/schemas` as the probe endpoint (platform-token-only path)
 
-**Risk**: if this endpoint requires `settings.read` scope and the token lacks it, the probe returns 403 for the wrong reason (scope, not auth), causing an unnecessary fallback. Acceptable trade-off.
+When no explicit access token is set, a read-only metadata probe is made with the platform token. Any non-401/403 response confirms Classic API authentication. Used only when `accessTok == platformTok` (i.e. no explicit access token was configured).
 
 ### 3. DQL validation is a hard requirement
 
@@ -55,6 +55,5 @@ Commands needing both resolved tokens and a `*client.Client` call `setupClientFr
 
 ## Risks / Trade-offs
 
-- **[Probe latency]** → Extra HTTP round-trip at startup. Acceptable for a startup credential check.
-- **[False fallback on scope 403]** → Access token used unnecessarily if probe endpoint returns 403 due to missing scope rather than auth failure. Low risk in practice.
+- **[Probe latency]** → Extra HTTP round-trip at startup when no explicit access token is set. Acceptable for a startup credential check.
 - **[Incomplete Classic API coverage]** → Only authentication is probed, not specific endpoint permissions. Some operations may still fail mid-install if the platform token lacks the required Classic API scopes. Users can set `DT_ACCESS_TOKEN` as a workaround in the meantime.

--- a/openspec/changes/platform-token-primary-auth/proposal.md
+++ b/openspec/changes/platform-token-primary-auth/proposal.md
@@ -9,17 +9,17 @@ This PR is a transitional step: platform token becomes the primary required cred
 ## What Changes
 
 - Platform token (`DT_PLATFORM_TOKEN`) becomes the only required credential
-- Access token (`DT_ACCESS_TOKEN`) becomes optional — used as a fallback for Classic API calls only when the platform token is rejected (401/403)
-- At startup, a lightweight probe determines which token to use for Classic API calls — no per-request retry logic needed
-- `dtwiz status` labels the access token as "(fallback)" to communicate its optional role
+- Access token (`DT_ACCESS_TOKEN`) becomes optional — when set (legacy customers), it takes precedence for Classic API calls; when absent, the platform token is used in its place and `"  Using platform token"` is printed
+- At startup, if an explicit access token is provided it is used directly for Classic API calls without probing; if absent, a lightweight probe determines whether the platform token is accepted by the Classic API
+- `dtwiz status` shows the access token section only when `DT_ACCESS_TOKEN` is set
 
 ## Capabilities
 
 ### Modified Capabilities
 
-- **Authentication resolution**: platform token is tried first for Classic API; access token is fallback
+- **Authentication resolution**: when access token is explicitly set it takes precedence for Classic API calls; otherwise platform token is used for both Platform and Classic APIs
 - **Credential validation**: only platform token is validated at startup (via DQL); access token is not required
-- **Status output**: access token shown as optional fallback, not a required credential
+- **Status output**: access token section shown only when `DT_ACCESS_TOKEN` is set; no "fallback" label
 
 ## Impact
 

--- a/openspec/changes/platform-token-primary-auth/proposal.md
+++ b/openspec/changes/platform-token-primary-auth/proposal.md
@@ -32,6 +32,7 @@ This PR is a transitional step: platform token becomes the primary required cred
 ## Follow-up
 
 Once all Classic API endpoints accept platform tokens, a follow-up change should:
+
 1. Remove the Classic API probe and access token fallback logic
 2. Remove `DT_ACCESS_TOKEN` / `--access-token` flag support entirely
 3. Remove the `checkAccessToken` validation path from `dtwiz status`

--- a/openspec/changes/platform-token-primary-auth/proposal.md
+++ b/openspec/changes/platform-token-primary-auth/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: Platform Token Primary Authentication
+
+## Why
+
+Dynatrace is deprecating access tokens. New tenants will no longer be able to create them. Platform tokens are the replacement and already work for all ingest endpoints. Classic API endpoints are in the process of being updated to accept platform tokens as well.
+
+This PR is a transitional step: platform token becomes the primary required credential, while access token remains as an optional fallback for Classic API calls that do not yet accept platform tokens. Once all Classic API calls accept platform tokens and this is verified, access token support can be removed entirely.
+
+## What Changes
+
+- Platform token (`DT_PLATFORM_TOKEN`) becomes the only required credential
+- Access token (`DT_ACCESS_TOKEN`) becomes optional — used as a fallback for Classic API calls only when the platform token is rejected (401/403)
+- At startup, a lightweight probe determines which token to use for Classic API calls — no per-request retry logic needed
+- `dtwiz status` labels the access token as "(fallback)" to communicate its optional role
+
+## Capabilities
+
+### Modified Capabilities
+
+- **Authentication resolution**: platform token is tried first for Classic API; access token is fallback
+- **Credential validation**: only platform token is validated at startup (via DQL); access token is not required
+- **Status output**: access token shown as optional fallback, not a required credential
+
+## Impact
+
+- **Modified files**: `cmd/auth.go`, `cmd/root.go`, and all install/update/uninstall command files
+- **Modified files**: `pkg/client/client.go` — two-token client construction restored
+- **Modified files**: `test/integration/setup.go`, `test/e2e/otel_test.go` — `TEST_DT_PLATFORM_TOKEN` required, `TEST_DT_ACCESS_TOKEN` optional
+- **New files**: `cmd/auth_test.go` — unit tests for the probe and fallback logic
+- **Auth**: Classic API probe uses `GET /api/v2/settings/schemas`; DQL validation uses `Bearer` always
+
+## Follow-up
+
+Once all Classic API endpoints accept platform tokens, a follow-up change should:
+1. Remove the Classic API probe and access token fallback logic
+2. Remove `DT_ACCESS_TOKEN` / `--access-token` flag support entirely
+3. Remove the `checkAccessToken` validation path from `dtwiz status`

--- a/openspec/changes/platform-token-primary-auth/specs/platform-token-primary-auth/spec.md
+++ b/openspec/changes/platform-token-primary-auth/specs/platform-token-primary-auth/spec.md
@@ -1,0 +1,79 @@
+# Platform Token Primary Authentication
+
+## Overview
+
+Dynatrace is deprecating access tokens. New tenants can no longer create them. Platform tokens (`dt0s16.*`) are the replacement and already work for all ingest endpoints. Classic API endpoints are being updated to accept platform tokens as well.
+
+This change makes platform token the required primary credential. Access token (`dt0c01.*`) is retained as an optional fallback for Classic API calls that do not yet accept platform tokens. Once Classic API coverage is complete and verified, access token support will be removed entirely.
+
+## ADDED Requirements
+
+### Requirement: Platform token is required
+
+All dtwiz commands SHALL require `DT_PLATFORM_TOKEN` to be set. If not set, the command SHALL exit with an error.
+
+#### Scenario: Platform token missing
+
+- **GIVEN** `DT_PLATFORM_TOKEN` is not set
+- **WHEN** the user runs any dtwiz command
+- **THEN** the command exits with `no Dynatrace platform token configured`
+
+---
+
+### Requirement: Access token is optional; used as Classic API fallback
+
+Access token is optional. At startup, dtwiz probes the Classic API with the platform token. If rejected (401/403), the access token is used instead for Classic API calls. This fallback exists only until all Classic API endpoints accept platform tokens.
+
+#### Scenario: Platform token accepted by Classic API
+
+- **GIVEN** `DT_PLATFORM_TOKEN` is set (and optionally `DT_ACCESS_TOKEN`)
+- **WHEN** the Classic API probe returns a non-401/403 response
+- **THEN** the platform token is used for Classic API calls and `--debug` logs `classic API auth: platform token accepted`
+
+#### Scenario: Platform token rejected, access token available
+
+- **GIVEN** Both `DT_PLATFORM_TOKEN` and `DT_ACCESS_TOKEN` are set
+- **WHEN** the Classic API probe returns 401 or 403
+- **THEN** the access token is used for Classic API calls and `--debug` logs `classic API auth: using access token as fallback`
+
+#### Scenario: Platform token rejected, no access token
+
+- **GIVEN** Only `DT_PLATFORM_TOKEN` is set
+- **WHEN** the Classic API probe returns 401 or 403
+- **THEN** the platform token is used as best effort and `--debug` logs `classic API auth: no access token configured, proceeding with platform token`
+
+#### Scenario: Only platform token set, command succeeds
+
+- **GIVEN** Only `DT_PLATFORM_TOKEN` is set
+- **WHEN** the user runs any install command (e.g. `dtwiz install otel --dry-run`)
+- **THEN** the command completes successfully
+
+---
+
+### Requirement: Platform token DQL validation is a hard requirement
+
+At startup, all commands SHALL validate the platform token via DQL query. Failure exits with an error regardless of whether an access token is set.
+
+#### Scenario: Platform token DQL validation fails
+
+- **GIVEN** `DT_PLATFORM_TOKEN` is set to an invalid or expired token
+- **WHEN** the user runs any command
+- **THEN** the command exits with `✗ Platform token: authentication failed`
+
+---
+
+### Requirement: Status output labels access token as optional fallback
+
+`dtwiz status` SHALL label the access token row as `"Access Token (fallback)"` to communicate its optional, transitional role.
+
+#### Scenario: Both tokens set
+
+- **GIVEN** Both `DT_PLATFORM_TOKEN` and `DT_ACCESS_TOKEN` are set
+- **WHEN** the user runs `dtwiz status`
+- **THEN** the output shows `Platform Token` and `Access Token (fallback)` as two separate rows
+
+#### Scenario: Only platform token set
+
+- **GIVEN** Only `DT_PLATFORM_TOKEN` is set
+- **WHEN** the user runs `dtwiz status`
+- **THEN** `Access Token (fallback)` shows as `✗ not set` without causing an error

--- a/openspec/changes/platform-token-primary-auth/tasks.md
+++ b/openspec/changes/platform-token-primary-auth/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Platform Token Primary Authentication
+
+## 1. Auth layer (`cmd/auth.go`)
+
+- [x] 1.1 Change `getDtEnvironment` to return `(envURL, accessTok, platformTok, err)` — raw tokens, no Classic API selection
+- [x] 1.2 Add `checkClassicAccess(envURL, token string) error` — probes `GET /api/v2/settings/schemas`, returns error on 401/403
+- [x] 1.3 Change `validateCredentials` to `(envURL, accessTok, platformTok string) (classicTok string, err error)` — validates platform token via DQL, probes Classic API, returns resolved classic token
+- [x] 1.4 Add debug log lines for each fallback outcome
+
+## 2. Client setup (`cmd/root.go`)
+
+- [x] 2.1 Add `setupClientFromCreds(envURL, classicTok, platformTok string)` helper
+- [x] 2.2 Update `setupClient` to call new `getDtEnvironment` + `validateCredentials`
+
+## 3. Command updates
+
+- [x] 3.1 Update all `cmd/install.go` commands to use new 4-value `getDtEnvironment` + `validateCredentials`, pass `classicTok` to Classic API installers and `platformTok` to `WatchIngest`
+- [x] 3.2 Update `cmd/setup.go` similarly
+- [x] 3.3 Update `cmd/update.go` similarly
+- [x] 3.4 Update `cmd/uninstall.go` similarly
+
+## 4. HTTP client (`pkg/client/client.go`)
+
+- [x] 4.1 Restore two-token `New(classicURL, platformURL, classicToken, platformToken string, verbosityLevel int)` — Classic client uses `authHeader(classicToken)`, Platform client always uses `"Bearer " + platformToken`
+
+## 5. Tests
+
+- [x] 5.1 Add `cmd/auth_test.go` with `TestCheckClassicAccess` (200/404/500 pass; 401/403 fail; network failure)
+- [x] 5.2 Add `TestValidateCredentials` covering: platform token accepted, platform token rejected + access token fallback, platform token rejected + no access token, DQL failure
+- [x] 5.3 Update `test/integration/setup.go` — `TEST_DT_PLATFORM_TOKEN` required, `TEST_DT_ACCESS_TOKEN` optional
+- [x] 5.4 Update `test/e2e/otel_test.go` — use `env.ClassicToken` / `env.PlatformToken` instead of `env.Token`
+- [x] 5.5 Fix `client.New` call sites in test files to pass both tokens

--- a/openspec/changes/platform-token-primary-auth/tasks.md
+++ b/openspec/changes/platform-token-primary-auth/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Auth layer (`cmd/auth.go`)
 
 - [x] 1.1 Change `getDtEnvironment` to return `(envURL, accessTok, platformTok, err)` — raw tokens, no Classic API selection
-- [x] 1.2 Add `checkClassicAccess(envURL, token string) error` — probes `GET /api/v2/settings/schemas`, returns error on 401/403
+- [x] 1.2 Add `checkPlatformTokenClassicAccess(envURL, token string) error` — probes `GET /api/v2/settings/schemas`, returns error on 401/403
 - [x] 1.3 Change `validateCredentials` to `(envURL, accessTok, platformTok string) (classicTok string, err error)` — validates platform token via DQL, probes Classic API, returns resolved classic token
 - [x] 1.4 Add debug log lines for each auth path outcome (explicit access token used, platform token accepted, platform token rejected but proceeding)
 
@@ -25,7 +25,7 @@
 
 ## 5. Tests
 
-- [x] 5.1 Add `cmd/auth_test.go` with `TestCheckClassicAccess` (200/404/500 pass; 401/403 fail; network failure)
+- [x] 5.1 Add `cmd/auth_test.go` with `TestCheckPlatformTokenClassicAccess` (200/404/500 pass; 401/403 fail; network failure)
 - [x] 5.2 Add `TestValidateCredentials` covering: platform token accepted, platform token rejected + access token fallback, platform token rejected + no access token, DQL failure
 - [x] 5.3 Update `test/integration/setup.go` — `TEST_DT_PLATFORM_TOKEN` required, `TEST_DT_ACCESS_TOKEN` optional
 - [x] 5.4 Update `test/e2e/otel_test.go` — use `env.ClassicToken` / `env.PlatformToken` instead of `env.Token`

--- a/openspec/changes/platform-token-primary-auth/tasks.md
+++ b/openspec/changes/platform-token-primary-auth/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.1 Change `getDtEnvironment` to return `(envURL, accessTok, platformTok, err)` — raw tokens, no Classic API selection
 - [x] 1.2 Add `checkClassicAccess(envURL, token string) error` — probes `GET /api/v2/settings/schemas`, returns error on 401/403
 - [x] 1.3 Change `validateCredentials` to `(envURL, accessTok, platformTok string) (classicTok string, err error)` — validates platform token via DQL, probes Classic API, returns resolved classic token
-- [x] 1.4 Add debug log lines for each fallback outcome
+- [x] 1.4 Add debug log lines for each auth path outcome (explicit access token used, platform token accepted, platform token rejected but proceeding)
 
 ## 2. Client setup (`cmd/root.go`)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -63,8 +63,11 @@ func authHeader(token string) string {
 }
 
 // New builds a Client with a ClassicClient and a PlatformClient.
-// classicURL and platformURL should already be in the correct URL families
-func New(classicURL, accessToken, platformURL, platformToken string, verbosityLevel int) (*Client, error) {
+// classicURL and platformURL should already be in the correct URL families.
+// classicToken is the access token when one is configured, otherwise the
+// platform token; platformToken is the platform token used for DQL/Grail
+// (always sent as Bearer regardless of prefix).
+func New(classicURL, platformURL, classicToken, platformToken string, verbosityLevel int) (*Client, error) {
 	if classicURL == "" {
 		return nil, fmt.Errorf("classic API URL is required")
 	}
@@ -74,7 +77,7 @@ func New(classicURL, accessToken, platformURL, platformToken string, verbosityLe
 
 	classic := &ClassicClient{
 		baseURL: classicURL,
-		http:    newRestyClient(classicURL, authHeader(accessToken), verbosityLevel),
+		http:    newRestyClient(classicURL, authHeader(classicToken), verbosityLevel),
 	}
 
 	platform := &PlatformClient{

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -13,7 +13,7 @@ import (
 
 func newTestPlatformClient(t *testing.T, serverURL string) *client.PlatformClient {
 	t.Helper()
-	c, err := client.New(serverURL, "dt0c01.test", serverURL, "dt0s16.test", 0)
+	c, err := client.New(serverURL, serverURL, "dt0s16.test", "dt0s16.test", 0)
 	if err != nil {
 		t.Fatalf("create test client: %v", err)
 	}

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -17,7 +17,7 @@ import (
 )
 
 // awsTemplateURL is the pinned Dynatrace CloudFormation template.
-const awsTemplateURL = "https://dynatrace-data-acquisition.s3.amazonaws.com/aws/deployment/cfn/v1.0.0/da-aws-activation.yaml"
+const awsTemplateURL = "https://dynatrace-data-acquisition.s3.amazonaws.com/aws/deployment/cfn/v1.0.11/da-aws-activation.yaml"
 
 // awsStackConfig holds all values required to render aws.tmpl and drive the
 // CloudFormation deployment.
@@ -205,7 +205,7 @@ func createDTMonitoringConfig(c *client.PlatformClient, accountID, region string
 		"value": map[string]interface{}{
 			"enabled":           false,
 			"description":       desc,
-			"version":           "1.0.0",
+			"version":           "1.0.11",
 			"featureSets":       defaultFeatureSets,
 			"activationContext": "DATA_ACQUISITION",
 			"aws": map[string]interface{}{

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -151,15 +151,6 @@ var defaultFeatureSets = []string{
 	"SNS_essential", "SQS_essential",
 }
 
-// dtAuthHeader returns the correct Authorization header value for a Dynatrace
-// token. Used by aws_lambda.go which uses raw HTTP calls.
-func dtAuthHeader(token string) string {
-	if strings.HasPrefix(token, "dt0c01.") {
-		return "Api-Token " + token
-	}
-	return "Bearer " + token
-}
-
 const (
 	daAWSExtension        = "com.dynatrace.extension.da-aws"
 	daAWSExtensionVersion = "1.0.11"

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -162,7 +162,7 @@ func dtAuthHeader(token string) string {
 
 const (
 	daAWSExtension        = "com.dynatrace.extension.da-aws"
-	daAWSExtensionVersion = "1.0.0"
+	daAWSExtensionVersion = "1.0.11"
 )
 
 // awsMonitoringConfigValue is used to decode the value field of a da-aws

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -152,13 +152,12 @@ var defaultFeatureSets = []string{
 }
 
 // dtAuthHeader returns the correct Authorization header value for a Dynatrace
-// token: Bearer for platform tokens (dt0s16.*), Api-Token otherwise.
-// Used by aws_lambda.go which still uses raw HTTP calls.
+// token. Used by aws_lambda.go which uses raw HTTP calls.
 func dtAuthHeader(token string) string {
-	if strings.HasPrefix(token, "dt0s16.") {
-		return "Bearer " + token
+	if strings.HasPrefix(token, "dt0c01.") {
+		return "Api-Token " + token
 	}
-	return "Api-Token " + token
+	return "Bearer " + token
 }
 
 const (
@@ -352,20 +351,13 @@ func buildDeployArgs(cfg awsStackConfig, templateFile string) []string {
 // InstallAWS deploys the Dynatrace AWS Data Acquisition CloudFormation stack.
 //
 // Parameters:
-//   - c:             Platform API client (Extensions monitoring configs via /platform/classic/environment/v2)
-//   - envURL:        Dynatrace Platform environment URL
-//   - token:         access token (used as default for settings/ingest token prompts)
-//   - platformToken: dt0s16.* token from --platform-token / DT_PLATFORM_TOKEN
-//   - dryRun:        when true, show what would be done without executing
-//   - startTime:     RFC3339 timestamp used as the from-clause for WatchIngest (empty = skip watch)
-func InstallAWS(c *client.PlatformClient, envURL, token, platformToken string, dryRun bool, startTime string) error {
+//   - c:         Platform API client (Extensions monitoring configs via /platform/classic/environment/v2)
+//   - envURL:    Dynatrace Platform environment URL
+//   - token:     platform token (dt0s16.*) used for settings, ingest, and watch
+//   - dryRun:    when true, show what would be done without executing
+//   - startTime: RFC3339 timestamp used as the from-clause for WatchIngest (empty = skip watch)
+func InstallAWS(c *client.PlatformClient, envURL, token string, dryRun bool, startTime string) error {
 	sep := strings.Repeat("─", 60)
-
-	// Prefer the explicit platform token; fall back to the access token.
-	defaultToken := platformToken
-	if defaultToken == "" {
-		defaultToken = token
-	}
 
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace AWS CloudFormation Integration")
@@ -379,11 +371,11 @@ func InstallAWS(c *client.PlatformClient, envURL, token, platformToken string, d
 		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 
-	if defaultToken == "" {
+	if token == "" {
 		return fmt.Errorf("platform token is required (--platform-token or DT_PLATFORM_TOKEN)")
 	}
-	settingsToken := defaultToken
-	ingestToken := defaultToken
+	settingsToken := token
+	ingestToken := token
 
 	// ── Preflight ─────────────────────────────────────────────────────────────
 
@@ -498,7 +490,7 @@ func InstallAWS(c *client.PlatformClient, envURL, token, platformToken string, d
 
 	// Run Lambda instrumentation on the main thread — it is quick but produces
 	// a lot of output, so let it finish before handing the terminal to watch.
-	lambdaErr := InstallAWSLambda(envURL, token, platformToken, false, false)
+	lambdaErr := InstallAWSLambda(envURL, token, false, false)
 	if lambdaErr != nil {
 		fmt.Printf("\n  Warning: Lambda instrumentation encountered an error: %s\n", lambdaErr)
 		fmt.Println("  You can retry with: dtwiz install aws-lambda")
@@ -506,8 +498,8 @@ func InstallAWS(c *client.PlatformClient, envURL, token, platformToken string, d
 
 	// Start watch after Lambda output is done — CFN deploy is still running
 	// in the background and will send its result into statusCh.
-	if startTime != "" && platformToken != "" {
-		WatchIngestWithStatus(envURL, platformToken, startTime, statusCh)
+	if startTime != "" && token != "" {
+		WatchIngestWithStatus(envURL, token, startTime, statusCh)
 	}
 
 	wg.Wait()

--- a/pkg/installer/aws.tmpl
+++ b/pkg/installer/aws.tmpl
@@ -7,7 +7,7 @@ stack:
   name: "{{ .StackName }}"
 
   # Pinned CloudFormation template (hosted by Dynatrace).
-  template_url: "https://dynatrace-data-acquisition.s3.amazonaws.com/aws/deployment/cfn/v1.0.0/da-aws-activation.yaml"
+  template_url: "https://dynatrace-data-acquisition.s3.amazonaws.com/aws/deployment/cfn/v1.0.11/da-aws-activation.yaml"
 
   # IAM resources are created by the template — CAPABILITY_NAMED_IAM is required.
   capabilities:

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -652,7 +652,7 @@ func updateFunctionConfig(functionName string, envVars map[string]string, layers
 // with the Dynatrace Lambda Layer. When confirm is true, the user is prompted
 // before applying changes; when false, changes are applied immediately after
 // the preview (used when called from install aws).
-func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool) error {
+func InstallAWSLambda(envURL, token string, dryRun, confirm bool) error {
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace AWS Lambda Instrumentation")
 	fmt.Println()
@@ -663,7 +663,7 @@ func InstallAWSLambda(envURL, token, platformToken string, dryRun, confirm bool)
 		return fmt.Errorf("Dynatrace environment URL is required (--environment or DT_ENVIRONMENT)") //nolint:staticcheck // ST1005: keep brand capitalization
 	}
 	if token == "" {
-		return fmt.Errorf("access token is required (--access-token or DT_ACCESS_TOKEN)")
+		return fmt.Errorf("platform token is required (--platform-token or DT_PLATFORM_TOKEN)")
 	}
 
 	if !isAWSCLIInstalled() {

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -178,7 +178,7 @@ func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building connection info request: %w", err)
 	}
-	req.Header.Set("Authorization", dtAuthHeader(token))
+	req.Header.Set("Authorization", AuthHeader(token))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -232,7 +232,7 @@ func getClusterID(envURL, token string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("building cluster ID request: %w", err)
 	}
-	req.Header.Set("Authorization", dtAuthHeader(token))
+	req.Header.Set("Authorization", AuthHeader(token))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -275,7 +275,7 @@ func getAgentConnectionToken(envURL, token string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("building agent connection token request: %w", err)
 	}
-	req.Header.Set("Authorization", dtAuthHeader(token))
+	req.Header.Set("Authorization", AuthHeader(token))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -332,7 +332,7 @@ func getLambdaLayerARN(cache layerARNCache, envURL, token, techtype, arch, regio
 	if err != nil {
 		return "", fmt.Errorf("building layer ARN request: %w", err)
 	}
-	req.Header.Set("Authorization", dtAuthHeader(token))
+	req.Header.Set("Authorization", AuthHeader(token))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/installer/demo.go
+++ b/pkg/installer/demo.go
@@ -170,7 +170,7 @@ func extractZip(zipPath, destDir string) error {
 // 1. Download & extract schnitzel (if not already present)
 // 2. Install Python if missing
 // 3. Install OTel Collector + Python auto-instrumentation targeting ./schnitzel
-func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
+func InstallDemo(envURL, token string, dryRun bool) error {
 	demoExists := checkDemoExists()
 	pythonCmd, err := pythonInstallPlan()
 	if err != nil {
@@ -238,5 +238,5 @@ func InstallDemo(envURL, accessTok, platformTok string, dryRun bool) error {
 		return fmt.Errorf("resolving demo directory path: %w", err)
 	}
 	AutoConfirm = true
-	return InstallOtelCollectorWithProject(envURL, accessTok, accessTok, platformTok, absDemoDir, dryRun)
+	return InstallOtelCollectorWithProject(envURL, token, token, absDemoDir, dryRun)
 }

--- a/pkg/installer/demo.go
+++ b/pkg/installer/demo.go
@@ -170,7 +170,7 @@ func extractZip(zipPath, destDir string) error {
 // 1. Download & extract schnitzel (if not already present)
 // 2. Install Python if missing
 // 3. Install OTel Collector + Python auto-instrumentation targeting ./schnitzel
-func InstallDemo(envURL, token string, dryRun bool) error {
+func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 	demoExists := checkDemoExists()
 	pythonCmd, err := pythonInstallPlan()
 	if err != nil {
@@ -238,5 +238,5 @@ func InstallDemo(envURL, token string, dryRun bool) error {
 		return fmt.Errorf("resolving demo directory path: %w", err)
 	}
 	AutoConfirm = true
-	return InstallOtelCollectorWithProject(envURL, token, token, absDemoDir, dryRun)
+	return InstallOtelCollectorWithProject(envURL, token, platformTok, absDemoDir, dryRun)
 }

--- a/pkg/installer/demo_test.go
+++ b/pkg/installer/demo_test.go
@@ -48,7 +48,7 @@ func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 
 	output := captureStdout(t, func() {
 		err := InstallOtelCollectorWithProject(
-			"https://fake.live.dynatrace.com", "tok", "tok", "plat", "", true,
+			"https://fake.live.dynatrace.com", "tok", "tok", "", true,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -66,7 +66,7 @@ func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 }
 
 func TestInstallOtelCollectorWithProjectPathNotFound(t *testing.T) {
-	err := InstallOtelCollectorWithProject("https://fake.live.dynatrace.com", "tok", "tok", "plat", "/nonexistent/path", false)
+	err := InstallOtelCollectorWithProject("https://fake.live.dynatrace.com", "tok", "tok", "/nonexistent/path", false)
 	if err == nil {
 		t.Fatal("expected error for non-existent project path")
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -78,7 +78,7 @@ func killAndWaitProcess(proc *os.Process) error {
 }
 
 // AuthHeader returns the correct Authorization header value for a given token.
-// API tokens (starting with "dt0c01.") use "Api-Token" scheme; all others use "Bearer".
+// API tokens (dt0c01.*) use the "Api-Token" scheme; all others use "Bearer".
 func AuthHeader(token string) string {
 	if strings.HasPrefix(token, "dt0c01.") {
 		return "Api-Token " + token

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -287,16 +287,11 @@ func fetchClusterName(fallback string) string {
 // InstallKubernetes deploys the Dynatrace Operator on a Kubernetes cluster.
 //
 // Parameters:
-//   - envURL:    Dynatrace environment URL
-//   - token:     data-ingest token (used as dataIngestToken in the Secret)
-//   - apiToken:  Classic Dynatrace access token (dt0c01.*) used as apiToken in the
-//     DynaKube Secret; falls back to token when empty
-//   - name:      DynaKube CR name (auto-derived from envURL if empty)
-//   - dryRun:    when true, only print what would be done
-func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error {
-	if apiToken == "" {
-		apiToken = token
-	}
+//   - envURL:  Dynatrace environment URL
+//   - token:   platform token used for both apiToken and dataIngestToken in the DynaKube Secret
+//   - name:    DynaKube CR name (auto-derived from envURL if empty)
+//   - dryRun:  when true, only print what would be done
+func InstallKubernetes(envURL, token, name string, dryRun bool) error {
 	apiURL := APIURL(envURL)
 
 	if name == "" {
@@ -310,8 +305,8 @@ func InstallKubernetes(envURL, token, apiToken, name string, dryRun bool) error 
 	tmplData := dynakubeTemplateData{
 		ClusterName:     name,
 		APIURL:          apiURL + "/api",
-		APIToken:        apiToken,
-		DataIngestToken: apiToken,
+		APIToken:        token,
+		DataIngestToken: token,
 		EECRepository:   eecRepositoryFromAPIURL(apiURL + "/api"),
 	}
 	manifest, err := renderDynakubeTemplate(tmplData)

--- a/pkg/installer/oneagent_test.go
+++ b/pkg/installer/oneagent_test.go
@@ -14,7 +14,7 @@ import (
 // newTestClassicClient creates a ClassicClient pointing at the given test server URL.
 func newTestClassicClient(t *testing.T, serverURL string) *client.ClassicClient {
 	t.Helper()
-	c, err := client.New(serverURL, "dt0c01.test", serverURL, "dt0s16.test", 0)
+	c, err := client.New(serverURL, serverURL, "dt0s16.test", "dt0s16.test", 0)
 	if err != nil {
 		t.Fatalf("create test client: %v", err)
 	}

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -23,7 +23,7 @@ func newMockTenantServer(t *testing.T, path string, status int, body string) *ht
 
 func newMockClient(t *testing.T, serverURL string) *client.Client {
 	t.Helper()
-	c, err := client.New(serverURL, "dt0c01.testtoken", serverURL, "dt0s16.testtoken", 0)
+	c, err := client.New(serverURL, serverURL, "dt0s16.testtoken", "dt0s16.testtoken", 0)
 	if err != nil {
 		t.Fatalf("newMockClient: %v", err)
 	}

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -190,11 +190,11 @@ func createRuntimePlan(proj detectedProject, apiURL, token, envURL, platformToke
 	return nil
 }
 
-func InstallOtelCollector(envURL, token, ingestToken, platformToken string, dryRun bool) error {
-	return InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, "", dryRun)
+func InstallOtelCollector(envURL, token, platformToken string, dryRun bool) error {
+	return InstallOtelCollectorWithProject(envURL, token, platformToken, "", dryRun)
 }
 
-func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, projectPath string, dryRun bool) error {
+func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath string, dryRun bool) error {
 	if projectPath != "" {
 		if _, err := os.Stat(projectPath); err != nil {
 			return fmt.Errorf("project path not found: %s", projectPath)
@@ -205,7 +205,7 @@ func InstallOtelCollectorWithProject(envURL, token, ingestToken, platformToken, 
 	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
 	fmt.Println()
 
-	cp, err := prepareCollectorPlan(envURL, token, ingestToken)
+	cp, err := prepareCollectorPlan(envURL, token)
 	if err != nil {
 		return err
 	}

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -707,12 +707,9 @@ type collectorPlan struct {
 	runningPIDs    []runningCollector
 }
 
-func prepareCollectorPlan(envURL, token, ingestToken string) (*collectorPlan, error) {
+func prepareCollectorPlan(envURL, token string) (*collectorPlan, error) {
 	apiURL := APIURL(envURL)
-	collectorToken := ingestToken
-	if collectorToken == "" {
-		collectorToken = token
-	}
+	collectorToken := token
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("getting working directory: %w", err)
@@ -734,7 +731,7 @@ func prepareCollectorPlan(envURL, token, ingestToken string) (*collectorPlan, er
 	}, nil
 }
 
-func (cp *collectorPlan) printDryRun(ingestToken string) {
+func (cp *collectorPlan) printDryRun() {
 	sep := strings.Repeat("─", 60)
 
 	fmt.Println("[dry-run] Would install Dynatrace OpenTelemetry Collector")
@@ -743,12 +740,7 @@ func (cp *collectorPlan) printDryRun(ingestToken string) {
 	fmt.Printf("  Config:       %s\n", cp.configPath)
 	assetName, _ := otelPlatformAssetName("latest")
 	fmt.Printf("  Asset:        %s\n", assetName)
-	fmt.Printf("  Ingest token: %s\n", func() string {
-		if ingestToken != "" {
-			return "(from --access-token)"
-		}
-		return "(from token)"
-	}())
+	fmt.Printf("  Ingest token: (from --platform-token)\n")
 
 	cp.printConfigPreview(sep)
 }
@@ -809,18 +801,18 @@ func (cp *collectorPlan) execute(envURL, platformToken string, skipVerification 
 
 // InstallOtelCollectorOnly installs the Dynatrace OTel Collector without
 // runtime instrumentation.
-func InstallOtelCollectorOnly(envURL, token, ingestToken, platformToken string, dryRun bool) error {
+func InstallOtelCollectorOnly(envURL, token, platformToken string, dryRun bool) error {
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
 	fmt.Println()
 
-	cp, err := prepareCollectorPlan(envURL, token, ingestToken)
+	cp, err := prepareCollectorPlan(envURL, token)
 	if err != nil {
 		return err
 	}
 
 	if dryRun {
-		cp.printDryRun(ingestToken)
+		cp.printDryRun()
 		return nil
 	}
 

--- a/pkg/installer/otel_collector.go
+++ b/pkg/installer/otel_collector.go
@@ -740,7 +740,7 @@ func (cp *collectorPlan) printDryRun() {
 	fmt.Printf("  Config:       %s\n", cp.configPath)
 	assetName, _ := otelPlatformAssetName("latest")
 	fmt.Printf("  Asset:        %s\n", assetName)
-	fmt.Printf("  Ingest token: (from --platform-token)\n")
+	fmt.Printf("  Ingest token: (configured)\n")
 
 	cp.printConfigPreview(sep)
 }

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -276,7 +276,7 @@ func PatchConfigFile(configPath, apiURL, token string) (*UpdateResult, error) {
 // If dryRun is true the preview is printed without prompting.
 // If configPath is empty or points to a non-existent file the user is prompted
 // to supply the correct path interactively.
-func UpdateOtelConfig(configPath, envURL, token string, dryRun bool) error {
+func UpdateOtelConfig(configPath, envURL, token, platformTok string, dryRun bool) error {
 	apiURL := APIURL(envURL)
 
 	// Resolve the config path: prompt when it's missing or the file doesn't exist.
@@ -388,7 +388,7 @@ func UpdateOtelConfig(configPath, envURL, token string, dryRun bool) error {
 	}
 
 	// Verify the restarted collector can deliver logs to Dynatrace.
-	if err := verifyOtelInstall(envURL, token, token, crashed); err != nil {
+	if err := verifyOtelInstall(envURL, platformTok, token, crashed); err != nil {
 		fmt.Printf("\n  Warning: log verification failed: %v\n", err)
 		fmt.Println("  The collector may still be working — check the Dynatrace UI.")
 		return nil

--- a/pkg/installer/otel_update.go
+++ b/pkg/installer/otel_update.go
@@ -16,10 +16,11 @@ import (
 
 // exporterSnippetTemplate is the YAML block to inject into an existing OTel Collector
 // configuration as the `otlp_http/dynatrace` exporter.
+// The second %s receives the full Authorization header value (e.g. "Bearer …" or "Api-Token …").
 const exporterSnippetTemplate = `otlp_http/dynatrace:
   endpoint: %s
   headers:
-    Authorization: "Api-Token %s"
+    Authorization: "%s"
 `
 
 // backupFile writes data to a timestamped .bak.<unix> copy of path and returns
@@ -65,7 +66,7 @@ type UpdateResult struct {
 func GenerateExporterSnippet(apiURL, token string) string {
 	return fmt.Sprintf(exporterSnippetTemplate,
 		dtOTLPEndpoint(apiURL),
-		token,
+		AuthHeader(token),
 	)
 }
 
@@ -177,7 +178,7 @@ func mergeDynatraceExporter(cfg map[string]interface{}, apiURL, token string) {
 	exporters["otlp_http/dynatrace"] = map[string]interface{}{
 		"endpoint": dtOTLPEndpoint(apiURL),
 		"headers": map[string]interface{}{
-			"Authorization": "Api-Token " + token,
+			"Authorization": AuthHeader(token),
 		},
 	}
 
@@ -275,7 +276,7 @@ func PatchConfigFile(configPath, apiURL, token string) (*UpdateResult, error) {
 // If dryRun is true the preview is printed without prompting.
 // If configPath is empty or points to a non-existent file the user is prompted
 // to supply the correct path interactively.
-func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bool) error {
+func UpdateOtelConfig(configPath, envURL, token string, dryRun bool) error {
 	apiURL := APIURL(envURL)
 
 	// Resolve the config path: prompt when it's missing or the file doesn't exist.
@@ -387,7 +388,7 @@ func UpdateOtelConfig(configPath, envURL, token, platformToken string, dryRun bo
 	}
 
 	// Verify the restarted collector can deliver logs to Dynatrace.
-	if err := verifyOtelInstall(envURL, platformToken, token, crashed); err != nil {
+	if err := verifyOtelInstall(envURL, token, token, crashed); err != nil {
 		fmt.Printf("\n  Warning: log verification failed: %v\n", err)
 		fmt.Println("  The collector may still be working — check the Dynatrace UI.")
 		return nil

--- a/pkg/installer/otel_update_test.go
+++ b/pkg/installer/otel_update_test.go
@@ -410,7 +410,7 @@ service:
 		t.Fatal(err)
 	}
 
-	err := UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", true)
+	err := UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", "", true)
 	if err != nil {
 		t.Fatalf("UpdateOtelConfig dry-run error: %v", err)
 	}

--- a/pkg/installer/otel_update_test.go
+++ b/pkg/installer/otel_update_test.go
@@ -410,7 +410,7 @@ service:
 		t.Fatal(err)
 	}
 
-	err := UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", "", true)
+	err := UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", true)
 	if err != nil {
 		t.Fatalf("UpdateOtelConfig dry-run error: %v", err)
 	}

--- a/test/e2e/otel_test.go
+++ b/test/e2e/otel_test.go
@@ -43,7 +43,7 @@ func TestOTelAutoInstrumentation(t *testing.T) {
 				}
 			},
 			install: func(env *integration.TestEnv, appDir, svcName string) error {
-				return installer.InstallOtelPython(env.EnvURL, env.AccessToken, env.PlatformToken, svcName, appDir, false)
+				return installer.InstallOtelPython(env.EnvURL, env.ClassicToken, env.PlatformToken, svcName, appDir, false)
 			},
 		},
 		{
@@ -66,7 +66,7 @@ func TestOTelAutoInstrumentation(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(appDir, "node_modules"), 0755); err != nil {
 					return err
 				}
-				return installer.InstallOtelNode(env.EnvURL, env.AccessToken, env.PlatformToken, svcName, appDir, false)
+				return installer.InstallOtelNode(env.EnvURL, env.ClassicToken, env.PlatformToken, svcName, appDir, false)
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestOTelAutoInstrumentation(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("mvn build failed: %w\n%s", err, out)
 				}
-				return installer.InstallOtelJava(env.EnvURL, env.AccessToken, svcName, appDir, false)
+				return installer.InstallOtelJava(env.EnvURL, env.ClassicToken, svcName, appDir, false)
 			},
 		},
 	}

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -18,24 +18,32 @@ type TestEnv struct {
 	TestID        string
 	TempDir       string
 	EnvURL        string
-	AccessToken   string
-	PlatformToken string
+	PlatformToken string // required; used for Platform/DQL API calls
+	AccessToken   string // optional; used as Classic API token when set
+	ClassicToken  string // effective Classic API token: AccessToken if set, else PlatformToken
 }
 
 // SetupIntegration validates required environment variables, constructs a
 // *client.Client, generates a unique test ID, and returns a TestEnv.
-// It calls t.Fatal if any required variable is missing.
+// TEST_DT_PLATFORM_TOKEN is required. TEST_DT_ACCESS_TOKEN is optional; when
+// set it is used as the Classic API token, otherwise PlatformToken is used.
+// It calls t.Fatal if requirements are not met.
 func SetupIntegration(t *testing.T) *TestEnv {
 	t.Helper()
 
 	envUrl := requireEnv(t, "TEST_DT_ENVIRONMENT")
-	accessToken := requireEnv(t, "TEST_DT_ACCESS_TOKEN")
 	platformToken := requireEnv(t, "TEST_DT_PLATFORM_TOKEN")
+	accessToken := os.Getenv("TEST_DT_ACCESS_TOKEN")
+
+	classicToken := platformToken
+	if accessToken != "" {
+		classicToken = accessToken
+	}
 
 	classicURL := installer.APIURL(envUrl)
 	platformURL := installer.AppsURL(envUrl)
 
-	c, err := client.New(classicURL, accessToken, platformURL, platformToken, 0)
+	c, err := client.New(classicURL, platformURL, classicToken, platformToken, 0)
 	if err != nil {
 		t.Fatalf("SetupIntegration: failed to create client: %v", err)
 	}
@@ -47,8 +55,9 @@ func SetupIntegration(t *testing.T) *TestEnv {
 		TestID:        testID,
 		TempDir:       t.TempDir(),
 		EnvURL:        envUrl,
-		AccessToken:   accessToken,
 		PlatformToken: platformToken,
+		AccessToken:   accessToken,
+		ClassicToken:  classicToken,
 	}
 }
 


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Platform token is now the primary authentication method. The access token (`DT_ACCESS_TOKEN`) becomes optional — when set (legacy customers), it takes precedence for Classic API calls; when absent, the platform token is used in its place and `"  Using platform token"` is printed to the console.

Previously, both tokens were treated symmetrically; now, the platform token is required and drives all Platform/DQL API calls. For Classic API calls, the access token takes precedence when explicitly configured, otherwise the platform token is used.

## How to test

1. Set only `DT_PLATFORM_TOKEN` (no `DT_ACCESS_TOKEN`) and run any install command with `--dry-run --debug` — should succeed, print `"  Using platform token"`, and log `"classic API auth: platform token accepted"`.
2. Set both tokens and run the same command — access token should be used directly for Classic API (logged as `"classic API auth: using explicit access token"`).
3. Omit `DT_PLATFORM_TOKEN` entirely — every command should fail with a clear error asking for `--platform-token`.

## Which other features are affected?

1. `dtwiz status` — access token row labeled "Access Token" is shown only when `DT_ACCESS_TOKEN` is set.
2. All install/update/uninstall commands — credential resolution order changed; existing workflows with only a platform token continue to work without any config change.

## Checklist

- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.