### PR TITLE
feat: use project flag

### DIFF
--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -192,7 +192,7 @@ func createRuntimePlan(proj detectedProject, apiURL, token, envURL, platformToke
 }
 
 // inferRuntimeFromPath returns "Java", "Node.js", "Python", or "" based on which
-// marker files are present directly inside path.
+// marker files or directories are present directly inside path.
 func inferRuntimeFromPath(path string) string {
 	hasFile := func(name string) bool {
 		_, err := os.Stat(filepath.Join(path, name))

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -203,8 +203,10 @@ func inferRuntimeFromPath(path string) string {
 			return "Java"
 		}
 	}
-	if hasFile("package.json") {
-		return "Node.js"
+	for _, m := range nodeProjectMarkers {
+		if hasFile(m) {
+			return "Node.js"
+		}
 	}
 	for _, m := range pythonProjectMarkers {
 		if hasFile(m) {

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -190,6 +191,29 @@ func createRuntimePlan(proj detectedProject, apiURL, token, envURL, platformToke
 	return nil
 }
 
+// inferRuntimeFromPath returns "Java", "Node.js", "Python", or "" based on which
+// marker files are present directly inside path.
+func inferRuntimeFromPath(path string) string {
+	hasFile := func(name string) bool {
+		_, err := os.Stat(filepath.Join(path, name))
+		return err == nil
+	}
+	for _, m := range javaProjectMarkers {
+		if hasFile(m) {
+			return "Java"
+		}
+	}
+	if hasFile("package.json") {
+		return "Node.js"
+	}
+	for _, m := range pythonProjectMarkers {
+		if hasFile(m) {
+			return "Python"
+		}
+	}
+	return ""
+}
+
 func InstallOtelCollector(envURL, token, platformToken string, dryRun bool) error {
 	return InstallOtelCollectorWithProject(envURL, token, platformToken, "", dryRun)
 }
@@ -214,10 +238,20 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 
 	var plan InstrumentationPlan
 	if projectPath != "" {
-		// --project provided: skip scan, but still detect running processes to stop them.
+		runtime := inferRuntimeFromPath(projectPath)
+		if runtime == "" {
+			return fmt.Errorf("could not detect runtime from project path: %s", projectPath)
+		}
 		projects := []ScannedProject{{Path: projectPath}}
-		matchProcessesToProjects(projects, detectPythonProcesses())
-		proj := detectedProject{ScannedProject: projects[0], Runtime: "Python"}
+		switch runtime {
+		case "Java":
+			matchProcessesToProjects(projects, detectJavaProcesses())
+		case "Node.js":
+			matchProcessesToProjects(projects, detectNodeProcesses())
+		default:
+			matchProcessesToProjects(projects, detectPythonProcesses())
+		}
+		proj := detectedProject{ScannedProject: projects[0], Runtime: runtime}
 		plan = createRuntimePlan(proj, cp.apiURL, token, envURL, platformToken)
 	} else {
 		projects := detectAllProjects(runtimes)

--- a/pkg/installer/otel_nodejs_project.go
+++ b/pkg/installer/otel_nodejs_project.go
@@ -16,8 +16,18 @@ type packageJSON struct {
 	Workspaces      json.RawMessage   `json:"workspaces"`
 }
 
+var nodeProjectMarkers = []string{
+	"package.json",
+	"package-lock.json",
+	"yarn.lock",
+	"pnpm-lock.yaml",
+	"bun.lockb",
+	".nvmrc",
+	".node-version",
+}
+
 func detectNodeProjects() []ScannedProject {
-	projects := scanProjectDirs([]string{"package.json"}, []string{"node_modules"})
+	projects := scanProjectDirs(nodeProjectMarkers, []string{"node_modules"})
 
 	// Expand monorepo workspaces: for each project with a "workspaces" field,
 	// resolve workspace directories and add them as individual projects.

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -35,9 +35,9 @@ func setTestStdin(t *testing.T, input string) {
 
 func TestInferRuntimeFromPath(t *testing.T) {
 	tests := []struct {
-		name    string
-		files   []string
-		want    string
+		name  string
+		files []string
+		want  string
 	}{
 		{name: "python requirements.txt", files: []string{"requirements.txt"}, want: "Python"},
 		{name: "python pyproject.toml", files: []string{"pyproject.toml"}, want: "Python"},

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -33,6 +33,44 @@ func setTestStdin(t *testing.T, input string) {
 	})
 }
 
+func TestInferRuntimeFromPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		want    string
+	}{
+		{name: "python requirements.txt", files: []string{"requirements.txt"}, want: "Python"},
+		{name: "python pyproject.toml", files: []string{"pyproject.toml"}, want: "Python"},
+		{name: "python manage.py", files: []string{"manage.py"}, want: "Python"},
+		{name: "java pom.xml", files: []string{"pom.xml"}, want: "Java"},
+		{name: "java build.gradle", files: []string{"build.gradle"}, want: "Java"},
+		{name: "java build.gradle.kts", files: []string{"build.gradle.kts"}, want: "Java"},
+		{name: "nodejs package.json", files: []string{"package.json"}, want: "Node.js"},
+		{name: "no markers", files: []string{"README.md"}, want: ""},
+		// Java wins over Node.js when both present (e.g. Spring with frontend tooling).
+		{name: "java beats nodejs", files: []string{"pom.xml", "package.json"}, want: "Java"},
+		// Java wins over Python.
+		{name: "java beats python", files: []string{"build.gradle", "requirements.txt"}, want: "Java"},
+		// Node.js wins over Python.
+		{name: "nodejs beats python", files: []string{"package.json", "requirements.txt"}, want: "Node.js"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte{}, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := inferRuntimeFromPath(dir)
+			if got != tt.want {
+				t.Errorf("inferRuntimeFromPath(%v) = %q, want %q", tt.files, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectAvailableRuntimes_DefaultEnabled(t *testing.T) {
 	featureflags.ClearCLIOverrideForTest(t, featureflags.AllRuntimes)
 	t.Setenv("DTWIZ_ALL_RUNTIMES", "")

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -37,6 +37,7 @@ func TestInferRuntimeFromPath(t *testing.T) {
 	tests := []struct {
 		name  string
 		files []string
+		dirs  []string
 		want  string
 	}{
 		{name: "python requirements.txt", files: []string{"requirements.txt"}, want: "Python"},
@@ -45,6 +46,7 @@ func TestInferRuntimeFromPath(t *testing.T) {
 		{name: "java pom.xml", files: []string{"pom.xml"}, want: "Java"},
 		{name: "java build.gradle", files: []string{"build.gradle"}, want: "Java"},
 		{name: "java build.gradle.kts", files: []string{"build.gradle.kts"}, want: "Java"},
+		{name: "java .mvn directory", dirs: []string{".mvn"}, want: "Java"},
 		{name: "nodejs package.json", files: []string{"package.json"}, want: "Node.js"},
 		{name: "no markers", files: []string{"README.md"}, want: ""},
 		// Java wins over Node.js when both present (e.g. Spring with frontend tooling).
@@ -63,9 +65,14 @@ func TestInferRuntimeFromPath(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			for _, d := range tt.dirs {
+				if err := os.Mkdir(filepath.Join(dir, d), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
 			got := inferRuntimeFromPath(dir)
 			if got != tt.want {
-				t.Errorf("inferRuntimeFromPath(%v) = %q, want %q", tt.files, got, tt.want)
+				t.Errorf("inferRuntimeFromPath(%v, dirs=%v) = %q, want %q", tt.files, tt.dirs, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

- [x] Bug fix
- [x] New feature

`install otel --project <path>` previously hardcoded the runtime as Python regardless of what was at `<path>`. This PR infers the runtime from marker files in the directory, so Java and Node.js projects are now handled correctly.

## How to test

1. Run `dtwiz install otel --project <path-to-java-project>` (directory with `pom.xml` or `build.gradle`) — should build a Java instrumentation plan.
2. Run `dtwiz install otel --project <path-to-node-project>` (directory with `package.json`) — should build a Node.js instrumentation plan.
3. Run `dtwiz install otel --project <path-to-python-project>` (directory with `requirements.txt`) — should behave as before.
4. Run `dtwiz install otel --project <path-with-no-markers>` — should exit with `could not detect runtime from project path: <path>`.
5. Run `dtwiz install demo` — schnitzel demo (Python, has `requirements.txt` at root) should work unchanged.

## Which other features are affected?

1. `dtwiz install demo` — calls `InstallOtelCollectorWithProject` internally; verified safe since the schnitzel repo has `requirements.txt` at root.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.