### PR TITLE
feat: oneagent installer

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -59,6 +59,7 @@ var installOneAgentCmd = &cobra.Command{
 		opts := oneagent.InstallOptions{
 			DryRun:                installDryRun,
 			MonitoringMode:        flagMonitoringMode,
+			HostGroup:             hostGroup,
 			NoVerifySignature:     flagNoVerifySignature,
 			SkipConnectivityCheck: flagSkipConnectivityCheck,
 			ConnectivityCheckOnly: flagConnectivityCheckOnly,

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -55,7 +56,7 @@ var installOneAgentCmd = &cobra.Command{
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		hostGroup, _ := cmd.Flags().GetString("host-group")
 
-		opts := installer.InstallOptions{
+		opts := oneagent.InstallOptions{
 			DryRun:                installDryRun,
 			MonitoringMode:        flagMonitoringMode,
 			NoVerifySignature:     flagNoVerifySignature,
@@ -66,7 +67,7 @@ var installOneAgentCmd = &cobra.Command{
 		}
 
 		if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-			return installer.InstallOneAgentV2(c, opts)
+			return oneagent.InstallOneAgentV2(c, opts)
 		}
 
 		if err := installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup); err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 var installDryRun bool
@@ -25,6 +26,11 @@ var installCmd = &cobra.Command{
 	Short: "Install a Dynatrace ingestion method",
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// installCmd.PersistentPreRun overrides root's, so reproduce its behaviour here.
+		logger.Init(debugFlag, verbosityFlag)
+		logger.Verbose("logging: verbose")
+		logger.Debug("logging: debug")
+		featureflags.ApplyCLIOverrides(cmd.Flags())
 		installer.AutoConfirm = installAutoConfirm
 	},
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
 )
 
@@ -139,7 +140,7 @@ var setupCmd = &cobra.Command{
 		switch selected.Method {
 		case recommender.MethodOneAgent:
 			if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-				installErr = installer.InstallOneAgentV2(c, installer.InstallOptions{
+				installErr = oneagent.InstallOneAgentV2(c, oneagent.InstallOptions{
 					DryRun:         setupDryRun,
 					MonitoringMode: string(installer.InstallModeFullStack),
 				})

--- a/openspec/changes/oneagent-analyze/design.md
+++ b/openspec/changes/oneagent-analyze/design.md
@@ -19,7 +19,7 @@ Gaps relative to the production requirements for this rework:
 - No post-install confirmation. The function returns success as soon as the installer subprocess exits 0. (The caller wires `WatchIngest` from `pkg/installer/ingest_watch.go` which polls Grail via DQL for general data flow, but it does not confirm that *this specific host* has registered.)
 - `--monitoring-mode` is not user-configurable — the flow always behaves as full-stack.
 
-The existing implementation is not assumed correct; this change rebuilds the flow in `oneagent_v2.go` and replaces the old function at the end.
+The existing implementation is not assumed correct; this change rebuilds the flow in `pkg/installer/oneagent/` and replaces the old function at the end.
 
 The codebase already has:
 
@@ -32,7 +32,7 @@ The codebase already has:
 
 **Goals:**
 
-- A new `InstallOneAgentV2` flow in `pkg/installer/oneagent_v2.go` covering the eight critical tasks documented in [tasks.md](../tasks.md).
+- A new `InstallOneAgentV2` flow in `pkg/installer/oneagent/` covering the eight critical tasks documented in [tasks.md](../tasks.md).
 - Fail-fast pre-flights before any network work.
 - Mandatory installer-token minting with no fallback.
 - Linux signature verification gated only by the explicit `--no-verify-signature` flag.
@@ -50,15 +50,17 @@ The codebase already has:
 
 ## Decisions
 
-### 1. Two-file split: `oneagent.go` + `oneagent_v2.go`
+### 1. Package split: `pkg/installer/oneagent/`
 
-During Tasks 1–7, the new flow lives entirely in `pkg/installer/oneagent_v2.go`. The existing `oneagent.go` is left untouched (apart from a small extension in Task 2 to expose `oneAgentInstallerType` results in the new `Environment` struct shape, behind a new helper that does not break existing callers).
+The new flow lives entirely in `pkg/installer/oneagent/` (Go package `oneagent`), leaving the rest of `pkg/installer/` unchanged until Task 8. The package is split across three source files:
 
-At Task 8, `oneagent_v2.go`'s functions are renamed/moved into `oneagent.go`, replacing the old implementations entirely. `oneagent_v2.go` is deleted.
+- `oneagent.go` — types, entry point `InstallOneAgentV2`, `DefaultAgentConfig`, `ResolveAgentConfig`, `detectRuntimeEnvironment`
+- `download.go` — `DownloadInstaller`, `readErrorBody`, OS/arch helpers
+- `verify.go` — `VerifyInstallerSignature`, CA fetch, openssl invocation
 
-This split keeps the diff reviewable, makes the rollback path mechanical, and avoids touching the old call sites until they are ready to be cut over.
+At Task 8, the `pkg/installer/oneagent/` package replaces the old `InstallOneAgent` entirely and the feature flag is removed.
 
-**Alternative considered:** Build the new flow incrementally inside `oneagent.go` by toggling code paths on the feature flag inside individual functions. Rejected — interleaved code paths make the rollback and the eventual cleanup much more invasive.
+This split keeps each concern isolated, makes rollback mechanical (delete the directory), and avoids touching the old call sites until Task 8.
 
 ### 2. Feature flag: `ONEAGENT_POC`, removed at Task 8
 
@@ -77,7 +79,7 @@ During Tasks 1–7, `cmd/install.go`'s `installOneAgentCmd.RunE` branches:
 
 ```go
 if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-    return installer.InstallOneAgentV2(c.Classic, opts)
+    return oneagent.InstallOneAgentV2(c, opts)
 }
 return installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup)
 ```

--- a/openspec/changes/oneagent-analyze/proposal.md
+++ b/openspec/changes/oneagent-analyze/proposal.md
@@ -37,7 +37,7 @@ The new flow is gated behind `ONEAGENT_POC` during development. Once Task 8 land
 
 ## Impact
 
-- **New files:** `pkg/installer/oneagent_v2.go`, `pkg/installer/oneagent_v2_test.go`, `test/e2e/oneagent_test.go` (optional, Task 11).
+- **New package:** `pkg/installer/oneagent/` (source split across `oneagent.go`, `download.go`, `verify.go`; tests in `oneagent_test.go`), `test/e2e/oneagent_test.go` (optional, Task 11).
 - **Modified files:**
   - `pkg/installer/oneagent.go` — extended in Task 2 to return the `Environment` struct; replaced entirely in Task 8.
   - `pkg/featureflags/featureflags.go` — `ONEAGENT_POC` added in Task 1; removed in Task 8.
@@ -46,6 +46,6 @@ The new flow is gated behind `ONEAGENT_POC` during development. Once Task 8 land
 - **Breaking change:** `InstallOneAgent`'s signature changes in Task 8 (struct-based options). All callers (`cmd/install.go`, `cmd/setup.go`) update together.
 - **Rollback:**
   - During development: set `DTWIZ_ONEAGENT_POC=false` (default) to fall back to the existing flow.
-  - Pre-Task-8: delete `pkg/installer/oneagent_v2.go` and revert `cmd/install.go`/`pkg/featureflags/featureflags.go`.
+  - Pre-Task-8: delete `pkg/installer/oneagent/` and revert `cmd/install.go`/`pkg/featureflags/featureflags.go`.
   - Post-Task-8: the old flow no longer exists; rollback is a git revert of the Task-8 commit.
 - **Feature flag:** `ONEAGENT_POC` (env `DTWIZ_ONEAGENT_POC`, CLI `--oneagent-poc`) — temporary, removed at the end of Task 8.

--- a/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
+++ b/openspec/changes/oneagent-analyze/specs/oneagent-analyze/tasks.md
@@ -21,13 +21,13 @@ Before implementing, review the design and spec documents to understand the requ
 
 Detect OS/arch and run the existing-OneAgent and privilege pre-flights before any network work. Fail fast with clear, actionable errors. Agent configuration (default + `--monitoring-mode` override) is a separate concern owned by Task 2.5.
 
-**Files:** `pkg/installer/oneagent.go` (extend), `pkg/installer/oneagent_v2.go` (extend — created in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — created in Task 1), `pkg/analyzer/detect_oneagent_unix.go` / `_windows.go` (reuse)
+**Files:** `pkg/installer/oneagent.go` (extend), `pkg/installer/oneagent/` (extend — created in Task 1), `pkg/analyzer/detect_oneagent_unix.go` / `_windows.go` (reuse)
 
-Task 1 has already created `oneagent_v2.go` with the `InstallOptions` struct and the stub `InstallOneAgentV2` entry function. This task fills in the stub with the OS-detection + preflight stages.
+Task 1 has already created the `pkg/installer/oneagent/` package with the `InstallOptions` struct and the full `InstallOneAgentV2` entry function. This task fills in the OS-detection + preflight stages.
 
 ### Part A — OS/Arch detection
 
-- [ ] 2.1 Define `Environment` struct (`OS`, `Arch`, `Supported`, `Reason`) in `oneagent_v2.go`
+- [ ] 2.1 Define `Environment` struct (`OS`, `Arch`, `Supported`, `Reason`) in `pkg/installer/oneagent/oneagent.go` (if not already present from Task 1)
 - [ ] 2.2 Implement `DetectEnvironment() Environment` mapping `runtime.GOOS`/`runtime.GOARCH` → `OS` ("windows"/"linux"/"aix"/"other") and `Arch` ("x86" for `amd64`/`386`, "arm" for `arm64`/`arm`, "other" otherwise)
 - [ ] 2.3 Mark AIX as `Supported: false` with `Reason: "AIX is not supported"`; preserve the existing macOS rejection message
 - [ ] 2.4 Unit tests covering Linux/amd64, Linux/arm64, Windows/amd64, AIX rejection, and unknown OS
@@ -55,9 +55,9 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 - **Default path** — when no flag is passed, `ResolveAgentConfig` returns `{MonitoringMode: "fullstack"}` exactly. This is the zero-config default for OneAgent installs per `AGENTS.md`.
 - **Override path** — when `--monitoring-mode <value>` is passed (or `opts.MonitoringMode != ""`), the field is overridden. No allow-list — the value is passed through verbatim to the installer's `--set-monitoring-mode=<value>` flag in Task 6.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1), `cmd/install.go` (modify — wire `--monitoring-mode`)
+**Files:** `pkg/installer/oneagent/` (extend — scaffolded in Task 1), `cmd/install.go` (modify — wire `--monitoring-mode`)
 
-- [x] 2.5.1 Define the `AgentConfig` struct in `oneagent_v2.go`:
+- [x] 2.5.1 Define the `AgentConfig` struct in `pkg/installer/oneagent/oneagent.go`:
 
   ```go
   type AgentConfig struct {
@@ -84,7 +84,7 @@ Resolve the agent's runtime configuration — monitoring mode and app-log conten
 
 Resolve agent communication endpoints dynamically from the tenant API. Drop the hardcoded fallback used by the old flow. After resolving, probe each endpoint for TCP reachability. Connectivity failures are warnings, not blockers.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1), `pkg/installer/installer.go` (reuse `ExtractTenantID`)
+**Files:** `pkg/installer/oneagent/` (extend — scaffolded in Task 1), `pkg/installer/installer.go` (reuse `ExtractTenantID`)
 
 ### Part A — Endpoint resolution
 

--- a/openspec/changes/oneagent-configure/design.md
+++ b/openspec/changes/oneagent-configure/design.md
@@ -12,7 +12,7 @@ The existing `InstallOneAgent` flow in `pkg/installer/oneagent.go` receives a `*
 
 **Non-Goals:**
 
-- Implementing a separate token resolution or extraction step in `oneagent_v2.go`.
+- Implementing a separate token resolution or extraction step in `pkg/installer/oneagent/`.
 - Minting or exchanging tokens via any external API.
 
 ## Decisions

--- a/openspec/changes/oneagent-configure/proposal.md
+++ b/openspec/changes/oneagent-configure/proposal.md
@@ -15,6 +15,6 @@ The v2 OneAgent installer flow uses the credentials already carried by `c.Classi
 
 ## Impact
 
-- **Modified files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/oneagent_v2_test.go` (extend)
+- **Modified files:** `pkg/installer/oneagent/` (extend), `pkg/installer/oneagent/oneagent_test.go` (extend)
 - **No breaking changes** to existing callers during development — the new flow is behind `ONEAGENT_POC`.
 - **No new scope requirements:** unlike token minting, this requires no `tokens.write` permission.

--- a/openspec/changes/oneagent-init/design.md
+++ b/openspec/changes/oneagent-init/design.md
@@ -43,19 +43,19 @@ const (
 
 Default-false means existing behavior is preserved. At Task 8, the constant and registry entry are deleted in a single mechanical commit; no search-and-replace needed.
 
-### 2. New file: pkg/installer/oneagent_v2.go
+### 2. New package: pkg/installer/oneagent/
 
-All new scaffolding lives in a new file, leaving `oneagent.go` untouched (until Task 8 replacement). This keeps the diff reviewable and makes rollback mechanical (delete one file).
+All new code lives in a dedicated `oneagent` package, leaving the rest of `pkg/installer/` untouched. The package is split into three files for clarity:
 
-File structure:
+- `oneagent.go` — types (`Environment`, `AgentConfig`, `InstallOptions`), entry point `InstallOneAgentV2`, `DefaultAgentConfig`, `ResolveAgentConfig`, `detectRuntimeEnvironment`
+- `download.go` — `DownloadInstaller`, `readErrorBody`, `installerOSSegment`, `installerExtension`, `humanBytes`
+- `verify.go` — `VerifyInstallerSignature`, `fetchDynatraceRootCA`, `runOpensslVerify`, `dtRootCertURL`
 
-- Type definitions (exported)
-- Entry point: `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` — returns `errors.New("oneagent v2 not yet implemented")`
-- Stub functions for Tasks 2–7 — each returns a placeholder error and is documented with the task number
+This keeps each concern isolated and makes rollback mechanical (delete the package directory).
 
-### 3. Type definitions: `Environment`, `AgentConfig`, `InstallOptions`, etc.
+### 3. Type definitions: `Environment`, `AgentConfig`, `InstallOptions`
 
-All types are exported and structured so subsequent tasks can populate and test them independently:
+All types are exported from `pkg/installer/oneagent` and structured so they can be populated and tested independently:
 
 ```go
 type Environment struct {
@@ -78,25 +78,6 @@ type InstallOptions struct {
     PrintEndpoints        bool
     Quiet                 bool
 }
-
-type Endpoint struct {
-    Host string
-    Port int
-}
-
-type ConnectivityReport struct {
-    AllPassed  bool
-    FailedCount int
-    Results    []ConnectivityResult
-}
-
-type ConnectivityResult struct {
-    Host      string
-    Port      int
-    Reachable bool
-    Latency   time.Duration
-    Error     error
-}
 ```
 
 ### 4. CLI flag definitions on `installOneAgentCmd`
@@ -118,7 +99,7 @@ All new flags are added to the `installOneAgentCmd` Cobra command definition (no
 `cmd/install.go`'s `installOneAgentCmd.RunE` constructs an `InstallOptions` struct from the flags:
 
 ```go
-opts := installer.InstallOptions{
+opts := oneagent.InstallOptions{
     DryRun:                installDryRun,
     MonitoringMode:        flagMonitoringMode,
     NoVerifySignature:     flagNoVerifySignature,
@@ -138,7 +119,7 @@ The command handler branches based on the feature flag:
 ```go
 // Task 1 — feature-flag branching; remove at Task 8
 if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-    return installer.InstallOneAgentV2(c, opts)
+    return oneagent.InstallOneAgentV2(c, opts)
 }
 
 // Existing flow (default)
@@ -147,13 +128,13 @@ return installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup)
 
 The comment is a clear marker for Task 8 search-and-replace: remove the if-block, keep only the existing `InstallOneAgent` call, then replace it with the `InstallOneAgentV2` code at Task 8.
 
-### 7. Stub test file: pkg/installer/oneagent_v2_test.go
+### 7. Test file: pkg/installer/oneagent/oneagent_test.go
 
 Created with:
 
-- Helper functions for mocking HTTP server responses (httptest setup, mock tenant API, etc.)
-- Skeleton test cases with `t.Skip()` and TODO comments indicating which task each batch covers
-- Compilable structure so `go test ./...` passes even with unimplemented tests
+- Helper functions for mocking HTTP server responses (`newMockTenantServer`, `newMockClient`, `newTestClassicClient`, `createStubFile`)
+- Full test coverage for `ResolveAgentConfig`, `DownloadInstaller`, `VerifyInstallerSignature`, and `InstallOneAgentV2`
+- All tests compilable and passing with `go test ./...`
 
 ### 8. No breaking changes during development
 

--- a/openspec/changes/oneagent-init/proposal.md
+++ b/openspec/changes/oneagent-init/proposal.md
@@ -7,9 +7,9 @@ This change lays that foundation without touching the core installer logic.
 ## What Changes
 
 - **Feature flag:** `ONEAGENT_POC` (env var `DTWIZ_ONEAGENT_POC`) added to `pkg/featureflags` — disabled by default, removable in a single commit at the end of Task 8.
-- **New file:** `pkg/installer/oneagent_v2.go` with entry point `InstallOneAgentV2()` and stub functions for Tasks 2–7.
-- **Type definitions:** `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult` — all exported and used by subsequent tasks.
-- **Test scaffold:** `pkg/installer/oneagent_v2_test.go` with helper stubs and test structure.
+- **New package:** `pkg/installer/oneagent/` with entry point `InstallOneAgentV2()` and implementations split across three files: `oneagent.go` (types, entry point, config resolution), `download.go` (installer download), `verify.go` (CMS signature verification).
+- **Type definitions:** `Environment`, `AgentConfig`, `InstallOptions` — all exported in `pkg/installer/oneagent`.
+- **Tests:** `pkg/installer/oneagent/oneagent_test.go` with HTTP mock helpers and full test coverage.
 - **CLI flags:** `--force`, `--monitoring-mode`, `--no-verify-signature`, `--skip-connectivity-check`, `--connectivity-check-only`, `--print-endpoints` — all wired on `installOneAgentCmd`.
 - **Feature-flag branching:** In `cmd/install.go`, conditional dispatch based on `ONEAGENT_POC` enables the new flow when the flag is set.
 
@@ -23,8 +23,8 @@ This change lays that foundation without touching the core installer logic.
 
 ## Impact
 
-- **New files:** `pkg/installer/oneagent_v2.go`, `pkg/installer/oneagent_v2_test.go`
-- **Modified files:** `pkg/featureflags/featureflags.go` (new constant + registry entry), `cmd/install.go` (new flags + branching)
+- **New package:** `pkg/installer/oneagent/` (`oneagent.go`, `download.go`, `verify.go`, `oneagent_test.go`)
+- **Modified files:** `pkg/featureflags/featureflags.go` (new constant + registry entry), `cmd/install.go` (new flags + branching), `cmd/setup.go` (new import + call)
 - **No changes to existing behavior** — by default (`ONEAGENT_POC=false`), `dtwiz install oneagent` uses the existing flow.
-- **Rollback:** Delete `pkg/installer/oneagent_v2*.go`, remove the feature flag constant and registry entry, revert `cmd/install.go` branching. Three-file change to undo.
+- **Rollback:** Delete `pkg/installer/oneagent/`, remove the feature flag constant and registry entry, revert `cmd/install.go` and `cmd/setup.go` changes.
 - **Pre-requisite:** This change must land before Tasks 2–7 can be implemented.

--- a/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/spec.md
@@ -24,39 +24,41 @@
 - **WHEN** `dtwiz --help` runs and `dtwiz status` is executed
 - **THEN** the flag appears in `dtwiz status` output showing its enabled/disabled state, and in help text if feature-flag listing is exposed
 
-### Requirement: Scaffold oneagent_v2.go with stub functions
+### Requirement: New package pkg/installer/oneagent/ with core installer logic
 
-`pkg/installer/oneagent_v2.go` SHALL be created with:
+`pkg/installer/oneagent/` SHALL be created as a standalone Go package (`package oneagent`) with the installer split across three source files:
 
-- Entry point: `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` — documented but not implemented (returns `errors.New("not yet implemented")`)
-- Type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
-- Stub function signatures (not implemented) for all Tasks 2–7 functions: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
+- `oneagent.go`: types, entry point `InstallOneAgentV2`, `DefaultAgentConfig`, `ResolveAgentConfig`, `detectRuntimeEnvironment`
+- `download.go`: `DownloadInstaller`, `readErrorBody`, `installerOSSegment`, `installerExtension`, `humanBytes`
+- `verify.go`: `VerifyInstallerSignature`, `fetchDynatraceRootCA`, `runOpensslVerify`
 
-#### Scenario: oneagent_v2.go compiles
+Type definitions: `Environment`, `AgentConfig`, `InstallOptions`
 
-- **GIVEN** `pkg/installer/oneagent_v2.go` is created with stub function signatures
+#### Scenario: package compiles
+
+- **GIVEN** `pkg/installer/oneagent/` is created
 - **WHEN** `go build ./...` runs
 - **THEN** the code compiles without errors
 
 #### Scenario: Type definitions are exported
 
-- **GIVEN** `Environment`, `AgentConfig`, `InstallOptions`, and `Endpoint` are defined as public types
-- **WHEN** test code imports `pkg/installer`
+- **GIVEN** `Environment`, `AgentConfig`, `InstallOptions` are defined as public types
+- **WHEN** test code imports `github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent`
 - **THEN** it can construct and reference these types
 
-### Requirement: Scaffold oneagent_v2_test.go with test structure
+### Requirement: Test file pkg/installer/oneagent/oneagent_test.go
 
-`pkg/installer/oneagent_v2_test.go` SHALL be created with:
+`pkg/installer/oneagent/oneagent_test.go` SHALL be created with:
 
-- Test helper functions for mocking HTTP server responses (tenant API, token mint, installer download, etc.)
-- Skeleton test cases with TODO placeholders for Tasks 2–7 unit tests
-- Comment blocks indicating which task each test batch covers
+- Test helper functions for mocking HTTP server responses (`newMockTenantServer`, `newMockClient`, `newTestClassicClient`, `createStubFile`)
+- Full test coverage for `ResolveAgentConfig`, `DownloadInstaller`, `VerifyInstallerSignature`, and `InstallOneAgentV2`
+- All tests passing with `go test ./pkg/installer/oneagent/...`
 
-#### Scenario: Test file compiles
+#### Scenario: Test file compiles and all tests pass
 
-- **GIVEN** `pkg/installer/oneagent_v2_test.go` is created with skeleton test structure
-- **WHEN** `go test ./... -v` runs
-- **THEN** the tests compile without errors (and any TODO tests are skipped or marked as `t.Skip()`)
+- **GIVEN** `pkg/installer/oneagent/oneagent_test.go` exists
+- **WHEN** `go test ./pkg/installer/oneagent/... -v` runs
+- **THEN** all tests pass without errors
 
 ### Requirement: Feature-flag branching in cmd/install.go
 
@@ -64,7 +66,7 @@
 
 ```go
 if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-    return installer.InstallOneAgentV2(c, opts)
+    return oneagent.InstallOneAgentV2(c, opts)
 }
 return installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup)
 ```
@@ -104,7 +106,7 @@ Pre-existing flags (`--dry-run`, `--quiet`) remain unchanged.
 
 ### Requirement: InstallOptions struct carries all CLI-derived inputs
 
-`InstallOptions` struct in `pkg/installer/oneagent_v2.go` SHALL carry all CLI flags and options:
+`InstallOptions` struct in `pkg/installer/oneagent/oneagent.go` SHALL carry all CLI flags and options:
 
 ```go
 type InstallOptions struct {
@@ -126,12 +128,18 @@ This struct is populated from `cmd/install.go` and passed to `InstallOneAgentV2`
 - **WHEN** `cmd/install.go` constructs an `InstallOptions` from the flags
 - **THEN** the struct carries all values correctly
 
-### Requirement: Minimal type signatures for all Task 2–7 functions
+### Requirement: Core functions implemented in pkg/installer/oneagent/
 
-All stub functions in `oneagent_v2.go` SHALL have signatures matching their design, so they can be called during integration-test setup even if not yet implemented. Each stub returns a documented placeholder error.
+The following functions SHALL be implemented (not stubs) in `pkg/installer/oneagent/`:
 
-#### Scenario: Function signatures match design
+- `DefaultAgentConfig() AgentConfig` — returns config with `MonitoringMode: "fullstack"`
+- `ResolveAgentConfig(opts InstallOptions) AgentConfig` — applies opts overrides over defaults
+- `DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)` — downloads installer binary
+- `VerifyInstallerSignature(env Environment, installerPath string, skip bool) error` — CMS signature verification via openssl
+- `detectRuntimeEnvironment() (Environment, error)` — detects OS/arch at runtime
 
-- **GIVEN** the design.md describes `func ResolveEndpoints(c *client.ClassicClient) ([]Endpoint, error)`
-- **WHEN** `pkg/installer/oneagent_v2.go` is examined
-- **THEN** the function signature matches exactly
+#### Scenario: Functions are implemented and testable
+
+- **GIVEN** `pkg/installer/oneagent/` is built
+- **WHEN** tests call `ResolveAgentConfig`, `DownloadInstaller`, or `VerifyInstallerSignature`
+- **THEN** the functions execute real logic (not placeholder errors)

--- a/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
+++ b/openspec/changes/oneagent-init/specs/oneagent-init/tasks.md
@@ -15,7 +15,7 @@ Before implementing, review the design and spec documents to understand the requ
 
 Set up the foundational structure for the OneAgent PoC implementation: feature flag, stub files, type definitions, CLI flags, and feature-flag branching.
 
-**Files:** `pkg/featureflags/featureflags.go` (extend), `pkg/installer/oneagent_v2.go` (create), `pkg/installer/oneagent_v2_test.go` (create), `cmd/install.go` (extend)
+**Files:** `pkg/featureflags/featureflags.go` (extend), `pkg/installer/oneagent/oneagent.go` (create), `pkg/installer/oneagent/download.go` (create), `pkg/installer/oneagent/verify.go` (create), `pkg/installer/oneagent/oneagent_test.go` (create), `cmd/install.go` (extend), `cmd/setup.go` (extend)
 
 ### Feature Flag
 
@@ -24,19 +24,19 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 - [x] 1.3 Unit test: `IsEnabled(featureflags.OneAgentPoC)` returns `false` by default
 - [x] 1.4 Unit test: set `DTWIZ_ONEAGENT_POC=true` and verify `IsEnabled` returns `true`
 
-### Scaffolding: pkg/installer/oneagent_v2.go
+### Package: pkg/installer/oneagent/
 
-- [x] 1.5 Create `pkg/installer/oneagent_v2.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`, `Endpoint`, `ConnectivityReport`, `ConnectivityResult`
+- [x] 1.5 Create `pkg/installer/oneagent/oneagent.go` with type definitions: `Environment`, `AgentConfig`, `InstallOptions`
 - [x] 1.6 Define `InstallOptions` struct carrying `DryRun`, `MonitoringMode`, `NoVerifySignature`, `SkipConnectivityCheck`, `ConnectivityCheckOnly`, `PrintEndpoints`, `Quiet`
-- [x] 1.7 Implement stub entry point `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` that prints a "under development" warning and returns `nil` (not an error, to avoid showing help output in the setup flow)
-- [x] 1.8 Add stub function signatures (not implemented) for: `DetectEnvironment()`, `RunPreflightChecks()`, `ResolveAgentConfig()`, `ResolveEndpoints()`, `MintInstallerToken()`, `DownloadInstaller()`, `VerifyInstallerSignature()`, `BuildInstallCommand()`, `ExecuteInstallCommand()`, `WaitForHostRegistration()`, `CheckAllEndpoints()`
+- [x] 1.7 Implement `InstallOneAgentV2(c *client.Client, opts InstallOptions) error` — full implementation, not a stub
+- [x] 1.8 Implement `DefaultAgentConfig()`, `ResolveAgentConfig()`, `detectRuntimeEnvironment()` in `oneagent.go`; `DownloadInstaller()` in `download.go`; `VerifyInstallerSignature()` in `verify.go`
 - [x] 1.9 Ensure code compiles with `go build ./...`
 
-### Scaffolding: pkg/installer/oneagent_v2_test.go
+### Tests: pkg/installer/oneagent/oneagent_test.go
 
-- [x] 1.10 Create `pkg/installer/oneagent_v2_test.go` with skeleton structure
-- [x] 1.11 Add test helper functions for mocking HTTP responses (placeholder comments for Tasks 2–7)
-- [x] 1.12 Ensure tests compile with `go test ./... -v` (mark pending tests with `t.Skip()` if needed)
+- [x] 1.10 Create `pkg/installer/oneagent/oneagent_test.go` with full test coverage
+- [x] 1.11 Add test helper functions: `newMockTenantServer`, `newMockClient`, `newTestClassicClient`, `createStubFile`, `withRootCertURL`
+- [x] 1.12 Ensure all tests pass with `go test ./pkg/installer/oneagent/... -v`
 
 ### CLI Flags
 
@@ -50,11 +50,11 @@ Set up the foundational structure for the OneAgent PoC implementation: feature f
 
   ```go
   if featureflags.IsEnabled(featureflags.OneAgentPoC) {
-      return installer.InstallOneAgentV2(c, opts)
+      return oneagent.InstallOneAgentV2(c, opts)
   }
   return installer.InstallOneAgent(c.Classic, installDryRun, quiet, hostGroup)
   ```
 
 - [x] 1.17 Add a comment marking the branching point: `// Task 1 — feature-flag branching; remove at Task 8`
 - [x] 1.18 Verify existing `InstallOneAgent` call path is unchanged when the flag is disabled (default)
-- [x] 1.19 Integration test: with `DTWIZ_ONEAGENT_POC=true`, verify `InstallOneAgentV2` is called (prints "under development" warning and returns `nil`; setup flow skips `WatchIngest`)
+- [x] 1.19 Update `cmd/setup.go` to import `pkg/installer/oneagent` and call `oneagent.InstallOneAgentV2(c, oneagent.InstallOptions{...})`

--- a/openspec/changes/oneagent-install/design.md
+++ b/openspec/changes/oneagent-install/design.md
@@ -2,13 +2,13 @@
 
 ## Context
 
-The existing `downloadOneAgentInstaller` helper in `pkg/installer/oneagent.go` streams the installer to a temp file using the user's `--access-token`. There is no signature verification and no structured command representation — the install command is assembled inline from positional parameters. This change covers Tasks 5 and 6 of the OneAgent PoC: download (with minted token), Linux signature verification, command build, and command execution.
+The existing `downloadOneAgentInstaller` helper in `pkg/installer/oneagent.go` streams the installer to a temp file via the resty client and shells out with positional install arguments — no signature verification, no structured command representation. This change covers Tasks 5 and 6 of the OneAgent PoC: download, Linux signature verification, command build, and command execution.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- `DownloadInstaller` authenticates with the minted token, not the user's long-lived token.
+- `DownloadInstaller` uses the credentials already embedded in the ClassicClient (set upstream by `validateCredentials`) — no token extraction in installer code. Confirmed by `oneagent-configure`.
 - Linux signature verification is mandatory unless `--no-verify-signature` is passed; missing `openssl` is a hard error.
 - `BuildInstallCommand` produces a complete, testable argv slice from typed inputs.
 - `ExecuteInstallCommand` returns the subprocess exit code alongside any error; `--dry-run` previews without executing.
@@ -17,20 +17,21 @@ The existing `downloadOneAgentInstaller` helper in `pkg/installer/oneagent.go` s
 
 - Go-native CMS signature verification — `openssl cms -verify` against the published Dynatrace pipeline is the documented approach. A Go-crypto rewrite adds external dependency risk and divergence in PKCS#7 parsing.
 - Windows-specific installer URL, `.exe` extension, and Authenticode verification — covered in `oneagent-windows`.
+- Minting a separate installer-scoped token. Earlier drafts of this change planned a `MintInstallerToken` step; `oneagent-configure` eliminated that and standardised on the credential already embedded in `c.Classic`.
 
 ## Decisions
 
-### 1. Download: minted token override
+### 1. Download: reuse the ClassicClient credential
 
-`DownloadInstaller` overrides the resty client's default `Authorization` header for the single download request, using `Api-Token <mintedToken>`. The user's `--access-token` does not appear in the download request.
+`DownloadInstaller` calls `c.HTTP().R().SetDoNotParseResponse(true).Get(path)`. The resty client already carries the correct `Authorization` header set upstream by `setupClientFromCreds`. The token is never extracted to a variable in installer code, so it cannot accidentally appear in log lines.
 
 Download URL pattern:
 
 - Linux x86: `/api/v1/deployment/installer/agent/unix/default/latest?arch=x86`
 - Linux arm: `/api/v1/deployment/installer/agent/unix/default/latest?arch=arm`
-- Windows: handled in `oneagent-windows`
+- Windows: `/api/v1/deployment/installer/agent/windows/default/latest?arch=x86` (path-only; `.exe` extension and Windows execution flow are covered in `oneagent-windows`)
 
-Temp file: `os.CreateTemp("", "dynatrace-oneagent-*")` → `chmod 0o700` on Unix. On success, stdout outputs via `display.PrintStatusLine("installer", "<basename> (<size>)", display.ColorOK)`.
+Temp file: `os.CreateTemp("", "dynatrace-oneagent-*.sh")` (or `*.exe` for Windows env) → `chmod 0o700` on Unix. On success, stdout outputs via `display.PrintStatusLine("installer", "<basename> (<size>)", display.ColorOK)`.
 
 ### 2. Linux signature verification: openssl subprocess
 
@@ -42,10 +43,12 @@ The Dynatrace Linux installer ships with a CMS detached signature. Verification 
 | openssl cms -verify -CAfile <dt-root.cert.pem>
 ```
 
+In Go this is built without a shell: `cmd.Stdin = io.MultiReader(header, installerFile)` where `header` is the MIME prelude string and `installerFile` is the opened installer.
+
 Steps:
 
 1. `exec.LookPath("openssl")` — missing → hard error, no silent skip.
-2. Download `https://ca.dynatrace.com/dt-root.cert.pem` to a second temp file.
+2. Download `https://ca.dynatrace.com/dt-root.cert.pem` to a temp file with a standalone `resty.New()` client (no auth needed). The URL is held in a package-level var so tests can override it.
 3. Run pipeline via `exec.Command`; capture stderr.
 4. Non-zero exit → error wrapping the openssl stderr.
 
@@ -83,4 +86,4 @@ Linux argv:
 | Execute start | Debug | `"executing installer"` | `argv` |
 | Execute done | Verbose | `"installer exited"` | `exit_code`, `duration` |
 
-Token values are never placed in argv and therefore safe to log at Debug.
+The token is never extracted from the resty client into a Go variable, so no log key can ever carry it. The `Authorization` header is also redacted by `sensitiveHTTPHeaders` in the resty pre-request hook.

--- a/openspec/changes/oneagent-install/design.md
+++ b/openspec/changes/oneagent-install/design.md
@@ -31,7 +31,7 @@ Download URL pattern:
 - Linux arm: `/api/v1/deployment/installer/agent/unix/default/latest?arch=arm`
 - Windows: `/api/v1/deployment/installer/agent/windows/default/latest?arch=x86` (path-only; `.exe` extension and Windows execution flow are covered in `oneagent-windows`)
 
-Temp file: `os.CreateTemp("", "dynatrace-oneagent-*.sh")` (or `*.exe` for Windows env) → `chmod 0o700` on Unix. On success, stdout outputs via `display.PrintStatusLine("installer", "<basename> (<size>)", display.ColorOK)`.
+Temp file: `os.CreateTemp("", "dynatrace-oneagent-*.sh")` (or `*.exe` for Windows env) → `chmod 0o700` on Unix. During streaming, a `display.ProgressReader` wraps the response body and emits a `\r`-overwriting progress line to stderr (TTY-only, suppressed in CI/pipes, throttled to ≤10 Hz). On success, stderr is cleared and stdout outputs via `display.PrintStatusLine("installer", "<basename> (<size>)", display.ColorOK)`.
 
 ### 2. Linux signature verification: openssl subprocess
 

--- a/openspec/changes/oneagent-install/proposal.md
+++ b/openspec/changes/oneagent-install/proposal.md
@@ -1,10 +1,10 @@
 # Why
 
-The existing OneAgent installer flow downloads the installer binary using the user's long-lived token without any signature verification, then shells out with positional arguments and no structured command representation. This change implements a secure download pipeline — using the minted token from `oneagent-configure` — followed by Linux signature verification and OS-specific command construction and execution.
+The existing OneAgent installer flow downloads the installer binary without any signature verification, then shells out with positional arguments and no structured command representation. This change implements a streamed download (reusing the credentials already embedded in the ClassicClient — same pattern as every other installer in the repo, confirmed by `oneagent-configure`), Linux signature verification against the published Dynatrace root CA, and OS-specific command construction and execution.
 
 ## What Changes
 
-- `DownloadInstaller(c *client.ClassicClient, mintedToken string, env Environment) (string, error)`: streams the installer to a temp file authenticated with the minted token. Temp file permissions are `0o700` on Unix.
+- `DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)`: streams the installer to a temp file using `c.HTTP().R()` — the resty client already carries the correct `Authorization` header. Temp file permissions are tightened to `0o700` on Unix.
 - `VerifyInstallerSignature(env Environment, installerPath string, skip bool) error`: on Linux, verifies the installer's CMS signature against `https://ca.dynatrace.com/dt-root.cert.pem` via `openssl cms -verify`. Non-Linux and `--no-verify-signature` skip silently. Missing `openssl` is a hard error, not a silent skip.
 - `BuildInstallCommand(env Environment, cfg AgentConfig, opts InstallOptions, installerPath string) ([]string, error)`: constructs the OS-specific argv from `AgentConfig` (`--set-monitoring-mode`, `--set-app-log-content-access`) and options.
 - `ExecuteInstallCommand(argv []string, dryRun, quiet bool) (int, error)`: runs the installer subprocess, streaming output. `--dry-run` prints the command without executing.
@@ -13,7 +13,7 @@ The existing OneAgent installer flow downloads the installer binary using the us
 
 ### New Capabilities
 
-- `oneagent-installer-download`: Installer download authenticated with the minted token; Linux signature verification via `openssl cms -verify`.
+- `oneagent-installer-download`: Streamed installer download authenticated by the embedded ClassicClient credential; Linux signature verification via `openssl cms -verify`.
 - `oneagent-install-execution`: OS-specific install command construction from `AgentConfig`; sudo/UAC elevation; `--dry-run` support.
 
 ## Impact

--- a/openspec/changes/oneagent-install/proposal.md
+++ b/openspec/changes/oneagent-install/proposal.md
@@ -1,6 +1,6 @@
 # Why
 
-The existing OneAgent installer flow downloads the installer binary without any signature verification, then shells out with positional arguments and no structured command representation. This change implements a streamed download (reusing the credentials already embedded in the ClassicClient — same pattern as every other installer in the repo, confirmed by `oneagent-configure`), Linux signature verification against the published Dynatrace root CA, and OS-specific command construction and execution.
+The existing OneAgent installer flow downloads the installer binary without any signature verification, then shells out with positional arguments and no structured command representation. This change implements a streamed download (reusing the credentials already embedded in the ClassicClient — same pattern as every other installer in the repo, confirmed by `oneagent-configure`), Linux signature verification against the published Dynatrace root Certificate Authority, and OS-specific command construction and execution.
 
 ## What Changes
 

--- a/openspec/changes/oneagent-install/proposal.md
+++ b/openspec/changes/oneagent-install/proposal.md
@@ -18,6 +18,6 @@ The existing OneAgent installer flow downloads the installer binary without any 
 
 ## Impact
 
-- **Modified files:** `pkg/installer/oneagent_v2.go` (extend — download, verification, build, execute), `pkg/installer/oneagent_v2_test.go` (extend)
+- **Modified files:** `pkg/installer/oneagent/` (extend — download in `download.go`, verification in `verify.go`, build/execute in `oneagent.go`), `pkg/installer/oneagent/oneagent_test.go` (extend)
 - **New flag:** `--no-verify-signature` on `installOneAgentCmd` (skip Linux signature check).
 - **Dependency:** `openssl` must be present on Linux unless `--no-verify-signature` is passed. Missing `openssl` aborts the install with a clear error.

--- a/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
@@ -2,16 +2,15 @@
 
 ## ADDED Requirements
 
-### Requirement: Installer download uses the minted token
+### Requirement: Installer download reuses the ClassicClient credential
 
-`InstallOneAgentV2` SHALL download the OneAgent installer using the minted token from `MintInstallerToken`, not the user-supplied access token. The download SHALL stream to a temporary file with `0o700` permissions on Unix (preventing other local users from reading the binary).
+`InstallOneAgentV2` SHALL download the OneAgent installer using the resty client embedded in `c.Classic`. The credential is set upstream by `validateCredentials` / `setupClientFromCreds` and SHALL NOT be extracted to a variable in installer code. The download SHALL stream to a temporary file with `0o700` permissions on Unix (preventing other local users from reading the binary).
 
-#### Scenario: Download authenticated with minted token
+#### Scenario: Download uses the embedded Authorization header
 
-- **GIVEN** `MintInstallerToken` returned `tok-installer-abc`
-- **WHEN** `DownloadInstaller(c, "tok-installer-abc", env)` is called
-- **THEN** the request `Authorization` header is `Api-Token tok-installer-abc`
-- **AND** the user's `--access-token` does NOT appear in the request
+- **WHEN** `DownloadInstaller(c, env)` is called
+- **THEN** the request `Authorization` header is the one configured on `c.HTTP()` upstream
+- **AND** no installer code extracts the raw token into a Go variable
 
 #### Scenario: Linux x86 installer URL
 
@@ -33,7 +32,7 @@
 
 #### Scenario: Temp file permissions on Unix
 
-- **GIVEN** the download succeeds on Linux
+- **GIVEN** the download succeeds on a Unix host
 - **WHEN** the temp file is created
 - **THEN** its permissions are `0o700`
 
@@ -45,19 +44,19 @@
 
 - **GIVEN** the installer downloads successfully
 - **WHEN** `DownloadInstaller` returns
-- **THEN** stdout contains exactly one line via `display.PrintStatusLine` showing the installer filename and size (e.g. `Dynatrace-OneAgent-Linux-x86-1.340.0.sh (245MB)`)
-- **AND** the filename is the OS-specific basename of the temp file (Unix: `.sh`, Windows: `.exe`)
+- **THEN** stdout contains exactly one line via `display.PrintStatusLine` showing the installer filename and size (e.g. `dynatrace-oneagent-1963786212.sh (245MB)`)
+- **AND** the filename is the OS-specific basename of the temp file (Unix env: `.sh`, Windows env: `.exe`)
 
 ### Requirement: Download debug logging
 
-`DownloadInstaller` SHALL emit `logger.Debug` for the download start (URL, OS, arch) and `logger.Verbose` for the download completion (path, size in bytes). Neither the minted token nor the user's access token SHALL appear in any log line. The `Authorization` request header SHALL NOT be logged.
+`DownloadInstaller` SHALL emit `logger.Debug` for the download start (URL, OS, arch) and `logger.Verbose` for the download completion (path, size in bytes). The credential SHALL NOT appear in any log line. The `Authorization` request header SHALL NOT be logged.
 
 #### Scenario: Download start logged at Debug
 
 - **GIVEN** `--debug` is enabled
 - **WHEN** `DownloadInstaller` issues the GET request
 - **THEN** stderr contains a Debug line with message `"downloading installer"` and keys `url`, `os`, `arch`
-- **AND** no log line contains the minted token value
+- **AND** no log line contains the raw credential value
 
 #### Scenario: Download completion logged at Verbose
 
@@ -226,7 +225,7 @@ When `opts.DryRun == true`, `ExecuteInstallCommand` SHALL print the argv (joined
 
 - **GIVEN** `--dry-run` is passed
 - **WHEN** `InstallOneAgentV2` runs end-to-end
-- **THEN** `DetectEnvironment`, `RunPreflightChecks`, `ResolveAgentConfig`, `ResolveEndpoints`, `MintInstallerToken`, `DownloadInstaller`, and `VerifyInstallerSignature` all run
+- **THEN** `DetectEnvironment`, `RunPreflightChecks`, `ResolveAgentConfig`, `ResolveEndpoints`, `DownloadInstaller`, and `VerifyInstallerSignature` all run
 - **AND** `ExecuteInstallCommand` only prints the command
 - **AND** `WaitForHostRegistration` is skipped (nothing to verify)
 
@@ -275,7 +274,7 @@ When `opts.DryRun == false`, `ExecuteInstallCommand` SHALL launch the installer 
 
 ### Requirement: Build and execution debug logging
 
-`BuildInstallCommand` SHALL emit a `logger.Debug` line capturing the full argv. `ExecuteInstallCommand` SHALL emit a `logger.Debug` line at execution start and a `logger.Verbose` line at completion with exit code and duration. Because the minted token is never placed into argv, the argv is safe to log at Debug. Token values from upstream stages SHALL still not appear in any log line.
+`BuildInstallCommand` SHALL emit a `logger.Debug` line capturing the full argv. `ExecuteInstallCommand` SHALL emit a `logger.Debug` line at execution start and a `logger.Verbose` line at completion with exit code and duration. The credential is never placed into argv, so the argv is safe to log at Debug.
 
 #### Scenario: Built command logged at Debug
 

--- a/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
@@ -38,7 +38,9 @@
 
 ### Requirement: User-facing download output
 
-`DownloadInstaller` SHALL output to stdout (visible at default verbosity, no `-v` required) a one-line confirmation on success via `display.PrintStatusLine("installer", "<filename> (<size>)", display.ColorOK)`. Progress detail SHALL NOT be printed at default verbosity beyond this single line — finer detail belongs in `logger.Debug`/`logger.Verbose`.
+`DownloadInstaller` SHALL output to stdout (visible at default verbosity, no `-v` required) a one-line confirmation on success via `display.PrintStatusLine("installer", "<filename> (<size>)", display.ColorOK)`. Multi-line or log-style progress output SHALL NOT be printed at default verbosity — finer detail belongs in `logger.Debug`/`logger.Verbose`.
+
+During the download, a TTY-only `\r`-overwriting progress indicator MAY be emitted to stderr showing bytes received (and percentage when `Content-Length` is known). This indicator is suppressed automatically when stderr is not a terminal (CI, pipes). It does not appear on stdout and is erased before the final `PrintStatusLine` confirmation, so the net visible output remains a single line.
 
 #### Scenario: Successful download produces one stdout line
 
@@ -46,6 +48,19 @@
 - **WHEN** `DownloadInstaller` returns
 - **THEN** stdout contains exactly one line via `display.PrintStatusLine` showing the installer filename and size (e.g. `dynatrace-oneagent-1963786212.sh (245MB)`)
 - **AND** the filename is the OS-specific basename of the temp file (Unix env: `.sh`, Windows env: `.exe`)
+
+#### Scenario: TTY progress indicator during download
+
+- **GIVEN** stderr is a terminal
+- **WHEN** `DownloadInstaller` is streaming the installer body
+- **THEN** a `\r`-overwriting progress line is emitted to stderr at most once per 100 ms showing bytes downloaded and, when `Content-Length` is known, the percentage
+- **AND** the progress line is erased (ANSI `\r\033[2K`) before `DownloadInstaller` returns
+
+#### Scenario: Progress suppressed in non-TTY environments
+
+- **GIVEN** stderr is not a terminal (e.g. CI, pipe)
+- **WHEN** `DownloadInstaller` streams the installer body
+- **THEN** no progress output is emitted to stderr
 
 ### Requirement: Download debug logging
 

--- a/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
@@ -227,24 +227,36 @@ When `openssl cms -verify` returns a non-zero exit code, `VerifyInstallerSignatu
 - **WHEN** `BuildInstallCommand` runs
 - **THEN** the argv contains `"--set-monitoring-mode=infra-only"`
 
-### Requirement: --dry-run prints command without executing
+### Requirement: --dry-run prints a plan without any network calls or disk writes
 
-When `opts.DryRun == true`, `ExecuteInstallCommand` SHALL print the argv (joined with single spaces) prefixed with `"Command: "` and return `(0, nil)` without launching any subprocess.
+When `opts.DryRun == true`, `InstallOneAgentV2` SHALL print a human-readable plan and return immediately after environment detection and config resolution. No installer SHALL be downloaded, no signature SHALL be verified, and no subprocess SHALL be spawned.
 
-#### Scenario: Dry-run does not execute
+The plan SHALL include:
+- The full installer download URL (computed locally from `c.Classic.BaseURL()` and the detected environment)
+- Whether signature verification would run and against which CA, or that it is skipped
+- The resolved monitoring mode
+
+#### Scenario: Dry-run prints plan and returns without network calls
 
 - **GIVEN** `opts.DryRun == true`
-- **WHEN** `ExecuteInstallCommand(argv, true, false)` is called
-- **THEN** stdout contains `"Command: " + strings.Join(argv, " ")`
-- **AND** no subprocess is spawned
+- **WHEN** `InstallOneAgentV2` is called
+- **THEN** stdout contains `[dry-run] Would install Dynatrace OneAgent` followed by the installer URL, signature note, and monitoring mode
+- **AND** `DownloadInstaller` is NOT called
+- **AND** `VerifyInstallerSignature` is NOT called
+- **AND** `ExecuteInstallCommand` is NOT called
+- **AND** no HTTP requests are made
 
-#### Scenario: Dry-run still confirms preflight passed
+#### Scenario: Dry-run signature line reflects --no-verify-signature
 
-- **GIVEN** `--dry-run` is passed
-- **WHEN** `InstallOneAgentV2` runs end-to-end
-- **THEN** `DetectEnvironment`, `RunPreflightChecks`, `ResolveAgentConfig`, `ResolveEndpoints`, `DownloadInstaller`, and `VerifyInstallerSignature` all run
-- **AND** `ExecuteInstallCommand` only prints the command
-- **AND** `WaitForHostRegistration` is skipped (nothing to verify)
+- **GIVEN** `opts.DryRun == true` and `opts.NoVerifySignature == true` (or `env.OS != "linux"`)
+- **WHEN** `InstallOneAgentV2` prints the plan
+- **THEN** the signature line reads `Signature:  skipped`
+
+#### Scenario: Dry-run signature line shows CA URL on Linux without --no-verify-signature
+
+- **GIVEN** `opts.DryRun == true` and `env.OS == "linux"` and `opts.NoVerifySignature == false`
+- **WHEN** `InstallOneAgentV2` prints the plan
+- **THEN** the signature line reads `Signature:  would verify against https://ca.dynatrace.com/dt-root.cert.pem`
 
 ### Requirement: Execute streams output and captures exit code
 

--- a/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
@@ -232,6 +232,7 @@ When `openssl cms -verify` returns a non-zero exit code, `VerifyInstallerSignatu
 When `opts.DryRun == true`, `InstallOneAgentV2` SHALL print a human-readable plan and return immediately after environment detection and config resolution. No installer SHALL be downloaded, no signature SHALL be verified, and no subprocess SHALL be spawned.
 
 The plan SHALL include:
+
 - The full installer download URL (computed locally from `c.Classic.BaseURL()` and the detected environment)
 - Whether signature verification would run and against which CA, or that it is skipped
 - The resolved monitoring mode

--- a/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/spec.md
@@ -123,6 +123,8 @@ When `env.OS == "linux"` and `--no-verify-signature` is not passed, `VerifyInsta
 
 `VerifyInstallerSignature` SHALL output to stdout on successful Linux verification via `display.PrintStatusLine("signature", "Installer signature verified", display.ColorOK)`. The skip paths (`--no-verify-signature` set, or non-Linux OS) SHALL produce no stdout output. Verification failure produces an error returned to the caller, not stdout output.
 
+During verification, TTY-only `\r`-overwriting pending lines MAY be emitted to stderr via `display.PrintPending` at two milestones: before the root CA is fetched (`"fetching root CA..."`) and before openssl runs (`"verifying..."`). These lines are suppressed automatically when stderr is not a terminal (CI, pipes) and are erased with `display.ClearPending` before `VerifyInstallerSignature` returns (on both success and failure paths), so the net visible output remains a single `PrintStatusLine` on success.
+
 #### Scenario: Successful Linux verification outputs status line
 
 - **GIVEN** `env.OS == "linux"`

--- a/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
@@ -13,7 +13,7 @@ Before implementing, review the design and spec documents to understand the requ
 
 > **Findings (Task 0 outcome):**
 >
-> - The earlier draft of this change planned a minted installer-scoped token (`DownloadInstaller(c, mintedToken, env)`). `oneagent-configure` later eliminated minting and standardised on the credential already embedded in `c.Classic`. This change has been updated to match: `DownloadInstaller(c *client.ClassicClient, env Environment)`. The token is never extracted to a Go variable in installer code.
+> - The earlier draft of this change planned a minted installer-scoped token (`DownloadInstaller(c, mintedToken, env)`). `oneagent-configure` later eliminated minting and standardised on the credential already embedded in `c.Classic`. This change has been updated to match: `DownloadInstaller(c *client.ClassicClient, env Environment)`.
 > - The `Environment` type referenced by Task 5/6 was planned in `oneagent-init` Task 1.5 and is defined in `pkg/installer/oneagent/oneagent.go` as `{OS, Arch, Supported, Reason}`.
 
 ## 5. Download Installer + Linux Signature Verification

--- a/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
@@ -14,13 +14,13 @@ Before implementing, review the design and spec documents to understand the requ
 > **Findings (Task 0 outcome):**
 >
 > - The earlier draft of this change planned a minted installer-scoped token (`DownloadInstaller(c, mintedToken, env)`). `oneagent-configure` later eliminated minting and standardised on the credential already embedded in `c.Classic`. This change has been updated to match: `DownloadInstaller(c *client.ClassicClient, env Environment)`. The token is never extracted to a Go variable in installer code.
-> - The `Environment` type referenced by Task 5/6 was planned in `oneagent-init` Task 1.5 but was not actually added to `pkg/installer/oneagent_v2.go`. It is introduced here as a minimal `{OS, Arch}` struct.
+> - The `Environment` type referenced by Task 5/6 was planned in `oneagent-init` Task 1.5 and is defined in `pkg/installer/oneagent/oneagent.go` as `{OS, Arch, Supported, Reason}`.
 
 ## 5. Download Installer + Linux Signature Verification
 
 Use the credentials embedded in the ClassicClient to download the installer. On Linux, verify the signature against the published Dynatrace root CA.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/oneagent_v2_test.go` (extend)
+**Files:** `pkg/installer/oneagent/download.go` (extend), `pkg/installer/oneagent/oneagent_test.go` (extend)
 
 ### Part A — Download
 
@@ -51,7 +51,7 @@ Use the credentials embedded in the ClassicClient to download the installer. On 
 
 Build the OS-specific install command from `AgentConfig` and execute it (or preview under `--dry-run`).
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/sudo_unix.go` / `_windows.go` (reuse), `pkg/installer/oneagent_v2_test.go` (extend)
+**Files:** `pkg/installer/oneagent/oneagent.go` (extend), `pkg/installer/sudo_unix.go` / `_windows.go` (reuse), `pkg/installer/oneagent/oneagent_test.go` (extend)
 
 ### Part A — Build command
 

--- a/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
@@ -6,39 +6,44 @@ Before implementing, review the design and spec documents to understand the requ
 
 **Files:** `design.md`, `spec.md`
 
-- [ ] 0.1 Read `design.md` and `spec.md` to understand token minting, download, and signature verification requirements
-- [ ] 0.2 Identify and document any unclear assumptions about API endpoints or certificate handling
-- [ ] 0.3 Review existing OneAgent installer code patterns in `pkg/installer/oneagent.go`
-- [ ] 0.4 Confirm logging, error handling, and cross-platform behavior align with the specification
+- [x] 0.1 Read `design.md` and `spec.md` to understand download, signature verification, and command construction requirements
+- [x] 0.2 Identify and document any unclear assumptions about API endpoints or certificate handling
+- [x] 0.3 Review existing OneAgent installer code patterns in `pkg/installer/oneagent.go`
+- [x] 0.4 Confirm logging, error handling, and cross-platform behavior align with the specification
+
+> **Findings (Task 0 outcome):**
+>
+> - The earlier draft of this change planned a minted installer-scoped token (`DownloadInstaller(c, mintedToken, env)`). `oneagent-configure` later eliminated minting and standardised on the credential already embedded in `c.Classic`. This change has been updated to match: `DownloadInstaller(c *client.ClassicClient, env Environment)`. The token is never extracted to a Go variable in installer code.
+> - The `Environment` type referenced by Task 5/6 was planned in `oneagent-init` Task 1.5 but was not actually added to `pkg/installer/oneagent_v2.go`. It is introduced here as a minimal `{OS, Arch}` struct.
 
 ## 5. Download Installer + Linux Signature Verification
 
-Use the minted token to download the installer. On Linux, verify the signature against the published Dynatrace root CA.
+Use the credentials embedded in the ClassicClient to download the installer. On Linux, verify the signature against the published Dynatrace root CA.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent.go` (extend or factor out shared download helper), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1)
+**Files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/oneagent_v2_test.go` (extend)
 
 ### Part A — Download
 
-- [ ] 5.1 Implement `DownloadInstaller(c *client.ClassicClient, mintedToken string, env Environment) (string, error)` that streams the installer to a temp file
-- [ ] 5.2 Use the minted token in the request `Authorization` header (override the client's default token for this single request)
-- [ ] 5.3 Select OS/arch from `env` (Linux x86 / Linux arm / Windows x86) to populate the installer-type path segment (Windows path handling is in Task 11)
-- [ ] 5.4 Set temp file permissions to `0o700` on Unix; preserve existing `0o755` on the executable bit when running
-- [ ] 5.5 Unit tests with `httptest.Server`: streaming download, 401 response, malformed body
-- [ ] 5.5a Emit `logger.Debug("downloading installer", "url", downloadURL, "os", env.OS, "arch", env.Arch)` at the start of the request; do NOT include the token or `Authorization` header in any log field
-- [ ] 5.5b Emit `logger.Verbose("installer downloaded", "path", tmpFile.Name(), "size_bytes", n)` after streaming completes
+- [x] 5.1 Implement `DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)` that streams the installer to a temp file
+- [x] 5.2 Use `c.HTTP().R().SetDoNotParseResponse(true).Get(path)` — the resty client carries the correct `Authorization` header set upstream by `setupClientFromCreds`; no token extraction in installer code
+- [x] 5.3 Select OS/arch from `env` (Linux x86 / Linux arm / Windows x86) to populate the installer-type path segment (Windows execution flow is in Task 11)
+- [x] 5.4 Set temp file permissions to `0o700` on Unix (covers both confidentiality and the executable bit needed at run time)
+- [x] 5.5 Unit tests with `httptest.Server`: streaming download, 401 response, unsupported OS, URL/arch matrix
+- [x] 5.5a Emit `logger.Debug("downloading installer", "url", downloadURL, "os", env.OS, "arch", env.Arch)` at the start of the request; the credential is never placed in a log field
+- [x] 5.5b Emit `logger.Verbose("installer downloaded", "path", tmpFile.Name(), "size_bytes", n)` after streaming completes
 
 ### Part B — Linux signature verification
 
-- [ ] 5.6 Implement `VerifyInstallerSignature(env Environment, installerPath string, skip bool) error`
-- [ ] 5.7 Return nil when `skip == true` or `env.OS != "linux"`
-- [ ] 5.8 On Linux: locate `openssl` via `exec.LookPath`; return `"openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."` if missing
-- [ ] 5.9 Download `https://ca.dynatrace.com/dt-root.cert.pem` to a temp file using the resty client (no token needed)
-- [ ] 5.10 Run the documented `openssl cms -verify` pipeline; on non-zero exit, return a wrapped error including stderr
-- [ ] 5.11 Unit tests: skip flag honored, non-Linux skip, missing openssl error, mock pipeline success/failure (use fake `openssl` in `$PATH` via `t.Setenv`)
-- [ ] 5.12 Emit `logger.Debug("openssl lookup", "path", p, "found", err == nil)` after the `exec.LookPath` call
-- [ ] 5.13 Emit `logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)` before/after the CA download
-- [ ] 5.14 On success, emit `logger.Verbose("installer signature verified")`
-- [ ] 5.15 On failure, emit `logger.Debug("signature verification failed", "exit_code", code, "stderr", stderrCaptured)` before returning the wrapped error
+- [x] 5.6 Implement `VerifyInstallerSignature(env Environment, installerPath string, skip bool) error`
+- [x] 5.7 Return nil when `skip == true` or `env.OS != "linux"`
+- [x] 5.8 On Linux: locate `openssl` via `exec.LookPath`; return `"openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."` if missing
+- [x] 5.9 Download `https://ca.dynatrace.com/dt-root.cert.pem` to a temp file using a standalone resty client (no token needed); URL is held in a package-level var so tests can override it
+- [x] 5.10 Run the documented `openssl cms -verify` pipeline (header + installer streamed via `cmd.Stdin = io.MultiReader(...)`); on non-zero exit, return a wrapped error including stderr
+- [x] 5.11 Unit tests: skip flag honored, non-Linux skip, missing openssl error, mock pipeline success/failure (fake `openssl` in `$PATH` via `t.Setenv`), CA-fetch failure aborts before openssl runs
+- [x] 5.12 Emit `logger.Debug("openssl lookup", "path", p, "found", err == nil)` after the `exec.LookPath` call
+- [x] 5.13 Emit `logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)` before the CA download
+- [x] 5.14 On success, emit `logger.Verbose("installer signature verified")`
+- [x] 5.15 On failure, emit `logger.Debug("signature verification failed", "exit_code", code, "stderr", stderrCaptured)` before returning the wrapped error
 
 ---
 
@@ -46,7 +51,7 @@ Use the minted token to download the installer. On Linux, verify the signature a
 
 Build the OS-specific install command from `AgentConfig` and execute it (or preview under `--dry-run`).
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/sudo_unix.go` / `_windows.go` (reuse), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1)
+**Files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/sudo_unix.go` / `_windows.go` (reuse), `pkg/installer/oneagent_v2_test.go` (extend)
 
 ### Part A — Build command
 
@@ -54,7 +59,7 @@ Build the OS-specific install command from `AgentConfig` and execute it (or prev
 - [ ] 6.2 Windows: emit `{installerPath, --quiet?, --set-monitoring-mode=<cfg.MonitoringMode>, --set-app-log-content-access=<cfg.AppLogContentAccess>, --set-host-group=<opts.HostGroup>?}` (Windows `--quiet` MUST be the first flag; Windows-specific implementation in Task 11)
 - [ ] 6.3 Linux: emit `{/bin/sh, installerPath, --set-server=<apiURL>, --set-monitoring-mode=..., --set-app-log-content-access=..., --set-host-group=<opts.HostGroup>?}`; prepend `sudo` when `needsSudo()` is true
 - [ ] 6.4 Unit tests covering both OS branches, `--monitoring-mode` override, host-group present/absent, `--quiet` flag ordering on Windows
-- [ ] 6.4a Emit `logger.Debug("built install command", "argv", argv)` once the argv slice is final — the minted token is not in argv, so this is safe
+- [ ] 6.4a Emit `logger.Debug("built install command", "argv", argv)` once the argv slice is final — the credential is not in argv, so this is safe
 
 ### Part B — Execute command
 

--- a/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
+++ b/openspec/changes/oneagent-install/specs/oneagent-install/tasks.md
@@ -63,10 +63,9 @@ Build the OS-specific install command from `AgentConfig` and execute it (or prev
 
 ### Part B — Execute command
 
-- [ ] 6.5 Implement `ExecuteInstallCommand(argv []string, dryRun, quiet bool) (int, error)`
-- [ ] 6.6 Dry-run: print `Command: <argv joined>`, return `(0, nil)`, do NOT shell out
-- [ ] 6.7 Execute: stream stdout/stderr when `quiet == false`; capture when `quiet == true`
-- [ ] 6.8 Return the subprocess exit code alongside any wrapping error; non-zero exit code is an error with the installer output included
-- [ ] 6.9 Unit tests: dry-run produces no subprocess, executor returns exit code, stderr captured on failure
-- [ ] 6.10 Emit `logger.Debug("executing installer", "argv", argv)` immediately before spawning the subprocess (NOT in the dry-run branch)
-- [ ] 6.11 Emit `logger.Verbose("installer exited", "exit_code", code, "duration", time.Since(start))` after the subprocess returns
+- [ ] 6.5 Implement `ExecuteInstallCommand(argv []string, quiet bool) (int, error)` — no `dryRun` parameter; dry-run is checked beforehand in `InstallOneAgentV2` before this function is ever called
+- [ ] 6.6 Execute: stream stdout/stderr when `quiet == false`; capture when `quiet == true`
+- [ ] 6.7 Return the subprocess exit code alongside any wrapping error; non-zero exit code is an error with the installer output included
+- [ ] 6.8 Unit tests: executor returns exit code, stderr captured on failure
+- [ ] 6.9 Emit `logger.Debug("executing installer", "argv", argv)` immediately before spawning the subprocess
+- [ ] 6.10 Emit `logger.Verbose("installer exited", "exit_code", code, "duration", time.Since(start))` after the subprocess returns

--- a/openspec/changes/oneagent-validate/proposal.md
+++ b/openspec/changes/oneagent-validate/proposal.md
@@ -6,7 +6,7 @@ This change adds post-install verification: `WaitForHostRegistration` polls Grai
 
 ## What Changes
 
-- `WaitForHostRegistration(p *client.PlatformClient, hostname string, timeout time.Duration) (string, error)` added to `pkg/installer/oneagent_v2.go`.
+- `WaitForHostRegistration(p *client.PlatformClient, hostname string, timeout time.Duration) (string, error)` added to `pkg/installer/oneagent/oneagent.go`.
 - Uses the Platform API / Grail DQL stack already used by `WatchIngest` (`pkg/installer/ingest_watch.go`) — no new URL family or auth scheme.
 - Timeout (2 minutes) is a warning, not a failure: the installer subprocess already exited 0, and host registration is eventually consistent.
 - If no platform token is configured, the step is skipped with a clear warning — the install still reports success.
@@ -19,6 +19,6 @@ This change adds post-install verification: `WaitForHostRegistration` polls Grai
 
 ## Impact
 
-- **Modified files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/oneagent_v2_test.go` (extend)
+- **Modified files:** `pkg/installer/oneagent/` (extend), `pkg/installer/oneagent/oneagent_test.go` (extend)
 - **No new flags** — verification is automatic; the only opt-out is not supplying a platform token.
 - **No breaking change** — the function is called after `ExecuteInstallCommand` returns 0; timeout returns `("", nil)` so the overall install exit code remains 0.

--- a/openspec/changes/oneagent-validate/specs/oneagent-validate/tasks.md
+++ b/openspec/changes/oneagent-validate/specs/oneagent-validate/tasks.md
@@ -16,7 +16,7 @@ Before implementing, review the design and spec documents to understand the requ
 
 Confirm the agent has registered with the tenant. Timeout is a warning, not a failure.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent_v2_test.go` (extend — scaffolded in Task 1)
+**Files:** `pkg/installer/oneagent/oneagent.go` (extend — scaffolded in Task 1), `pkg/installer/oneagent/oneagent_test.go` (extend — scaffolded in Task 1)
 
 - [ ] 7.1 Implement `WaitForHostRegistration(p *client.PlatformClient, hostname string, timeout time.Duration) (string, error)` polling Grail via `POST <p.BaseURL()>/platform/storage/query/v1/query:execute` every 5s. The DQL query is approximately:
 

--- a/openspec/changes/oneagent-windows/design.md
+++ b/openspec/changes/oneagent-windows/design.md
@@ -67,7 +67,7 @@ Platform-specific code goes in:
 - `pkg/installer/preflight_windows.go` (`//go:build windows`) — `isAdminWindows`, Windows privilege check.
 - `pkg/installer/preflight_unix.go` (`//go:build !windows`) — `needsSudo`-based check (already exists as `sudo_unix.go`; extend or add file as needed).
 
-Shared code in `oneagent_v2.go` calls `CheckPrivilege()` without a runtime `GOOS` check — the build tag dispatch handles it.
+Shared code in `pkg/installer/oneagent/` calls `CheckPrivilege()` without a runtime `GOOS` check — the build tag dispatch handles it.
 
 ### 6. Logging
 

--- a/openspec/changes/oneagent-windows/proposal.md
+++ b/openspec/changes/oneagent-windows/proposal.md
@@ -24,5 +24,5 @@ Tasks 2–7 of the OneAgent PoC implement the core install flow with Linux as th
 ## Impact
 
 - **New files:** `pkg/installer/preflight_windows.go` (`//go:build windows`), corresponding `preflight_unix.go` stub if needed.
-- **Modified files:** `pkg/installer/oneagent_v2.go` (extend download, verify, build paths), `pkg/installer/oneagent_v2_test.go` (extend with Windows happy-path and PowerShell mock tests).
+- **Modified files:** `pkg/installer/oneagent/` (extend download in `download.go`, verify in `verify.go`, build paths in `oneagent.go`), `pkg/installer/oneagent/oneagent_test.go` (extend with Windows happy-path and PowerShell mock tests).
 - **New dependency:** `golang.org/x/sys/windows` for process token / SID inspection (may already be present transitively).

--- a/openspec/changes/oneagent-windows/specs/oneagent-windows/spec.md
+++ b/openspec/changes/oneagent-windows/specs/oneagent-windows/spec.md
@@ -216,6 +216,6 @@ Windows-specific code shall use consistent Go build tags and file naming convent
 #### Scenario: Shared code handles both platforms
 
 - **GIVEN** functions like `CheckPrivilege` that have platform-specific implementations
-- **WHEN** the shared `oneagent_v2.go` calls the function
+- **WHEN** the shared `pkg/installer/oneagent/` calls the function
 - **THEN** the function dispatch is automatic via build tags
 - **AND** no runtime platform checks are needed within the function call site

--- a/openspec/changes/oneagent-windows/specs/oneagent-windows/tasks.md
+++ b/openspec/changes/oneagent-windows/specs/oneagent-windows/tasks.md
@@ -15,7 +15,7 @@ Before implementing, review the design and spec documents to understand the requ
 
 Complete Windows-specific implementation not covered inline by earlier tasks: correct installer download URL/extension, Authenticode signature verification via PowerShell, and temp-file permission handling. Earlier tasks (2.7b, 5.3, 6.2, 7) reference Windows but leave the platform-specific logic as stubs or TODOs. This spec consolidates all Windows-specific work.
 
-**Files:** `pkg/installer/oneagent_v2.go` (extend), `pkg/installer/oneagent_v2_test.go` (extend), `pkg/installer/preflight_windows.go` (create or extend), `pkg/installer/sudo_windows.go` (extend)
+**Files:** `pkg/installer/oneagent/` (extend), `pkg/installer/oneagent/oneagent_test.go` (extend), `pkg/installer/preflight_windows.go` (create or extend), `pkg/installer/sudo_windows.go` (extend)
 
 ### Part A — Windows installer download
 
@@ -43,6 +43,6 @@ Complete Windows-specific implementation not covered inline by earlier tasks: co
 
 ### Part D — Windows integration test
 
-- [ ] 11.16 Add `TestInstallOneAgentV2_HappyPath_Windows` to `oneagent_v2_test.go`: mock tenant API, mock download returns a `.exe` body, Authenticode check mocked as `Valid`, install command starts with the installer path then `--quiet` as first flag (no `/bin/sh` prefix, no `sudo`), executor returns exit code 0
+- [ ] 11.16 Add `TestInstallOneAgentV2_HappyPath_Windows` to `pkg/installer/oneagent/oneagent_test.go`: mock tenant API, mock download returns a `.exe` body, Authenticode check mocked as `Valid`, install command starts with the installer path then `--quiet` as first flag (no `/bin/sh` prefix, no `sudo`), executor returns exit code 0
 - [ ] 11.17 Assert no `chmod`-equivalent is called on the downloaded installer path in the Windows happy-path flow
 - [ ] 11.18 Assert the download URL contains the Windows path segment and the temp file name ends in `.exe`

--- a/openspec/specs/display-package/spec.md
+++ b/openspec/specs/display-package/spec.md
@@ -46,13 +46,14 @@ Any new color or print need SHALL be evaluated against this palette first. A new
 
 ### Requirement: Print helpers for common output patterns
 
-The `pkg/display` package SHALL expose `Header(message string)`, `PrintSectionDivider()`, `PrintStatusLine(label, message string, c *color.Color)`, `PrintFlagLine(label, message string, c *color.Color)`, and `PrintError(label string, err error)` as helpers for recurring output patterns used across commands and installers.
+The `pkg/display` package SHALL expose `Header(message string)`, `PrintSectionDivider()`, `PrintStatusLine(label, message string, c *color.Color)`, `PrintFlagLine(label, message string, c *color.Color)`, `PrintError(label string, err error)`, `PrintPending(label, message string)`, and `ClearPending()` as helpers for recurring output patterns used across commands and installers.
 
 `Header` SHALL print the message indented with two spaces using `ColorHeader`, followed immediately by a section divider — callers SHALL NOT call `PrintSectionDivider()` after `Header()`. Callers SHALL NOT add leading spaces to the message argument; `Header` applies indentation itself.
 `PrintSectionDivider` SHALL print a `─` separator of `DividerLineLength` characters indented with two spaces using `ColorMuted`. It is available for use outside of `Header` where a standalone divider is needed.
 `PrintStatusLine` SHALL print a line of the form `<label>:  <message>` (indented two spaces) where the label is styled with `ColorDefault` and the message is styled with the provided color.
 `PrintFlagLine` SHALL print a line of the form `<label>  <message>` (no colon, indented two spaces) where the label is styled with `ColorDefault` and the message is styled with the provided color.
 `PrintError` SHALL print a line of the form `<label>: ✗ <err>` (indented two spaces) where the error text is styled with `ColorError`.
+`PrintPending` SHALL write a `\r`-prefixed in-progress line of the form `<label>:  <message>` to stderr without a trailing newline, allowing a subsequent call to overwrite it. It SHALL be a no-op when stderr is not a TTY. `ClearPending` SHALL erase the line written by `PrintPending` using ANSI `\r\033[2K` and SHALL also be a no-op on non-TTY stderr. Callers MUST call `ClearPending` (or allow `PrintStatusLine` to start a new line) before returning — a pending line SHALL never be left on screen.
 
 Any print pattern that recurs across two or more files SHALL be extracted into `pkg/display/print.go`. Print patterns that are specific to a single installer or command MAY remain in that file but MUST reuse `display.Color*` variables and MUST NOT construct their own `color.New(...)` instances for roles already covered by the palette.
 

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -50,7 +50,7 @@ func PrintFlagLine(label, message string, colorFunc *color.Color) {
 // is not a TTY to avoid polluting CI logs.
 func PrintPending(label, message string) {
 	if isTTY() {
-		fmt.Fprintf(os.Stderr, "\r  %s:  %s", label, message)
+		fmt.Fprintf(os.Stderr, "\r\033[2K  %s:  %s", label, message)
 	}
 }
 

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/fatih/color"
@@ -41,6 +42,22 @@ func PrintFlagLine(label, message string, colorFunc *color.Color) {
 	_, err := fmt.Fprintf(color.Output, "  %s  %s\n", ColorDefault.Sprint(label), colorFunc.Sprint(message))
 	if err != nil {
 		PrintError(label, err)
+	}
+}
+
+// PrintPending writes an in-progress status to stderr using \r so a subsequent
+// ClearPending or PrintStatusLine starts on a clean line. No-ops when stderr
+// is not a TTY to avoid polluting CI logs.
+func PrintPending(label, message string) {
+	if isTTY() {
+		fmt.Fprintf(os.Stderr, "\r  %s:  %s", label, message)
+	}
+}
+
+// ClearPending erases the line written by PrintPending.
+func ClearPending() {
+	if isTTY() {
+		fmt.Fprint(os.Stderr, "\r\033[2K")
 	}
 }
 

--- a/pkg/display/progress.go
+++ b/pkg/display/progress.go
@@ -1,0 +1,82 @@
+package display
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/term"
+)
+
+const progressPrintInterval = 100 * time.Millisecond
+
+// ProgressReader wraps an io.Reader and prints a download progress line to
+// stderr at most once per progressPrintInterval. Output is suppressed when
+// stderr is not a TTY (e.g. CI, pipes) to avoid polluting logs.
+type ProgressReader struct {
+	r         io.Reader
+	w         io.Writer
+	read      int64
+	total     int64 // -1 when Content-Length is unknown
+	isTTY     bool
+	lastPrint time.Time
+}
+
+// NewProgressReader returns a ProgressReader. total should be the expected
+// number of bytes, or -1 if unknown (e.g. no Content-Length header).
+func NewProgressReader(r io.Reader, total int64) *ProgressReader {
+	return &ProgressReader{
+		r:     r,
+		w:     os.Stderr,
+		total: total,
+		isTTY: term.IsTerminal(int(os.Stderr.Fd())),
+	}
+}
+
+func (p *ProgressReader) Read(buf []byte) (int, error) {
+	n, err := p.r.Read(buf)
+	p.read += int64(n)
+	if p.isTTY && time.Since(p.lastPrint) >= progressPrintInterval {
+		p.print()
+		p.lastPrint = time.Now()
+	}
+	return n, err
+}
+
+func (p *ProgressReader) print() {
+	if p.total > 0 {
+		pct := float64(p.read) / float64(p.total) * 100
+		fmt.Fprintf(p.w, "\r  downloading:  %s / %s (%.0f%%)",
+			HumanBytes(p.read), HumanBytes(p.total), pct)
+	} else {
+		fmt.Fprintf(p.w, "\r  downloading:  %s", HumanBytes(p.read))
+	}
+}
+
+// Clear erases the progress line so the next output starts on a clean line.
+// Should be called after the read is complete (success or failure).
+func (p *ProgressReader) Clear() {
+	if p.isTTY {
+		fmt.Fprint(p.w, "\r\033[2K")
+	}
+}
+
+// HumanBytes formats a byte count as a human-readable string (e.g. "42MB").
+func HumanBytes(n int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case n >= gb:
+		return fmt.Sprintf("%dGB", n/gb)
+	case n >= mb:
+		return fmt.Sprintf("%dMB", n/mb)
+	case n >= kb:
+		return fmt.Sprintf("%dKB", n/kb)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/pkg/display/progress.go
+++ b/pkg/display/progress.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"os"
 	"time"
-
-	"golang.org/x/term"
 )
 
 const progressPrintInterval = 100 * time.Millisecond
@@ -30,7 +28,7 @@ func NewProgressReader(r io.Reader, total int64) *ProgressReader {
 		r:     r,
 		w:     os.Stderr,
 		total: total,
-		isTTY: term.IsTerminal(int(os.Stderr.Fd())),
+		isTTY: isTTY(),
 	}
 }
 

--- a/pkg/display/tty.go
+++ b/pkg/display/tty.go
@@ -1,0 +1,11 @@
+package display
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}

--- a/pkg/installer/oneagent.go
+++ b/pkg/installer/oneagent.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // InstallMode controls which OneAgent components are installed.
@@ -95,6 +96,11 @@ func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 		iType, arch,
 	)
 
+	authScheme := strings.SplitN(c.HTTP().Header.Get("Authorization"), " ", 2)[0]
+	logger.Debug("downloading installer",
+		"url", strings.TrimRight(c.BaseURL(), "/")+path,
+		"auth_scheme", authScheme,
+	)
 	fmt.Printf("  Downloading OneAgent installer from %s...\n", c.BaseURL())
 	resp, err := c.HTTP().R().SetDoNotParseResponse(true).Get(path)
 	if err != nil {
@@ -103,7 +109,14 @@ func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 	defer resp.RawBody().Close()
 
 	if resp.StatusCode() != http.StatusOK {
-		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
+		body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
+		logger.Debug("installer download failed",
+			"status", resp.StatusCode(),
+			"auth_scheme", authScheme,
+			"response_body", strings.TrimSpace(string(body)),
+		)
+		return "", fmt.Errorf("installer download failed with status %d: %s",
+			resp.StatusCode(), strings.TrimSpace(string(body)))
 	}
 
 	tmpFile, err := os.CreateTemp("", oneAgentInstallerFilename())

--- a/pkg/installer/oneagent.go
+++ b/pkg/installer/oneagent.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // InstallMode controls which OneAgent components are installed.
@@ -96,11 +95,6 @@ func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 		iType, arch,
 	)
 
-	authScheme := strings.SplitN(c.HTTP().Header.Get("Authorization"), " ", 2)[0]
-	logger.Debug("downloading installer",
-		"url", strings.TrimRight(c.BaseURL(), "/")+path,
-		"auth_scheme", authScheme,
-	)
 	fmt.Printf("  Downloading OneAgent installer from %s...\n", c.BaseURL())
 	resp, err := c.HTTP().R().SetDoNotParseResponse(true).Get(path)
 	if err != nil {
@@ -109,14 +103,7 @@ func downloadOneAgentInstaller(c *client.ClassicClient) (string, error) {
 	defer resp.RawBody().Close()
 
 	if resp.StatusCode() != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
-		logger.Debug("installer download failed",
-			"status", resp.StatusCode(),
-			"auth_scheme", authScheme,
-			"response_body", strings.TrimSpace(string(body)),
-		)
-		return "", fmt.Errorf("installer download failed with status %d: %s",
-			resp.StatusCode(), strings.TrimSpace(string(body)))
+		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
 	}
 
 	tmpFile, err := os.CreateTemp("", oneAgentInstallerFilename())

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -83,10 +83,10 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 			"response_body", body,
 		)
 		if resp.StatusCode() == http.StatusForbidden || resp.StatusCode() == http.StatusUnauthorized {
-			return "", fmt.Errorf( //nolint:staticcheck // ST1005: user-facing remediation hint with sentence structure
+			return "", fmt.Errorf(
 				"installer download failed (%d) — if using a platform token, ensure it has the InstallerDownload scope; "+
 					"or pass a dt0c01.* access token with --access-token or DT_ACCESS_TOKEN.\n"+
-					"Run with --debug for the API error detail.",
+					"Run with --debug for the API error detail",
 				resp.StatusCode(),
 			)
 		}

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -99,7 +99,11 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 	}
 	defer tmpFile.Close()
 
-	n, err := io.Copy(tmpFile, resp.RawBody())
+	totalBytes := resp.RawResponse.ContentLength // -1 when unknown
+	src := display.NewProgressReader(resp.RawBody(), totalBytes)
+
+	n, err := io.Copy(tmpFile, src)
+	src.Clear()
 	if err != nil {
 		_ = os.Remove(tmpFile.Name())
 		return "", fmt.Errorf("writing installer to disk: %w", err)
@@ -114,7 +118,7 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 
 	logger.Verbose("installer downloaded", "path", tmpFile.Name(), "size_bytes", n)
 	display.PrintStatusLine("installer",
-		fmt.Sprintf("%s (%s)", filepath.Base(tmpFile.Name()), humanBytes(n)),
+		fmt.Sprintf("%s (%s)", filepath.Base(tmpFile.Name()), display.HumanBytes(n)),
 		display.ColorOK)
 	return tmpFile.Name(), nil
 }
@@ -124,22 +128,4 @@ func installerExtension(os string) string {
 		return ".exe"
 	}
 	return ".sh"
-}
-
-func humanBytes(n int64) string {
-	const (
-		kb = 1024
-		mb = kb * 1024
-		gb = mb * 1024
-	)
-	switch {
-	case n >= gb:
-		return fmt.Sprintf("%dGB", n/gb)
-	case n >= mb:
-		return fmt.Sprintf("%dMB", n/mb)
-	case n >= kb:
-		return fmt.Sprintf("%dKB", n/kb)
-	default:
-		return fmt.Sprintf("%dB", n)
-	}
 }

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -1,4 +1,4 @@
-package installer
+package oneagent
 
 import (
 	"fmt"
@@ -15,101 +15,6 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
-
-type InstallOptions struct {
-	DryRun                bool
-	MonitoringMode        string
-	NoVerifySignature     bool
-	SkipConnectivityCheck bool
-	ConnectivityCheckOnly bool
-	PrintEndpoints        bool
-	Quiet                 bool
-}
-
-type AgentConfig struct {
-	MonitoringMode string
-}
-
-// Environment identifies the target OS and CPU architecture used to select the
-// correct OneAgent installer. OS values: "linux", "windows". Arch values:
-// "x86", "arm".
-type Environment struct {
-	OS   string
-	Arch string
-}
-
-func DefaultAgentConfig() AgentConfig {
-	return AgentConfig{MonitoringMode: string(InstallModeFullStack)}
-}
-
-func ResolveAgentConfig(opts InstallOptions) AgentConfig {
-	cfg := DefaultAgentConfig()
-	if opts.MonitoringMode != "" {
-		cfg.MonitoringMode = opts.MonitoringMode
-	}
-	logger.Debug("resolved agent config",
-		"monitoring-mode", cfg.MonitoringMode,
-		"override_set", cfg.MonitoringMode != string(InstallModeFullStack),
-	)
-	return cfg
-}
-
-func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
-	display.PrintStatusLine("oneagent", fmt.Sprintf("PoC flow (monitoring-mode=%s)", opts.MonitoringMode), display.ColorWarning)
-
-	env, err := detectRuntimeEnvironment()
-	if err != nil {
-		return err
-	}
-	logger.Debug("detected environment", "os", env.OS, "arch", env.Arch)
-
-	cfg := ResolveAgentConfig(opts)
-	logger.Debug("install options",
-		"dry_run", opts.DryRun,
-		"no_verify_signature", opts.NoVerifySignature,
-		"monitoring_mode", cfg.MonitoringMode,
-	)
-
-	installerPath, err := DownloadInstaller(c.Classic, env)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(installerPath)
-
-	if err := VerifyInstallerSignature(env, installerPath, opts.NoVerifySignature); err != nil {
-		return err
-	}
-
-	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
-	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
-	return nil
-}
-
-// detectRuntimeEnvironment returns an Environment based on the current host
-// OS and architecture. Used as a stand-in until DetectEnvironment (Task 2) is
-// implemented.
-func detectRuntimeEnvironment() (Environment, error) {
-	var arch string
-	switch runtime.GOARCH {
-	case "amd64":
-		arch = "x86"
-	case "arm64":
-		arch = "arm"
-	default:
-		return Environment{}, fmt.Errorf("unsupported architecture for OneAgent: %s", runtime.GOARCH)
-	}
-
-	switch runtime.GOOS {
-	case "linux":
-		return Environment{OS: "linux", Arch: arch}, nil
-	case "windows":
-		return Environment{OS: "windows", Arch: arch}, nil
-	case "darwin":
-		return Environment{}, fmt.Errorf("OneAgent direct install is not supported on macOS; use Docker or Linux")
-	default:
-		return Environment{}, fmt.Errorf("unsupported OS for OneAgent: %s", runtime.GOOS)
-	}
-}
 
 // readErrorBody reads up to 2 KB from a resty response body. Used on non-200
 // responses where SetDoNotParseResponse(true) is active. Go's net/http

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -1,6 +1,7 @@
 package oneagent
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,11 +18,18 @@ import (
 )
 
 // readErrorBody reads up to 2 KB from a resty response body. Used on non-200
-// responses where SetDoNotParseResponse(true) is active. Go's net/http
-// transport handles transparent gzip decompression at the transport level, so
-// no manual decompression is needed here.
+// responses where SetDoNotParseResponse(true) is active. Because the shared
+// resty client sets Accept-Encoding: gzip explicitly, Go's transport does not
+// decompress automatically — we must do it here when the server signals gzip.
 func readErrorBody(resp *resty.Response) string {
-	body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
+	var r io.Reader = resp.RawBody()
+	if resp.Header().Get("Content-Encoding") == "gzip" {
+		if gz, err := gzip.NewReader(r); err == nil {
+			defer gz.Close()
+			r = gz
+		}
+	}
+	body, _ := io.ReadAll(io.LimitReader(r, 2048))
 	return strings.TrimSpace(string(body))
 }
 

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -120,6 +120,7 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 	n, err := io.Copy(tmpFile, src)
 	src.Clear()
 	if err != nil {
+		tmpFile.Close()
 		_ = os.Remove(tmpFile.Name())
 		return "", fmt.Errorf("writing installer to disk: %w", err)
 	}

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -47,16 +47,31 @@ func installerOSSegment(os string) (string, error) {
 	}
 }
 
+func installerAPIPath(env Environment) (string, error) {
+	osSeg, err := installerOSSegment(env.OS)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/api/v1/deployment/installer/agent/%s/default/latest?arch=%s", osSeg, env.Arch), nil
+}
+
+func InstallerDownloadURL(baseURL string, env Environment) (string, error) {
+	path, err := installerAPIPath(env)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(baseURL, "/") + path, nil
+}
+
 // DownloadInstaller streams the OneAgent installer to a temporary file using
 // the credentials already embedded in the ClassicClient (set upstream by
 // validateCredentials). On Unix the file permissions are tightened to 0o700.
 // The caller owns the returned path and is responsible for removing it.
 func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error) {
-	osSeg, err := installerOSSegment(env.OS)
+	path, err := installerAPIPath(env)
 	if err != nil {
 		return "", err
 	}
-	path := fmt.Sprintf("/api/v1/deployment/installer/agent/%s/default/latest?arch=%s", osSeg, env.Arch)
 	downloadURL := strings.TrimRight(c.BaseURL(), "/") + path
 
 	// Log auth scheme (Bearer vs Api-Token) without exposing the token value.

--- a/pkg/installer/oneagent/download_test.go
+++ b/pkg/installer/oneagent/download_test.go
@@ -1,0 +1,212 @@
+package oneagent
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallerOSSegment(t *testing.T) {
+	cases := []struct {
+		os      string
+		want    string
+		wantErr bool
+	}{
+		{"linux", "unix", false},
+		{"windows", "windows", false},
+		{"freebsd", "", true},
+		{"darwin", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		got, err := installerOSSegment(c.os)
+		if (err != nil) != c.wantErr {
+			t.Errorf("installerOSSegment(%q) error = %v, wantErr %v", c.os, err, c.wantErr)
+		}
+		if got != c.want {
+			t.Errorf("installerOSSegment(%q) = %q, want %q", c.os, got, c.want)
+		}
+	}
+}
+
+func TestInstallerExtension(t *testing.T) {
+	cases := []struct {
+		os   string
+		want string
+	}{
+		{"windows", ".exe"},
+		{"linux", ".sh"},
+		{"darwin", ".sh"},
+		{"", ".sh"},
+	}
+	for _, c := range cases {
+		got := installerExtension(c.os)
+		if got != c.want {
+			t.Errorf("installerExtension(%q) = %q, want %q", c.os, got, c.want)
+		}
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1KB"},
+		{2 * 1024 * 1024, "2MB"},
+		{3 * 1024 * 1024 * 1024, "3GB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDownloadInstaller_LinuxX86_StreamsAndStores(t *testing.T) {
+	content := []byte("fake-installer-binary-content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/deployment/installer/agent/unix/default/latest" {
+			t.Errorf("path = %q, want unix segment", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("arch"); got != "x86" {
+			t.Errorf("arch = %q, want x86", got)
+		}
+		if auth := r.Header.Get("Authorization"); auth == "" {
+			t.Error("expected Authorization header to be present")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	c := newTestClassicClient(t, srv.URL)
+	path, err := DownloadInstaller(c, Environment{OS: "linux", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read downloaded: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+	if !strings.HasSuffix(path, ".sh") {
+		t.Errorf("filename %q should end in .sh on Unix env", path)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Errorf("perms = %o, want 0700", info.Mode().Perm())
+		}
+	}
+}
+
+func TestDownloadInstaller_LinuxArm_URL(t *testing.T) {
+	var gotArch string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotArch = r.URL.Query().Get("arch")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "arm"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+	if gotArch != "arm" {
+		t.Errorf("arch query = %q, want arm", gotArch)
+	}
+}
+
+func TestDownloadInstaller_Windows_URL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "windows", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+	if gotPath != "/api/v1/deployment/installer/agent/windows/default/latest" {
+		t.Errorf("path = %q, want windows segment", gotPath)
+	}
+	if !strings.HasSuffix(path, ".exe") {
+		t.Errorf("filename %q should end in .exe for Windows env", path)
+	}
+}
+
+func TestDownloadInstaller_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error %q does not mention 401", err)
+	}
+}
+
+func TestDownloadInstaller_UnsupportedOS(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "freebsd", Arch: "x86"})
+	if err == nil {
+		t.Fatal("expected error for unsupported OS")
+	}
+	if !strings.Contains(err.Error(), "unsupported installer OS") {
+		t.Errorf("error = %q, want unsupported OS message", err)
+	}
+}
+
+func TestDownloadInstaller_DebugLogLineRedactsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "downloading installer") {
+		t.Errorf("logs missing 'downloading installer' line:\n%s", logs)
+	}
+	if strings.Contains(logs, "dt0s16.test") {
+		t.Errorf("logs contain raw token:\n%s", logs)
+	}
+}

--- a/pkg/installer/oneagent/download_test.go
+++ b/pkg/installer/oneagent/download_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
 func TestInstallerOSSegment(t *testing.T) {
@@ -64,7 +66,7 @@ func TestHumanBytes(t *testing.T) {
 		{3 * 1024 * 1024 * 1024, "3GB"},
 	}
 	for _, c := range cases {
-		if got := humanBytes(c.in); got != c.want {
+		if got := display.HumanBytes(c.in); got != c.want {
 			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
 		}
 	}

--- a/pkg/installer/oneagent/oneagent.go
+++ b/pkg/installer/oneagent/oneagent.go
@@ -13,6 +13,7 @@ import (
 type InstallOptions struct {
 	DryRun                bool
 	MonitoringMode        string
+	HostGroup             string
 	NoVerifySignature     bool
 	SkipConnectivityCheck bool
 	ConnectivityCheckOnly bool
@@ -63,6 +64,11 @@ func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 		"monitoring_mode", cfg.MonitoringMode,
 	)
 
+	if opts.DryRun {
+		printDryRun(c.Classic.BaseURL(), env, cfg, opts)
+		return nil
+	}
+
 	installerPath, err := DownloadInstaller(c.Classic, env)
 	if err != nil {
 		return err
@@ -76,6 +82,23 @@ func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
 	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
 	return nil
+}
+
+func printDryRun(baseURL string, env Environment, cfg AgentConfig, opts InstallOptions) {
+	fmt.Println("[dry-run] Would install Dynatrace OneAgent")
+	if url, err := InstallerDownloadURL(baseURL, env); err == nil {
+		fmt.Printf("  Installer:  %s\n", url)
+	}
+	if opts.NoVerifySignature || env.OS != "linux" {
+		fmt.Printf("  Signature:  skipped\n")
+	} else {
+		fmt.Printf("  Signature:  would verify against %s\n", dtRootCertURL)
+	}
+	fmt.Printf("  Mode:       %s\n", cfg.MonitoringMode)
+	if opts.HostGroup != "" {
+		fmt.Printf("  Host group: %s\n", opts.HostGroup)
+	}
+	display.PrintStatusLine("dry-run", "no changes made", display.ColorMuted)
 }
 
 // detectRuntimeEnvironment returns an Environment based on the current host

--- a/pkg/installer/oneagent/oneagent.go
+++ b/pkg/installer/oneagent/oneagent.go
@@ -49,8 +49,6 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 }
 
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
-	display.PrintStatusLine("oneagent", fmt.Sprintf("PoC flow (monitoring-mode=%s)", opts.MonitoringMode), display.ColorWarning)
-
 	env, err := detectRuntimeEnvironment()
 	if err != nil {
 		return err
@@ -58,6 +56,7 @@ func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 	logger.Debug("detected environment", "os", env.OS, "arch", env.Arch)
 
 	cfg := ResolveAgentConfig(opts)
+	display.PrintStatusLine("oneagent", fmt.Sprintf("PoC flow (monitoring-mode=%s)", cfg.MonitoringMode), display.ColorWarning)
 	logger.Debug("install options",
 		"dry_run", opts.DryRun,
 		"no_verify_signature", opts.NoVerifySignature,

--- a/pkg/installer/oneagent/oneagent.go
+++ b/pkg/installer/oneagent/oneagent.go
@@ -79,7 +79,7 @@ func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 		return err
 	}
 
-	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
+	display.PrintStatusLine("oneagent", "install execution not yet implemented", display.ColorWarning)
 	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
 	return nil
 }

--- a/pkg/installer/oneagent/oneagent.go
+++ b/pkg/installer/oneagent/oneagent.go
@@ -1,0 +1,106 @@
+package oneagent
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
+)
+
+type InstallOptions struct {
+	DryRun                bool
+	MonitoringMode        string
+	NoVerifySignature     bool
+	SkipConnectivityCheck bool
+	ConnectivityCheckOnly bool
+	PrintEndpoints        bool
+	Quiet                 bool
+}
+
+type AgentConfig struct {
+	MonitoringMode string
+}
+
+// Environment identifies the target OS and CPU architecture used to select the
+// correct OneAgent installer. OS values: "linux", "windows". Arch values:
+// "x86", "arm".
+type Environment struct {
+	OS   string
+	Arch string
+}
+
+func DefaultAgentConfig() AgentConfig {
+	return AgentConfig{MonitoringMode: "fullstack"}
+}
+
+func ResolveAgentConfig(opts InstallOptions) AgentConfig {
+	cfg := DefaultAgentConfig()
+	if opts.MonitoringMode != "" {
+		cfg.MonitoringMode = opts.MonitoringMode
+	}
+	logger.Debug("resolved agent config",
+		"monitoring-mode", cfg.MonitoringMode,
+		"override_set", cfg.MonitoringMode != "fullstack",
+	)
+	return cfg
+}
+
+func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
+	display.PrintStatusLine("oneagent", fmt.Sprintf("PoC flow (monitoring-mode=%s)", opts.MonitoringMode), display.ColorWarning)
+
+	env, err := detectRuntimeEnvironment()
+	if err != nil {
+		return err
+	}
+	logger.Debug("detected environment", "os", env.OS, "arch", env.Arch)
+
+	cfg := ResolveAgentConfig(opts)
+	logger.Debug("install options",
+		"dry_run", opts.DryRun,
+		"no_verify_signature", opts.NoVerifySignature,
+		"monitoring_mode", cfg.MonitoringMode,
+	)
+
+	installerPath, err := DownloadInstaller(c.Classic, env)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(installerPath)
+
+	if err := VerifyInstallerSignature(env, installerPath, opts.NoVerifySignature); err != nil {
+		return err
+	}
+
+	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
+	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
+	return nil
+}
+
+// detectRuntimeEnvironment returns an Environment based on the current host
+// OS and architecture. Used as a stand-in until DetectEnvironment (Task 2) is
+// implemented.
+func detectRuntimeEnvironment() (Environment, error) {
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "x86"
+	case "arm64":
+		arch = "arm"
+	default:
+		return Environment{}, fmt.Errorf("unsupported architecture for OneAgent: %s", runtime.GOARCH)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return Environment{OS: "linux", Arch: arch}, nil
+	case "windows":
+		return Environment{OS: "windows", Arch: arch}, nil
+	case "darwin":
+		return Environment{}, fmt.Errorf("OneAgent direct install is not supported on macOS; use Docker or Linux")
+	default:
+		return Environment{}, fmt.Errorf("unsupported OS for OneAgent: %s", runtime.GOOS)
+	}
+}

--- a/pkg/installer/oneagent/oneagent_test.go
+++ b/pkg/installer/oneagent/oneagent_test.go
@@ -97,6 +97,23 @@ func TestResolveAgentConfig_DebugLog(t *testing.T) {
 	}
 }
 
+func TestInstallOneAgentV2_DryRun_NoDownload(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("OneAgent not supported on macOS")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("dry-run made a real HTTP request: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newMockClient(t, srv.URL)
+	if err := InstallOneAgentV2(c, InstallOptions{DryRun: true, MonitoringMode: "fullstack"}); err != nil {
+		t.Fatalf("dry-run returned unexpected error: %v", err)
+	}
+}
+
 func TestInstallOneAgentV2_UnsupportedPlatformReturnsError(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("macOS-specific error path test")

--- a/pkg/installer/oneagent/oneagent_test.go
+++ b/pkg/installer/oneagent/oneagent_test.go
@@ -1,4 +1,4 @@
-package installer
+package oneagent
 
 import (
 	"bytes"
@@ -13,6 +13,27 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
 )
+
+// newTestClassicClient creates a ClassicClient pointing at the given test server URL.
+func newTestClassicClient(t *testing.T, serverURL string) *client.ClassicClient {
+	t.Helper()
+	c, err := client.New(serverURL, serverURL, "dt0s16.test", "dt0s16.test", 0)
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	return c.Classic
+}
+
+// createStubFile writes content to path (creating parent directories as needed).
+func createStubFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
 
 func newMockTenantServer(t *testing.T, path string, status int, body string) *httptest.Server {
 	t.Helper()
@@ -93,7 +114,7 @@ func TestInstallOneAgentV2_UnsupportedPlatformReturnsError(t *testing.T) {
 	}
 }
 
-// --- Task 5 Part A: DownloadInstaller ---
+// --- DownloadInstaller ---
 
 func TestDownloadInstaller_LinuxX86_StreamsAndStores(t *testing.T) {
 	content := []byte("fake-installer-binary-content")
@@ -236,7 +257,7 @@ func TestDownloadInstaller_DebugLogLineRedactsToken(t *testing.T) {
 	}
 }
 
-// --- Task 5 Part B: VerifyInstallerSignature ---
+// --- VerifyInstallerSignature ---
 
 func TestVerifyInstallerSignature_SkipFlag(t *testing.T) {
 	if err := VerifyInstallerSignature(Environment{OS: "linux"}, "/nonexistent", true); err != nil {

--- a/pkg/installer/oneagent/oneagent_test.go
+++ b/pkg/installer/oneagent/oneagent_test.go
@@ -114,295 +114,35 @@ func TestInstallOneAgentV2_UnsupportedPlatformReturnsError(t *testing.T) {
 	}
 }
 
-// --- DownloadInstaller ---
-
-func TestDownloadInstaller_LinuxX86_StreamsAndStores(t *testing.T) {
-	content := []byte("fake-installer-binary-content")
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/deployment/installer/agent/unix/default/latest" {
-			t.Errorf("path = %q, want unix segment", r.URL.Path)
-		}
-		if got := r.URL.Query().Get("arch"); got != "x86" {
-			t.Errorf("arch = %q, want x86", got)
-		}
-		if auth := r.Header.Get("Authorization"); auth == "" {
-			t.Error("expected Authorization header to be present")
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(content)
-	}))
-	defer srv.Close()
-
-	c := newTestClassicClient(t, srv.URL)
-	path, err := DownloadInstaller(c, Environment{OS: "linux", Arch: "x86"})
-	if err != nil {
-		t.Fatalf("DownloadInstaller: %v", err)
-	}
-	defer os.Remove(path)
-
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read downloaded: %v", err)
-	}
-	if string(got) != string(content) {
-		t.Errorf("content = %q, want %q", got, content)
-	}
-	if !strings.HasSuffix(path, ".sh") {
-		t.Errorf("filename %q should end in .sh on Unix env", path)
-	}
-	if runtime.GOOS != "windows" {
-		info, err := os.Stat(path)
+func TestDetectRuntimeEnvironment(t *testing.T) {
+	env, err := detectRuntimeEnvironment()
+	switch runtime.GOOS {
+	case "linux", "windows":
 		if err != nil {
-			t.Fatalf("stat: %v", err)
+			if !strings.Contains(err.Error(), "unsupported architecture") {
+				t.Errorf("unexpected error on %s: %v", runtime.GOOS, err)
+			}
+			return
 		}
-		if info.Mode().Perm() != 0o700 {
-			t.Errorf("perms = %o, want 0700", info.Mode().Perm())
+		if env.OS != runtime.GOOS {
+			t.Errorf("env.OS = %q, want %q", env.OS, runtime.GOOS)
 		}
-	}
-}
-
-func TestDownloadInstaller_LinuxArm_URL(t *testing.T) {
-	var gotArch string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotArch = r.URL.Query().Get("arch")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "arm"})
-	if err != nil {
-		t.Fatalf("DownloadInstaller: %v", err)
-	}
-	defer os.Remove(path)
-	if gotArch != "arm" {
-		t.Errorf("arch query = %q, want arm", gotArch)
-	}
-}
-
-func TestDownloadInstaller_Windows_URL(t *testing.T) {
-	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "windows", Arch: "x86"})
-	if err != nil {
-		t.Fatalf("DownloadInstaller: %v", err)
-	}
-	defer os.Remove(path)
-	if gotPath != "/api/v1/deployment/installer/agent/windows/default/latest" {
-		t.Errorf("path = %q, want windows segment", gotPath)
-	}
-	if !strings.HasSuffix(path, ".exe") {
-		t.Errorf("filename %q should end in .exe for Windows env", path)
-	}
-}
-
-func TestDownloadInstaller_Unauthorized(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
-	if err == nil {
-		t.Fatal("expected error for 401")
-	}
-	if !strings.Contains(err.Error(), "401") {
-		t.Errorf("error %q does not mention 401", err)
-	}
-}
-
-func TestDownloadInstaller_UnsupportedOS(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "freebsd", Arch: "x86"})
-	if err == nil {
-		t.Fatal("expected error for unsupported OS")
-	}
-	if !strings.Contains(err.Error(), "unsupported installer OS") {
-		t.Errorf("error = %q, want unsupported OS message", err)
-	}
-}
-
-func TestDownloadInstaller_DebugLogLineRedactsToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	var buf bytes.Buffer
-	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	orig := slog.Default()
-	slog.SetDefault(slog.New(handler))
-	t.Cleanup(func() { slog.SetDefault(orig) })
-
-	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
-	if err != nil {
-		t.Fatalf("DownloadInstaller: %v", err)
-	}
-	defer os.Remove(path)
-
-	logs := buf.String()
-	if !strings.Contains(logs, "downloading installer") {
-		t.Errorf("logs missing 'downloading installer' line:\n%s", logs)
-	}
-	if strings.Contains(logs, "dt0s16.test") {
-		t.Errorf("logs contain raw token:\n%s", logs)
-	}
-}
-
-// --- VerifyInstallerSignature ---
-
-func TestVerifyInstallerSignature_SkipFlag(t *testing.T) {
-	if err := VerifyInstallerSignature(Environment{OS: "linux"}, "/nonexistent", true); err != nil {
-		t.Errorf("skip=true should return nil, got %v", err)
-	}
-}
-
-func TestVerifyInstallerSignature_NonLinux(t *testing.T) {
-	cases := []string{"darwin", "windows", ""}
-	for _, os := range cases {
-		if err := VerifyInstallerSignature(Environment{OS: os}, "/nonexistent", false); err != nil {
-			t.Errorf("os=%q should return nil, got %v", os, err)
+		if env.Arch == "" {
+			t.Error("expected non-empty Arch")
 		}
-	}
-}
-
-func TestVerifyInstallerSignature_MissingOpenSSL(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("PATH-based openssl shadowing test relies on Unix semantics")
-	}
-	t.Setenv("PATH", t.TempDir())
-
-	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, "/nonexistent", false)
-	if err == nil {
-		t.Fatal("expected missing-openssl error")
-	}
-	if !strings.Contains(err.Error(), "openssl is required") {
-		t.Errorf("error = %q, want missing-openssl message", err)
-	}
-	if !strings.Contains(err.Error(), "--no-verify-signature") {
-		t.Errorf("error = %q, want --no-verify-signature hint", err)
-	}
-}
-
-func TestVerifyInstallerSignature_Success(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses /bin/sh fake openssl")
-	}
-	binDir := t.TempDir()
-	createStubFile(t, filepath.Join(binDir, "openssl"), "#!/bin/sh\ncat >/dev/null\nexit 0\n", 0o755)
-	t.Setenv("PATH", binDir)
-
-	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
-	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("PEM"))
-	}))
-	defer caSrv.Close()
-	withRootCertURL(t, caSrv.URL)
-
-	if err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false); err != nil {
-		t.Errorf("expected success, got %v", err)
-	}
-}
-
-func TestVerifyInstallerSignature_FailureWrapsStderr(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses /bin/sh fake openssl")
-	}
-	binDir := t.TempDir()
-	createStubFile(t, filepath.Join(binDir, "openssl"),
-		"#!/bin/sh\ncat >/dev/null\necho 'Verification failure' >&2\nexit 4\n", 0o755)
-	t.Setenv("PATH", binDir)
-
-	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
-	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("PEM"))
-	}))
-	defer caSrv.Close()
-	withRootCertURL(t, caSrv.URL)
-
-	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
-	if err == nil {
-		t.Fatal("expected verification failure")
-	}
-	if !strings.Contains(err.Error(), "Verification failure") {
-		t.Errorf("error = %q, missing openssl stderr", err)
-	}
-	if !strings.Contains(err.Error(), "exit 4") {
-		t.Errorf("error = %q, missing exit code", err)
-	}
-}
-
-func TestVerifyInstallerSignature_CADownloadFailsAborts(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses /bin/sh fake openssl")
-	}
-	binDir := t.TempDir()
-	// openssl should never be invoked because CA fetch fails first.
-	createStubFile(t, filepath.Join(binDir, "openssl"),
-		"#!/bin/sh\necho 'should not run' >&2\nexit 99\n", 0o755)
-	t.Setenv("PATH", binDir)
-
-	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer caSrv.Close()
-	withRootCertURL(t, caSrv.URL)
-
-	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
-	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
-	if err == nil {
-		t.Fatal("expected CA download failure")
-	}
-	if !strings.Contains(err.Error(), "Dynatrace root CA") {
-		t.Errorf("error = %q, want CA download error", err)
-	}
-}
-
-// withRootCertURL overrides the package-level CA URL for the duration of the
-// test, restoring it on cleanup.
-func withRootCertURL(t *testing.T, url string) {
-	t.Helper()
-	orig := dtRootCertURL
-	dtRootCertURL = url
-	t.Cleanup(func() { dtRootCertURL = orig })
-}
-
-func TestHumanBytes(t *testing.T) {
-	cases := []struct {
-		in   int64
-		want string
-	}{
-		{0, "0B"},
-		{512, "512B"},
-		{1024, "1KB"},
-		{2 * 1024 * 1024, "2MB"},
-		{3 * 1024 * 1024 * 1024, "3GB"},
-	}
-	for _, c := range cases {
-		if got := humanBytes(c.in); got != c.want {
-			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+	case "darwin":
+		if err == nil {
+			t.Fatal("expected error on macOS")
+		}
+		if !strings.Contains(err.Error(), "macOS") {
+			t.Errorf("error = %q, want macOS message", err)
+		}
+	default:
+		if err == nil {
+			t.Fatalf("expected error on unsupported OS %s", runtime.GOOS)
+		}
+		if !strings.Contains(err.Error(), "unsupported") {
+			t.Errorf("error = %q, want unsupported OS message", err)
 		}
 	}
 }

--- a/pkg/installer/oneagent/verify.go
+++ b/pkg/installer/oneagent/verify.go
@@ -1,4 +1,4 @@
-package installer
+package oneagent
 
 import (
 	"bytes"

--- a/pkg/installer/oneagent/verify.go
+++ b/pkg/installer/oneagent/verify.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 
@@ -23,6 +24,11 @@ var dtRootCertURL = "https://ca.dynatrace.com/dt-root.cert.pem"
 // openSSLMissingError is the user-facing message returned when openssl is not
 // found on a Linux host where signature verification is required.
 const openSSLMissingError = "openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."
+
+// rootCAFetchTimeout caps the time allowed to download the Dynatrace root CA
+// certificate. Kept short because the file is tiny (~2 KB); a stalled
+// connection should not block the install indefinitely.
+const rootCAFetchTimeout = 30 * time.Second
 
 // VerifyInstallerSignature verifies a Linux installer's CMS signature against
 // the published Dynatrace root CA. It returns nil when skip is true or
@@ -71,7 +77,7 @@ func fetchDynatraceRootCA(caURL string) (string, error) {
 
 	logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)
 
-	resp, err := resty.New().R().SetOutput(certPath).Get(caURL)
+	resp, err := resty.New().SetTimeout(rootCAFetchTimeout).R().SetOutput(certPath).Get(caURL)
 	if err != nil {
 		_ = os.Remove(certPath)
 		return "", fmt.Errorf("downloading Dynatrace root CA: %w", err)

--- a/pkg/installer/oneagent/verify.go
+++ b/pkg/installer/oneagent/verify.go
@@ -45,13 +45,17 @@ func VerifyInstallerSignature(env Environment, installerPath string, skip bool) 
 		return errors.New(openSSLMissingError) //nolint:staticcheck // ST1005: exact wording is required by spec (user-facing remediation hint)
 	}
 
+	display.PrintPending("signature", "fetching root CA...")
 	certPath, err := fetchDynatraceRootCA(dtRootCertURL)
 	if err != nil {
+		display.ClearPending()
 		return err
 	}
 	defer os.Remove(certPath)
 
+	display.PrintPending("signature", "verifying...")
 	code, stderr, err := runOpensslVerify(opensslPath, installerPath, certPath)
+	display.ClearPending()
 	if err != nil {
 		return fmt.Errorf("running openssl: %w", err)
 	}

--- a/pkg/installer/oneagent/verify_test.go
+++ b/pkg/installer/oneagent/verify_test.go
@@ -1,0 +1,233 @@
+package oneagent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// withRootCertURL overrides the package-level CA URL for the duration of the
+// test, restoring it on cleanup.
+func withRootCertURL(t *testing.T, url string) {
+	t.Helper()
+	orig := dtRootCertURL
+	dtRootCertURL = url
+	t.Cleanup(func() { dtRootCertURL = orig })
+}
+
+func TestVerifyInstallerSignature_SkipFlag(t *testing.T) {
+	if err := VerifyInstallerSignature(Environment{OS: "linux"}, "/nonexistent", true); err != nil {
+		t.Errorf("skip=true should return nil, got %v", err)
+	}
+}
+
+func TestVerifyInstallerSignature_NonLinux(t *testing.T) {
+	cases := []string{"darwin", "windows", ""}
+	for _, os := range cases {
+		if err := VerifyInstallerSignature(Environment{OS: os}, "/nonexistent", false); err != nil {
+			t.Errorf("os=%q should return nil, got %v", os, err)
+		}
+	}
+}
+
+func TestVerifyInstallerSignature_MissingOpenSSL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-based openssl shadowing test relies on Unix semantics")
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, "/nonexistent", false)
+	if err == nil {
+		t.Fatal("expected missing-openssl error")
+	}
+	if !strings.Contains(err.Error(), "openssl is required") {
+		t.Errorf("error = %q, want missing-openssl message", err)
+	}
+	if !strings.Contains(err.Error(), "--no-verify-signature") {
+		t.Errorf("error = %q, want --no-verify-signature hint", err)
+	}
+}
+
+func TestVerifyInstallerSignature_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	createStubFile(t, filepath.Join(binDir, "openssl"), "#!/bin/sh\ncat >/dev/null\nexit 0\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PEM"))
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	if err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false); err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+}
+
+func TestVerifyInstallerSignature_FailureWrapsStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	createStubFile(t, filepath.Join(binDir, "openssl"),
+		"#!/bin/sh\ncat >/dev/null\necho 'Verification failure' >&2\nexit 4\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PEM"))
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
+	if err == nil {
+		t.Fatal("expected verification failure")
+	}
+	if !strings.Contains(err.Error(), "Verification failure") {
+		t.Errorf("error = %q, missing openssl stderr", err)
+	}
+	if !strings.Contains(err.Error(), "exit 4") {
+		t.Errorf("error = %q, missing exit code", err)
+	}
+}
+
+func TestVerifyInstallerSignature_CADownloadFailsAborts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	// openssl should never be invoked because CA fetch fails first.
+	createStubFile(t, filepath.Join(binDir, "openssl"),
+		"#!/bin/sh\necho 'should not run' >&2\nexit 99\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
+	if err == nil {
+		t.Fatal("expected CA download failure")
+	}
+	if !strings.Contains(err.Error(), "Dynatrace root CA") {
+		t.Errorf("error = %q, want CA download error", err)
+	}
+}
+
+func TestFetchDynatraceRootCA_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PEM-CONTENT"))
+	}))
+	defer srv.Close()
+
+	path, err := fetchDynatraceRootCA(srv.URL)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer os.Remove(path)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CA file: %v", err)
+	}
+	if string(content) != "PEM-CONTENT" {
+		t.Errorf("content = %q, want PEM-CONTENT", content)
+	}
+}
+
+func TestFetchDynatraceRootCA_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := fetchDynatraceRootCA(srv.URL)
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if !strings.Contains(err.Error(), "Dynatrace root CA") {
+		t.Errorf("error = %q, want CA error message", err)
+	}
+}
+
+func TestRunOpensslVerify_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	opensslPath := filepath.Join(binDir, "openssl")
+	createStubFile(t, opensslPath, "#!/bin/sh\ncat >/dev/null\nexit 0\n", 0o755)
+
+	installer := filepath.Join(t.TempDir(), "installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cert := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(cert, []byte("PEM"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stderr, err := runOpensslVerify(opensslPath, installer, cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0; stderr = %q", code, stderr)
+	}
+}
+
+func TestRunOpensslVerify_ExitError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	opensslPath := filepath.Join(binDir, "openssl")
+	createStubFile(t, opensslPath, "#!/bin/sh\ncat >/dev/null\necho 'bad sig' >&2\nexit 7\n", 0o755)
+
+	installer := filepath.Join(t.TempDir(), "installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cert := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(cert, []byte("PEM"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stderr, err := runOpensslVerify(opensslPath, installer, cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit code = %d, want 7", code)
+	}
+	if !strings.Contains(stderr, "bad sig") {
+		t.Errorf("stderr = %q, want 'bad sig'", stderr)
+	}
+}

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -1,14 +1,10 @@
 package installer
 
 import (
-	"bytes"
-	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -84,7 +80,6 @@ func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 		return err
 	}
 
-	// Task 6 — BuildInstallCommand + ExecuteInstallCommand — not yet implemented.
 	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
 	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
 	return nil
@@ -116,31 +111,12 @@ func detectRuntimeEnvironment() (Environment, error) {
 	}
 }
 
-// readErrorBody reads up to 2 KB from a resty response body, decompressing
-// gzip when indicated by the Content-Encoding header OR by the gzip magic
-// bytes (1f 8b). The magic-byte fallback handles servers that compress the
-// body without setting Content-Encoding. Used on non-200 responses where
-// SetDoNotParseResponse(true) is active.
+// readErrorBody reads up to 2 KB from a resty response body. Used on non-200
+// responses where SetDoNotParseResponse(true) is active. Go's net/http
+// transport handles transparent gzip decompression at the transport level, so
+// no manual decompression is needed here.
 func readErrorBody(resp *resty.Response) string {
-	// Buffer the first 2 bytes to probe for the gzip magic number without
-	// consuming the reader irreversibly.
-	raw := resp.RawBody()
-	peek := make([]byte, 2)
-	n, _ := io.ReadFull(raw, peek)
-	combined := io.MultiReader(bytes.NewReader(peek[:n]), raw)
-
-	needsGzip := strings.EqualFold(resp.Header().Get("Content-Encoding"), "gzip") ||
-		(n == 2 && peek[0] == 0x1f && peek[1] == 0x8b)
-
-	var r io.Reader = combined
-	if needsGzip {
-		gr, err := gzip.NewReader(combined)
-		if err == nil {
-			defer gr.Close()
-			r = gr
-		}
-	}
-	body, _ := io.ReadAll(io.LimitReader(r, 2048))
+	body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
 	return strings.TrimSpace(string(body))
 }
 
@@ -253,109 +229,4 @@ func humanBytes(n int64) string {
 	default:
 		return fmt.Sprintf("%dB", n)
 	}
-}
-
-// dtRootCertURL is the published Dynatrace root CA used to verify the
-// signature of downloaded installers. Overridable in tests.
-var dtRootCertURL = "https://ca.dynatrace.com/dt-root.cert.pem"
-
-// openSSLMissingError is the user-facing message returned when openssl is not
-// found on a Linux host where signature verification is required.
-const openSSLMissingError = "openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."
-
-// VerifyInstallerSignature verifies a Linux installer's CMS signature against
-// the published Dynatrace root CA. It returns nil when skip is true or
-// env.OS != "linux". Missing openssl on Linux is a hard error; verification
-// failure aborts the install with the captured openssl stderr.
-func VerifyInstallerSignature(env Environment, installerPath string, skip bool) error {
-	if skip || env.OS != "linux" {
-		return nil
-	}
-
-	opensslPath, err := exec.LookPath("openssl")
-	logger.Debug("openssl lookup", "path", opensslPath, "found", err == nil)
-	if err != nil {
-		return errors.New(openSSLMissingError) //nolint:staticcheck // ST1005: exact wording is required by spec (user-facing remediation hint)
-	}
-
-	certPath, err := fetchDynatraceRootCA(dtRootCertURL)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(certPath)
-
-	code, stderr, err := runOpensslVerify(opensslPath, installerPath, certPath)
-	if err != nil {
-		return fmt.Errorf("running openssl: %w", err)
-	}
-	if code != 0 {
-		logger.Debug("signature verification failed", "exit_code", code, "stderr", stderr)
-		return fmt.Errorf("installer signature verification failed (openssl exit %d): %s", code, stderr)
-	}
-
-	logger.Verbose("installer signature verified")
-	display.PrintStatusLine("signature", "Installer signature verified", display.ColorOK)
-	return nil
-}
-
-// fetchDynatraceRootCA downloads the published Dynatrace root certificate to a
-// temp file and returns its path. The caller owns the file.
-func fetchDynatraceRootCA(caURL string) (string, error) {
-	tmp, err := os.CreateTemp("", "dt-root-cert-*.pem")
-	if err != nil {
-		return "", fmt.Errorf("creating temp file for root CA: %w", err)
-	}
-	certPath := tmp.Name()
-	_ = tmp.Close()
-
-	logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)
-
-	resp, err := resty.New().R().SetOutput(certPath).Get(caURL)
-	if err != nil {
-		_ = os.Remove(certPath)
-		return "", fmt.Errorf("downloading Dynatrace root CA: %w", err)
-	}
-	if resp.StatusCode() != http.StatusOK {
-		_ = os.Remove(certPath)
-		return "", fmt.Errorf("downloading Dynatrace root CA: status %d", resp.StatusCode())
-	}
-	return certPath, nil
-}
-
-// runOpensslVerify runs the documented Dynatrace CMS verification pipeline:
-//
-//	( echo "Content-Type: multipart/signed; ... boundary=--SIGNED-INSTALLER" ;
-//	  echo ; echo "----SIGNED-INSTALLER" ; cat <installer> )
-//	| openssl cms -verify -CAfile <certPath>
-//
-// It returns the openssl exit code and captured stderr. The error return is
-// non-nil only when the subprocess could not be started.
-func runOpensslVerify(opensslPath, installerPath, certPath string) (int, string, error) {
-	installer, err := os.Open(installerPath)
-	if err != nil {
-		return 0, "", fmt.Errorf("opening installer: %w", err)
-	}
-	defer installer.Close()
-
-	header := strings.NewReader(
-		"Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\"; " +
-			"micalg=\"sha-256\"; boundary=\"--SIGNED-INSTALLER\"\n\n" +
-			"----SIGNED-INSTALLER\n",
-	)
-
-	cmd := exec.Command(opensslPath, "cms", "-verify", "-CAfile", certPath)
-	cmd.Stdin = io.MultiReader(header, installer)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	cmd.Stdout = io.Discard
-
-	err = cmd.Run()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return exitErr.ExitCode(), strings.TrimSpace(stderr.String()), nil
-		}
-		return 0, strings.TrimSpace(stderr.String()), err
-	}
-	return 0, "", nil
 }

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -141,7 +141,14 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 	path := fmt.Sprintf("/api/v1/deployment/installer/agent/%s/default/latest?arch=%s", osSeg, env.Arch)
 	downloadURL := strings.TrimRight(c.BaseURL(), "/") + path
 
-	logger.Debug("downloading installer", "url", downloadURL, "os", env.OS, "arch", env.Arch)
+	// Log auth scheme (Bearer vs Api-Token) without exposing the token value.
+	authScheme := strings.SplitN(c.HTTP().Header.Get("Authorization"), " ", 2)[0]
+	logger.Debug("downloading installer",
+		"url", downloadURL,
+		"os", env.OS,
+		"arch", env.Arch,
+		"auth_scheme", authScheme,
+	)
 
 	resp, err := c.HTTP().R().SetDoNotParseResponse(true).Get(path)
 	if err != nil {
@@ -150,7 +157,22 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 	defer resp.RawBody().Close()
 
 	if resp.StatusCode() != http.StatusOK {
-		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
+		body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
+		logger.Debug("installer download failed",
+			"status", resp.StatusCode(),
+			"auth_scheme", authScheme,
+			"url", downloadURL,
+			"response_body", strings.TrimSpace(string(body)),
+		)
+		if resp.StatusCode() == http.StatusForbidden || resp.StatusCode() == http.StatusUnauthorized {
+			return "", fmt.Errorf( //nolint:staticcheck // ST1005: user-facing remediation hint with sentence structure
+				"installer download failed (%d) — if using a platform token, ensure it has the InstallerDownload scope; "+
+					"or pass a dt0c01.* access token with --access-token or DT_ACCESS_TOKEN.\n"+
+					"Run with --debug for the API error detail.",
+				resp.StatusCode(),
+			)
+		}
+		return "", fmt.Errorf("installer download failed with status %d: %s", resp.StatusCode(), strings.TrimSpace(string(body)))
 	}
 
 	tmpFile, err := os.CreateTemp("", "dynatrace-oneagent-*"+installerExtension(env.OS))

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -117,12 +117,24 @@ func detectRuntimeEnvironment() (Environment, error) {
 }
 
 // readErrorBody reads up to 2 KB from a resty response body, decompressing
-// gzip if the server sent Content-Encoding: gzip. Used to surface API error
-// detail on non-200 responses where SetDoNotParseResponse(true) is active.
+// gzip when indicated by the Content-Encoding header OR by the gzip magic
+// bytes (1f 8b). The magic-byte fallback handles servers that compress the
+// body without setting Content-Encoding. Used on non-200 responses where
+// SetDoNotParseResponse(true) is active.
 func readErrorBody(resp *resty.Response) string {
-	var r io.Reader = resp.RawBody()
-	if strings.EqualFold(resp.Header().Get("Content-Encoding"), "gzip") {
-		gr, err := gzip.NewReader(r)
+	// Buffer the first 2 bytes to probe for the gzip magic number without
+	// consuming the reader irreversibly.
+	raw := resp.RawBody()
+	peek := make([]byte, 2)
+	n, _ := io.ReadFull(raw, peek)
+	combined := io.MultiReader(bytes.NewReader(peek[:n]), raw)
+
+	needsGzip := strings.EqualFold(resp.Header().Get("Content-Encoding"), "gzip") ||
+		(n == 2 && peek[0] == 0x1f && peek[1] == 0x8b)
+
+	var r io.Reader = combined
+	if needsGzip {
+		gr, err := gzip.NewReader(combined)
 		if err == nil {
 			defer gr.Close()
 			r = gr

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -58,8 +58,61 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 }
 
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
-	display.PrintStatusLine("oneagent", fmt.Sprintf("under development (monitoring-mode=%s) — use --oneagent-poc=false or set DTWIZ_ONEAGENT_POC=false to use the stable installer", opts.MonitoringMode), display.ColorWarning)
+	display.PrintStatusLine("oneagent", fmt.Sprintf("PoC flow (monitoring-mode=%s)", opts.MonitoringMode), display.ColorWarning)
+
+	env, err := detectRuntimeEnvironment()
+	if err != nil {
+		return err
+	}
+	logger.Debug("detected environment", "os", env.OS, "arch", env.Arch)
+
+	cfg := ResolveAgentConfig(opts)
+	logger.Debug("install options",
+		"dry_run", opts.DryRun,
+		"no_verify_signature", opts.NoVerifySignature,
+		"monitoring_mode", cfg.MonitoringMode,
+	)
+
+	installerPath, err := DownloadInstaller(c.Classic, env)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(installerPath)
+
+	if err := VerifyInstallerSignature(env, installerPath, opts.NoVerifySignature); err != nil {
+		return err
+	}
+
+	// Task 6 — BuildInstallCommand + ExecuteInstallCommand — not yet implemented.
+	display.PrintStatusLine("oneagent", "download and verification complete; install execution not yet implemented (Task 6)", display.ColorWarning)
+	logger.Debug("install execution not yet implemented", "installer_path", installerPath)
 	return nil
+}
+
+// detectRuntimeEnvironment returns an Environment based on the current host
+// OS and architecture. Used as a stand-in until DetectEnvironment (Task 2) is
+// implemented.
+func detectRuntimeEnvironment() (Environment, error) {
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "x86"
+	case "arm64":
+		arch = "arm"
+	default:
+		return Environment{}, fmt.Errorf("unsupported architecture for OneAgent: %s", runtime.GOARCH)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return Environment{OS: "linux", Arch: arch}, nil
+	case "windows":
+		return Environment{OS: "windows", Arch: arch}, nil
+	case "darwin":
+		return Environment{}, fmt.Errorf("OneAgent direct install is not supported on macOS; use Docker or Linux")
+	default:
+		return Environment{}, fmt.Errorf("unsupported OS for OneAgent: %s", runtime.GOOS)
+	}
 }
 
 // installerOSSegment maps Environment.OS to the URL path segment used by the

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -115,6 +116,22 @@ func detectRuntimeEnvironment() (Environment, error) {
 	}
 }
 
+// readErrorBody reads up to 2 KB from a resty response body, decompressing
+// gzip if the server sent Content-Encoding: gzip. Used to surface API error
+// detail on non-200 responses where SetDoNotParseResponse(true) is active.
+func readErrorBody(resp *resty.Response) string {
+	var r io.Reader = resp.RawBody()
+	if strings.EqualFold(resp.Header().Get("Content-Encoding"), "gzip") {
+		gr, err := gzip.NewReader(r)
+		if err == nil {
+			defer gr.Close()
+			r = gr
+		}
+	}
+	body, _ := io.ReadAll(io.LimitReader(r, 2048))
+	return strings.TrimSpace(string(body))
+}
+
 // installerOSSegment maps Environment.OS to the URL path segment used by the
 // Dynatrace installer download API. Linux maps to "unix"; Windows maps to
 // "windows".
@@ -157,12 +174,12 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 	defer resp.RawBody().Close()
 
 	if resp.StatusCode() != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.RawBody(), 2048))
+		body := readErrorBody(resp)
 		logger.Debug("installer download failed",
 			"status", resp.StatusCode(),
 			"auth_scheme", authScheme,
 			"url", downloadURL,
-			"response_body", strings.TrimSpace(string(body)),
+			"response_body", body,
 		)
 		if resp.StatusCode() == http.StatusForbidden || resp.StatusCode() == http.StatusUnauthorized {
 			return "", fmt.Errorf( //nolint:staticcheck // ST1005: user-facing remediation hint with sentence structure
@@ -172,7 +189,7 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 				resp.StatusCode(),
 			)
 		}
-		return "", fmt.Errorf("installer download failed with status %d: %s", resp.StatusCode(), strings.TrimSpace(string(body)))
+		return "", fmt.Errorf("installer download failed with status %d: %s", resp.StatusCode(), body)
 	}
 
 	tmpFile, err := os.CreateTemp("", "dynatrace-oneagent-*"+installerExtension(env.OS))

--- a/pkg/installer/oneagent_v2.go
+++ b/pkg/installer/oneagent_v2.go
@@ -1,7 +1,18 @@
 package installer
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
@@ -20,6 +31,14 @@ type InstallOptions struct {
 
 type AgentConfig struct {
 	MonitoringMode string
+}
+
+// Environment identifies the target OS and CPU architecture used to select the
+// correct OneAgent installer. OS values: "linux", "windows". Arch values:
+// "x86", "arm".
+type Environment struct {
+	OS   string
+	Arch string
 }
 
 func DefaultAgentConfig() AgentConfig {
@@ -41,4 +60,198 @@ func ResolveAgentConfig(opts InstallOptions) AgentConfig {
 func InstallOneAgentV2(c *client.Client, opts InstallOptions) error {
 	display.PrintStatusLine("oneagent", fmt.Sprintf("under development (monitoring-mode=%s) — use --oneagent-poc=false or set DTWIZ_ONEAGENT_POC=false to use the stable installer", opts.MonitoringMode), display.ColorWarning)
 	return nil
+}
+
+// installerOSSegment maps Environment.OS to the URL path segment used by the
+// Dynatrace installer download API. Linux maps to "unix"; Windows maps to
+// "windows".
+func installerOSSegment(os string) (string, error) {
+	switch os {
+	case "linux":
+		return "unix", nil
+	case "windows":
+		return "windows", nil
+	default:
+		return "", fmt.Errorf("unsupported installer OS: %q", os)
+	}
+}
+
+// DownloadInstaller streams the OneAgent installer to a temporary file using
+// the credentials already embedded in the ClassicClient (set upstream by
+// validateCredentials). On Unix the file permissions are tightened to 0o700.
+// The caller owns the returned path and is responsible for removing it.
+func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error) {
+	osSeg, err := installerOSSegment(env.OS)
+	if err != nil {
+		return "", err
+	}
+	path := fmt.Sprintf("/api/v1/deployment/installer/agent/%s/default/latest?arch=%s", osSeg, env.Arch)
+	downloadURL := strings.TrimRight(c.BaseURL(), "/") + path
+
+	logger.Debug("downloading installer", "url", downloadURL, "os", env.OS, "arch", env.Arch)
+
+	resp, err := c.HTTP().R().SetDoNotParseResponse(true).Get(path)
+	if err != nil {
+		return "", fmt.Errorf("downloading OneAgent installer: %w", err)
+	}
+	defer resp.RawBody().Close()
+
+	if resp.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("installer download failed with status %d", resp.StatusCode())
+	}
+
+	tmpFile, err := os.CreateTemp("", "dynatrace-oneagent-*"+installerExtension(env.OS))
+	if err != nil {
+		return "", fmt.Errorf("creating temp file for installer: %w", err)
+	}
+	defer tmpFile.Close()
+
+	n, err := io.Copy(tmpFile, resp.RawBody())
+	if err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("writing installer to disk: %w", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpFile.Name(), 0o700); err != nil {
+			_ = os.Remove(tmpFile.Name())
+			return "", fmt.Errorf("setting installer permissions: %w", err)
+		}
+	}
+
+	logger.Verbose("installer downloaded", "path", tmpFile.Name(), "size_bytes", n)
+	display.PrintStatusLine("installer",
+		fmt.Sprintf("%s (%s)", filepath.Base(tmpFile.Name()), humanBytes(n)),
+		display.ColorOK)
+	return tmpFile.Name(), nil
+}
+
+func installerExtension(os string) string {
+	if os == "windows" {
+		return ".exe"
+	}
+	return ".sh"
+}
+
+func humanBytes(n int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case n >= gb:
+		return fmt.Sprintf("%dGB", n/gb)
+	case n >= mb:
+		return fmt.Sprintf("%dMB", n/mb)
+	case n >= kb:
+		return fmt.Sprintf("%dKB", n/kb)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+// dtRootCertURL is the published Dynatrace root CA used to verify the
+// signature of downloaded installers. Overridable in tests.
+var dtRootCertURL = "https://ca.dynatrace.com/dt-root.cert.pem"
+
+// openSSLMissingError is the user-facing message returned when openssl is not
+// found on a Linux host where signature verification is required.
+const openSSLMissingError = "openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."
+
+// VerifyInstallerSignature verifies a Linux installer's CMS signature against
+// the published Dynatrace root CA. It returns nil when skip is true or
+// env.OS != "linux". Missing openssl on Linux is a hard error; verification
+// failure aborts the install with the captured openssl stderr.
+func VerifyInstallerSignature(env Environment, installerPath string, skip bool) error {
+	if skip || env.OS != "linux" {
+		return nil
+	}
+
+	opensslPath, err := exec.LookPath("openssl")
+	logger.Debug("openssl lookup", "path", opensslPath, "found", err == nil)
+	if err != nil {
+		return errors.New(openSSLMissingError) //nolint:staticcheck // ST1005: exact wording is required by spec (user-facing remediation hint)
+	}
+
+	certPath, err := fetchDynatraceRootCA(dtRootCertURL)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(certPath)
+
+	code, stderr, err := runOpensslVerify(opensslPath, installerPath, certPath)
+	if err != nil {
+		return fmt.Errorf("running openssl: %w", err)
+	}
+	if code != 0 {
+		logger.Debug("signature verification failed", "exit_code", code, "stderr", stderr)
+		return fmt.Errorf("installer signature verification failed (openssl exit %d): %s", code, stderr)
+	}
+
+	logger.Verbose("installer signature verified")
+	display.PrintStatusLine("signature", "Installer signature verified", display.ColorOK)
+	return nil
+}
+
+// fetchDynatraceRootCA downloads the published Dynatrace root certificate to a
+// temp file and returns its path. The caller owns the file.
+func fetchDynatraceRootCA(caURL string) (string, error) {
+	tmp, err := os.CreateTemp("", "dt-root-cert-*.pem")
+	if err != nil {
+		return "", fmt.Errorf("creating temp file for root CA: %w", err)
+	}
+	certPath := tmp.Name()
+	_ = tmp.Close()
+
+	logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)
+
+	resp, err := resty.New().R().SetOutput(certPath).Get(caURL)
+	if err != nil {
+		_ = os.Remove(certPath)
+		return "", fmt.Errorf("downloading Dynatrace root CA: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		_ = os.Remove(certPath)
+		return "", fmt.Errorf("downloading Dynatrace root CA: status %d", resp.StatusCode())
+	}
+	return certPath, nil
+}
+
+// runOpensslVerify runs the documented Dynatrace CMS verification pipeline:
+//
+//	( echo "Content-Type: multipart/signed; ... boundary=--SIGNED-INSTALLER" ;
+//	  echo ; echo "----SIGNED-INSTALLER" ; cat <installer> )
+//	| openssl cms -verify -CAfile <certPath>
+//
+// It returns the openssl exit code and captured stderr. The error return is
+// non-nil only when the subprocess could not be started.
+func runOpensslVerify(opensslPath, installerPath, certPath string) (int, string, error) {
+	installer, err := os.Open(installerPath)
+	if err != nil {
+		return 0, "", fmt.Errorf("opening installer: %w", err)
+	}
+	defer installer.Close()
+
+	header := strings.NewReader(
+		"Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\"; " +
+			"micalg=\"sha-256\"; boundary=\"--SIGNED-INSTALLER\"\n\n" +
+			"----SIGNED-INSTALLER\n",
+	)
+
+	cmd := exec.Command(opensslPath, "cms", "-verify", "-CAfile", certPath)
+	cmd.Stdin = io.MultiReader(header, installer)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+
+	err = cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), strings.TrimSpace(stderr.String()), nil
+		}
+		return 0, strings.TrimSpace(stderr.String()), err
+	}
+	return 0, "", nil
 }

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -5,6 +5,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -80,5 +83,298 @@ func TestInstallOneAgentV2_ExitsCleanly(t *testing.T) {
 	c := newMockClient(t, srv.URL)
 	if err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"}); err != nil {
 		t.Errorf("expected clean exit, got error: %v", err)
+	}
+}
+
+// --- Task 5 Part A: DownloadInstaller ---
+
+func TestDownloadInstaller_LinuxX86_StreamsAndStores(t *testing.T) {
+	content := []byte("fake-installer-binary-content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/deployment/installer/agent/unix/default/latest" {
+			t.Errorf("path = %q, want unix segment", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("arch"); got != "x86" {
+			t.Errorf("arch = %q, want x86", got)
+		}
+		if auth := r.Header.Get("Authorization"); auth == "" {
+			t.Error("expected Authorization header to be present")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	c := newTestClassicClient(t, srv.URL)
+	path, err := DownloadInstaller(c, Environment{OS: "linux", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read downloaded: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+	if !strings.HasSuffix(path, ".sh") {
+		t.Errorf("filename %q should end in .sh on Unix env", path)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Errorf("perms = %o, want 0700", info.Mode().Perm())
+		}
+	}
+}
+
+func TestDownloadInstaller_LinuxArm_URL(t *testing.T) {
+	var gotArch string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotArch = r.URL.Query().Get("arch")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "arm"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+	if gotArch != "arm" {
+		t.Errorf("arch query = %q, want arm", gotArch)
+	}
+}
+
+func TestDownloadInstaller_Windows_URL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "windows", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+	if gotPath != "/api/v1/deployment/installer/agent/windows/default/latest" {
+		t.Errorf("path = %q, want windows segment", gotPath)
+	}
+	if !strings.HasSuffix(path, ".exe") {
+		t.Errorf("filename %q should end in .exe for Windows env", path)
+	}
+}
+
+func TestDownloadInstaller_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error %q does not mention 401", err)
+	}
+}
+
+func TestDownloadInstaller_UnsupportedOS(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "freebsd", Arch: "x86"})
+	if err == nil {
+		t.Fatal("expected error for unsupported OS")
+	}
+	if !strings.Contains(err.Error(), "unsupported installer OS") {
+		t.Errorf("error = %q, want unsupported OS message", err)
+	}
+}
+
+func TestDownloadInstaller_DebugLogLineRedactsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	path, err := DownloadInstaller(newTestClassicClient(t, srv.URL), Environment{OS: "linux", Arch: "x86"})
+	if err != nil {
+		t.Fatalf("DownloadInstaller: %v", err)
+	}
+	defer os.Remove(path)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "downloading installer") {
+		t.Errorf("logs missing 'downloading installer' line:\n%s", logs)
+	}
+	if strings.Contains(logs, "dt0s16.test") {
+		t.Errorf("logs contain raw token:\n%s", logs)
+	}
+}
+
+// --- Task 5 Part B: VerifyInstallerSignature ---
+
+func TestVerifyInstallerSignature_SkipFlag(t *testing.T) {
+	if err := VerifyInstallerSignature(Environment{OS: "linux"}, "/nonexistent", true); err != nil {
+		t.Errorf("skip=true should return nil, got %v", err)
+	}
+}
+
+func TestVerifyInstallerSignature_NonLinux(t *testing.T) {
+	cases := []string{"darwin", "windows", ""}
+	for _, os := range cases {
+		if err := VerifyInstallerSignature(Environment{OS: os}, "/nonexistent", false); err != nil {
+			t.Errorf("os=%q should return nil, got %v", os, err)
+		}
+	}
+}
+
+func TestVerifyInstallerSignature_MissingOpenSSL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-based openssl shadowing test relies on Unix semantics")
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, "/nonexistent", false)
+	if err == nil {
+		t.Fatal("expected missing-openssl error")
+	}
+	if !strings.Contains(err.Error(), "openssl is required") {
+		t.Errorf("error = %q, want missing-openssl message", err)
+	}
+	if !strings.Contains(err.Error(), "--no-verify-signature") {
+		t.Errorf("error = %q, want --no-verify-signature hint", err)
+	}
+}
+
+func TestVerifyInstallerSignature_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	createStubFile(t, filepath.Join(binDir, "openssl"), "#!/bin/sh\ncat >/dev/null\nexit 0\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PEM"))
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	if err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false); err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+}
+
+func TestVerifyInstallerSignature_FailureWrapsStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	createStubFile(t, filepath.Join(binDir, "openssl"),
+		"#!/bin/sh\ncat >/dev/null\necho 'Verification failure' >&2\nexit 4\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PEM"))
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
+	if err == nil {
+		t.Fatal("expected verification failure")
+	}
+	if !strings.Contains(err.Error(), "Verification failure") {
+		t.Errorf("error = %q, missing openssl stderr", err)
+	}
+	if !strings.Contains(err.Error(), "exit 4") {
+		t.Errorf("error = %q, missing exit code", err)
+	}
+}
+
+func TestVerifyInstallerSignature_CADownloadFailsAborts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh fake openssl")
+	}
+	binDir := t.TempDir()
+	// openssl should never be invoked because CA fetch fails first.
+	createStubFile(t, filepath.Join(binDir, "openssl"),
+		"#!/bin/sh\necho 'should not run' >&2\nexit 99\n", 0o755)
+	t.Setenv("PATH", binDir)
+
+	caSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer caSrv.Close()
+	withRootCertURL(t, caSrv.URL)
+
+	installer := filepath.Join(t.TempDir(), "fake-installer.sh")
+	if err := os.WriteFile(installer, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyInstallerSignature(Environment{OS: "linux", Arch: "x86"}, installer, false)
+	if err == nil {
+		t.Fatal("expected CA download failure")
+	}
+	if !strings.Contains(err.Error(), "Dynatrace root CA") {
+		t.Errorf("error = %q, want CA download error", err)
+	}
+}
+
+// withRootCertURL overrides the package-level CA URL for the duration of the
+// test, restoring it on cleanup.
+func withRootCertURL(t *testing.T, url string) {
+	t.Helper()
+	orig := dtRootCertURL
+	dtRootCertURL = url
+	t.Cleanup(func() { dtRootCertURL = orig })
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1KB"},
+		{2 * 1024 * 1024, "2MB"},
+		{3 * 1024 * 1024 * 1024, "3GB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }

--- a/pkg/installer/oneagent_v2_test.go
+++ b/pkg/installer/oneagent_v2_test.go
@@ -76,13 +76,20 @@ func TestResolveAgentConfig_DebugLog(t *testing.T) {
 	}
 }
 
-func TestInstallOneAgentV2_ExitsCleanly(t *testing.T) {
+func TestInstallOneAgentV2_UnsupportedPlatformReturnsError(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific error path test")
+	}
 	srv := newMockTenantServer(t, "/", http.StatusOK, `{}`)
 	defer srv.Close()
 
 	c := newMockClient(t, srv.URL)
-	if err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"}); err != nil {
-		t.Errorf("expected clean exit, got error: %v", err)
+	err := InstallOneAgentV2(c, InstallOptions{MonitoringMode: "fullstack"})
+	if err == nil {
+		t.Fatal("expected error on macOS, got nil")
+	}
+	if !strings.Contains(err.Error(), "macOS") {
+		t.Errorf("error = %q, want macOS message", err)
 	}
 }
 

--- a/pkg/installer/oneagent_v2_verify.go
+++ b/pkg/installer/oneagent_v2_verify.go
@@ -1,0 +1,122 @@
+package installer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
+)
+
+// dtRootCertURL is the published Dynatrace root CA used to verify the
+// signature of downloaded installers. Overridable in tests.
+var dtRootCertURL = "https://ca.dynatrace.com/dt-root.cert.pem"
+
+// openSSLMissingError is the user-facing message returned when openssl is not
+// found on a Linux host where signature verification is required.
+const openSSLMissingError = "openssl is required to verify the installer signature. Install openssl or pass --no-verify-signature to skip."
+
+// VerifyInstallerSignature verifies a Linux installer's CMS signature against
+// the published Dynatrace root CA. It returns nil when skip is true or
+// env.OS != "linux". Missing openssl on Linux is a hard error; verification
+// failure aborts the install with the captured openssl stderr.
+func VerifyInstallerSignature(env Environment, installerPath string, skip bool) error {
+	if skip || env.OS != "linux" {
+		return nil
+	}
+
+	opensslPath, err := exec.LookPath("openssl")
+	logger.Debug("openssl lookup", "path", opensslPath, "found", err == nil)
+	if err != nil {
+		return errors.New(openSSLMissingError) //nolint:staticcheck // ST1005: exact wording is required by spec (user-facing remediation hint)
+	}
+
+	certPath, err := fetchDynatraceRootCA(dtRootCertURL)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(certPath)
+
+	code, stderr, err := runOpensslVerify(opensslPath, installerPath, certPath)
+	if err != nil {
+		return fmt.Errorf("running openssl: %w", err)
+	}
+	if code != 0 {
+		logger.Debug("signature verification failed", "exit_code", code, "stderr", stderr)
+		return fmt.Errorf("installer signature verification failed (openssl exit %d): %s", code, stderr)
+	}
+
+	logger.Verbose("installer signature verified")
+	display.PrintStatusLine("signature", "Installer signature verified", display.ColorOK)
+	return nil
+}
+
+// fetchDynatraceRootCA downloads the published Dynatrace root certificate to a
+// temp file and returns its path. The caller owns the file.
+func fetchDynatraceRootCA(caURL string) (string, error) {
+	tmp, err := os.CreateTemp("", "dt-root-cert-*.pem")
+	if err != nil {
+		return "", fmt.Errorf("creating temp file for root CA: %w", err)
+	}
+	certPath := tmp.Name()
+	_ = tmp.Close()
+
+	logger.Debug("fetching dynatrace root ca", "url", caURL, "path", certPath)
+
+	resp, err := resty.New().R().SetOutput(certPath).Get(caURL)
+	if err != nil {
+		_ = os.Remove(certPath)
+		return "", fmt.Errorf("downloading Dynatrace root CA: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		_ = os.Remove(certPath)
+		return "", fmt.Errorf("downloading Dynatrace root CA: status %d", resp.StatusCode())
+	}
+	return certPath, nil
+}
+
+// runOpensslVerify runs the documented Dynatrace CMS verification pipeline:
+//
+//	( echo "Content-Type: multipart/signed; ... boundary=--SIGNED-INSTALLER" ;
+//	  echo ; echo "----SIGNED-INSTALLER" ; cat <installer> )
+//	| openssl cms -verify -CAfile <certPath>
+//
+// It returns the openssl exit code and captured stderr. The error return is
+// non-nil only when the subprocess could not be started.
+func runOpensslVerify(opensslPath, installerPath, certPath string) (int, string, error) {
+	installer, err := os.Open(installerPath)
+	if err != nil {
+		return 0, "", fmt.Errorf("opening installer: %w", err)
+	}
+	defer installer.Close()
+
+	header := strings.NewReader(
+		"Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\"; " +
+			"micalg=\"sha-256\"; boundary=\"--SIGNED-INSTALLER\"\n\n" +
+			"----SIGNED-INSTALLER\n",
+	)
+
+	cmd := exec.Command(opensslPath, "cms", "-verify", "-CAfile", certPath)
+	cmd.Stdin = io.MultiReader(header, installer)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+
+	err = cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), strings.TrimSpace(stderr.String()), nil
+		}
+		return 0, strings.TrimSpace(stderr.String()), err
+	}
+	return 0, "", nil
+}


### PR DESCRIPTION
## Description

- [x] New feature

Implements the initial OneAgent installer flow behind the existing `OneAgentPoC` feature flag.

The previous stub in `pkg/installer/oneagent_v2.go` is replaced by a proper `pkg/installer/oneagent/` package with three focused files:

- **`download.go`** — downloads the OneAgent installer from the Dynatrace API (`/api/v1/deployment/installer/agent/...`) to a temp file, sets executable permissions on Unix, and surfaces actionable error messages for auth failures (missing `InstallerDownload` scope).
- **`verify.go`** — verifies the downloaded installer's CMS signature against the published Dynatrace root CA using `openssl`. Skipped on Windows or when `--no-verify-signature` is passed.
- **`oneagent.go`** — orchestrates the above: detects runtime OS/arch, resolves agent config, downloads, verifies, and (stub for now) executes the installer.

Also fixes a bug in `cmd/install.go` where `installCmd.PersistentPreRun` was overriding the root command's hook without reproducing logger and feature-flag initialization.

## How to test
1. connect to the linux machine: https://secretserver.dynatrace.org/app/#/secrets/view/folder/8949
2. download this PR snapshot
3. Enable the feature flag: `export DTWIZ_ONEAGENT_POC=true`
4. define a DT_PLATFORM_TOKEN, but make sure it has proper scopes (`fleet-management:oneagents:download`), but assign all scopes to be safe
5. define `DT_ENVIRONMENT` and keep `DT_ACCESS_TOKEN` empty/unset
6. Run `dtwiz install oneagent` with valid credentials — installer should download and signature verification should pass.
7. Pass `--no-verify-signature` to skip the openssl step.

## Which other features are affected?
1. The `dtwiz install oneagent` command — only when the `OneAgentPoC` flag is enabled.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
