### PR TITLE
feat(windows-install): add windows defender instructions to the installation script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -183,13 +183,13 @@ try {
     }
     Write-Host ""
     Write-Host "┌────────────────────────────────────────────────────────────────┐"
-    Write-Host "│ ℹ️  In case dtwiz is blocked by Windows Defender               │"
+    Write-Host "│ ℹ️  In case dtwiz is blocked by Windows Security               │"
     Write-Host "├────────────────────────────────────────────────────────────────┤"
     Write-Host "│ 1. Run:                                                        │"
     Write-Host "│    Start-Process `"windowsdefender://exclusions`"                │"
     Write-Host "│                                                                │"
     Write-Host "│ 2. Add this folder to exclusions:                              │"
-    $DefenderPad = " " * (60 - $InstallDir.Length)
+    $DefenderPad = " " * ([Math]::Max(0, 60 - $InstallDir.Length))
     Write-Host "│    $InstallDir$DefenderPad│"
     Write-Host "│                                                                │"
     Write-Host "│ Then re-run `"dtwiz setup`".                                     │"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -181,6 +181,19 @@ try {
         Write-Host "  Added $InstallDir to your user PATH."
         Write-Host "  Open a new terminal for the change to take effect."
     }
+    Write-Host ""
+    Write-Host "┌────────────────────────────────────────────────────────────────┐"
+    Write-Host "│ ℹ️  In case dtwiz is blocked by Windows Defender               │"
+    Write-Host "├────────────────────────────────────────────────────────────────┤"
+    Write-Host "│ 1. Run:                                                        │"
+    Write-Host "│    Start-Process `"windowsdefender://exclusions`"                │"
+    Write-Host "│                                                                │"
+    Write-Host "│ 2. Add this folder to exclusions:                              │"
+    $DefenderPad = " " * (60 - $InstallDir.Length)
+    Write-Host "│    $InstallDir$DefenderPad│"
+    Write-Host "│                                                                │"
+    Write-Host "│ Then re-run `"dtwiz setup`".                                     │"
+    Write-Host "└────────────────────────────────────────────────────────────────┘"
 } finally {
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Feature Description

Updates the windows installation script to provide an info message for the case when the `dtwiz` binary is blocked from being executed by Windows Defender. 

## How to test
1. Run the PR preview windows snapshot on the Windows machine.
2. Make sure that at the end of the installation script, an info block is returned as on the screenshot below.
<img width="869" height="323" alt="image" src="https://github.com/user-attachments/assets/44c2c877-0f01-4baf-8eb7-95933a6bb267" />


## Which other features are affected?
N/A

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
