### PR TITLE
bugfix: shorten waiting period

### DIFF
--- a/pkg/installer/otel_process.go
+++ b/pkg/installer/otel_process.go
@@ -11,16 +11,10 @@ import (
 )
 
 const (
-	portPollInterval = 500 * time.Millisecond
-	// portPollTimeout has to outlast Maven compilation + Spring Boot startup.
-	// Typical projects take 20–45s on Unix; on slow Windows VMs Spring Boot
-	// can take 60–120s. Each probe iteration also burns ~5–10s to PowerShell
-	// startup, so the effective poll rate is much lower than portPollInterval.
-	// Services that legitimately do not expose a port make the user wait the
-	// full timeout before "port not detected" is shown.
-	portPollTimeout    = 3 * time.Minute
+	portPollInterval   = 500 * time.Millisecond
+	portPollTimeout    = 10 * time.Second
 	processSettleDelay = 3 * time.Second
-	slowHintDelay      = 10 * time.Second
+	slowHintDelay      = 5 * time.Second
 )
 
 type ManagedProcess struct {
@@ -165,7 +159,7 @@ func PrintProcessSummary(procs []*ManagedProcess, settleDuration time.Duration) 
 		go func() {
 			select {
 			case <-time.After(slowHintDelay):
-				fmt.Println("  Still detecting ports — this may take a while.")
+				fmt.Println("  Still detecting ports...")
 			case <-hintDone:
 			}
 		}()


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Shortens the port-detection waiting period in `otel_process.go`:
- `portPollTimeout` reduced from 3 minutes → 10 seconds
- `slowHintDelay` reduced from 10 seconds → 5 seconds
- Simplifies the "still detecting" hint message

The previous 3-minute timeout was originally sized to outlast Maven compilation and slow Windows Spring Boot startup (60–120s), but this made the experience painful for services that don't expose a port, since the user had to wait the full timeout before seeing "port not detected." 10 seconds is a more responsive default.

## How to test

1. Run `dtwiz install otel-python` (or java/node) against a service that does **not** expose a port (any repo with a load-generator) — confirm the timeout surfaces within ~10 seconds instead of waiting 3 minutes.
2. Run against a service that **does** expose a port — anything without a load generator - confirm detection still works correctly within the new timeout window.
3. Verify the "Still detecting ports..." hint appears after ~5 seconds when detection is slow.

## Which other features are affected?

1. All OTel per-language installers that use `ManagedProcess` for port detection: `otel_java.go`, `otel_java_multimodule.go`, `otel_nodejs.go`, `otel_python.go` — all share the constants from `otel_process.go`.

## Checklist

- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate. *(No test changes needed — no tests cover these timeout constants.)*
- [x] I followed the existing code style and conventions.