### PR TITLE
feat(windows-install): add instructions when dtwiz is blocked by windows defender

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -181,6 +181,18 @@ try {
         Write-Host "  Added $InstallDir to your user PATH."
         Write-Host "  Open a new terminal for the change to take effect."
     }
+    Write-Host ""
+    Write-Host "┌──────────────────────────────────────────────────────────────┐"
+    Write-Host "│ ℹ️  In case dtwiz is blocked by Windows Defender              │"
+    Write-Host "├──────────────────────────────────────────────────────────────┤"
+    Write-Host "│ 1. Run:                                                      │"
+    Write-Host "│    Start-Process `"windowsdefender://exclusions`"              │"
+    Write-Host "│                                                              │"
+    Write-Host "│ 2. Add this folder to exclusions:                            │"
+    Write-Host "│    $InstallDir"
+    Write-Host "│                                                              │"
+    Write-Host "│ Then re-run `"dtwiz setup`".                                   │"
+    Write-Host "└──────────────────────────────────────────────────────────────┘"
 } finally {
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Feature Description


## How to test
1.

## Which other features are affected?
1.

## Checklist
- [ ] Make sure Copilot has reviewed the PR as a preliminary check.
- [ ] I have tested these changes locally.
- [ ] I updated OpenSpec and other documentation where necessary.
- [ ] I added or updated tests where appropriate.
- [ ] I followed the existing code style and conventions.
