### PR TITLE
chore(k8s-dynakube): initialize openspec for dynakube yaml updates

### DIFF
--- a/openspec/changes/k8s-distro-aware-installer/.openspec.yaml
+++ b/openspec/changes/k8s-distro-aware-installer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/k8s-distro-aware-installer/design.md
+++ b/openspec/changes/k8s-distro-aware-installer/design.md
@@ -1,0 +1,60 @@
+# Design
+
+## Context
+
+`InstallKubernetes()` in `pkg/installer/kubernetes.go` renders a single `dynakube.tmpl` and applies it unconditionally. The analyzer already detects GKE, EKS, AKS, and OpenShift via `DetectK8sDistribution()`, but the detected value is never passed to the installer. Five distributions (GKE Autopilot, EKS Bottlerocket, IKS, RKE2, TKGI) are not detected at all. The result: KSPM always enabled regardless of platform, no annotations applied, no kubelet path overrides — silent failures on IKS and TKGI, pod admission rejections on OpenShift, CSI write errors on Bottlerocket.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Wire detected distribution from analyzer into the installer
+- Extend detection to cover all 10 distributions in `k8s-yamls/`
+- Conditionalize the DynaKube manifest on distribution: KSPM block, privileged/readonly annotations, kubeletPath override
+- All changes covered by unit + snapshot tests
+
+**Non-Goals:**
+
+- Changing the OneAgent mode (all distributions remain `applicationMonitoring`)
+- Cloud-cluster integration tests (unit + fake-kubectl coverage only)
+- Modifying the Helm install/upgrade logic
+- Structural DynaKube template refactor beyond adding conditionals
+
+## Decisions
+
+### 1. Pass `distro string` into `InstallKubernetes()` rather than re-detecting inside it
+
+The analyzer already runs before `installKubernetesCmd` executes. Re-detecting inside the installer would duplicate kubectl calls and add latency. The command layer fetches `SystemInfo`, reads `info.Kubernetes.Distribution`, and passes it down. If analyzer hasn't run (dry-run or future non-interactive path), the empty string falls through to the `"kubernetes"` default case in `distroTemplateData()`.
+
+Alternative considered: detect inside `InstallKubernetes()`. Rejected — violates single-responsibility, adds ~3 kubectl calls to install path already covered by analyze.
+
+### 2. New fields on `dynakubeTemplateData` over per-distro template files
+
+10 separate template files would be harder to keep in sync and would duplicate ~90% of content. Instead, 4 boolean/string fields drive `{{if}}` blocks in a single template. The diff between distros is small (KSPM block, one annotation, one path field) — a single template with conditionals is the right granularity.
+
+Alternative considered: per-distro YAML files embedded as separate `//go:embed` assets. Rejected — maintenance burden, no type safety on fields, harder to test rendering.
+
+### 3. Sub-variant detection requires live kubectl probes beyond the existing 4-string signature
+
+`DetectK8sDistribution(context, cluster, serverURL, serverVersion string)` is a pure function — fast, testable, no I/O. GKE Autopilot and EKS Bottlerocket cannot be distinguished from their parents using only these four strings. Two new probes are needed:
+
+- Autopilot: `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` — check for `autopilot.gke.io`
+- Bottlerocket: `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` — check for "Bottlerocket"
+
+These probes run only after the parent distro is confirmed (GKE or EKS), keeping the happy path fast. The pure `DetectK8sDistribution()` function remains unchanged for unit-testability; a new `ProbeK8sSubVariant(distro string) string` function wraps the kubectl calls.
+
+### 4. Detection order: sub-variants before parents
+
+`ProbeK8sSubVariant` is called after `DetectK8sDistribution` returns the parent distro. This keeps the existing pure function contract intact and avoids adding kubectl calls to every detection path.
+
+## Risks / Trade-offs
+
+`ProbeK8sSubVariant` kubectl calls add latency on GKE and EKS paths (~1–2s per probe with 5s timeout) → mitigated by running probes only when parent matches, with short timeouts and graceful fallback to parent distro on error.
+
+TKGI detection via `pks-system` namespace may produce false positives on clusters that previously ran TKGI but were migrated → acceptable edge case; user can override with `--platform` flag (future).
+
+`dynakube.tmpl` conditional blocks increase template complexity → mitigated by table-driven manifest assertion tests per distro.
+
+## Open Questions
+
+None blocking implementation.

--- a/openspec/changes/k8s-distro-aware-installer/design.md
+++ b/openspec/changes/k8s-distro-aware-installer/design.md
@@ -43,7 +43,7 @@ Alternative considered: per-distro YAML files embedded as separate `//go:embed` 
 
 These probes run only after the parent distro is confirmed (GKE or EKS), keeping the happy path fast. The pure `DetectK8sDistribution()` function remains unchanged for unit-testability; a new `ProbeK8sSubVariant(distro string) string` function wraps the kubectl calls.
 
-### 4. Detection order: sub-variants before parents
+### 4. Detection order: resolve sub-variants after parent match
 
 `ProbeK8sSubVariant` is called after `DetectK8sDistribution` returns the parent distro. This keeps the existing pure function contract intact and avoids adding kubectl calls to every detection path.
 

--- a/openspec/changes/k8s-distro-aware-installer/design.md
+++ b/openspec/changes/k8s-distro-aware-installer/design.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-`InstallKubernetes()` in `pkg/installer/kubernetes.go` renders a single `dynakube.tmpl` and applies it unconditionally. The analyzer already detects GKE, EKS, AKS, and OpenShift via `DetectK8sDistribution()`, but the detected value is never passed to the installer. Five distributions (GKE Autopilot, EKS Bottlerocket, IKS, RKE2, TKGI) are not detected at all. The result: KSPM always enabled regardless of platform, no annotations applied, no kubelet path overrides — silent failures on IKS and TKGI, pod admission rejections on OpenShift, CSI write errors on Bottlerocket.
+`InstallKubernetes()` in `pkg/installer/kubernetes.go` renders a single `dynakube.tmpl` and applies it unconditionally. The analyzer already detects GKE, EKS, AKS, and OpenShift via `DetectK8sDistribution()`, but the detected value is never passed to the installer. Five distributions (GKE Autopilot, EKS Bottlerocket, IKS, RKE, TKGI) are not detected at all. The result: KSPM always enabled regardless of platform, no annotations applied, no kubelet path overrides — silent failures on IKS and TKGI, pod admission rejections on OpenShift, CSI write errors on Bottlerocket.
 
 ## Goals / Non-Goals
 

--- a/openspec/changes/k8s-distro-aware-installer/proposal.md
+++ b/openspec/changes/k8s-distro-aware-installer/proposal.md
@@ -2,12 +2,12 @@
 
 ## Why
 
-`dtwiz install kubernetes` applies a single generic DynaKube manifest regardless of which Kubernetes distribution is running. This causes silent failures on IKS and TKGI (wrong kubelet path), rejected pods on OpenShift (missing SCC annotation), and broken CSI injection on EKS Bottlerocket (immutable rootfs requires read-only volume mode). The installer must detect the distribution and generate a manifest tailored to its constraints.
+`dtwiz install kubernetes` applies a single generic DynaKube manifest regardless of which Kubernetes distribution is running. This causes silent failures on IKS and TKGI (wrong kubelet path), rejected pods on OpenShift (missing privileged annotation needed for SCC), and broken CSI injection on EKS Bottlerocket (immutable rootfs requires read-only volume mode). The installer must detect the distribution and generate a manifest tailored to its constraints.
 
 ## What Changes
 
 - `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE2, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace existence)
-- Detection order enforced: sub-variants checked before their parent (GKE Autopilot before GKE, EKS Bottlerocket before EKS)
+- Detection order enforced: parent distro confirmed first, sub-variant probed only when parent matches (GKE confirmed → Autopilot probe; EKS confirmed → Bottlerocket probe)
 - `InstallKubernetes()` accepts a `distro` parameter; `installKubernetesCmd` passes the detected distribution
 - `dynakubeTemplateData` gains four new fields: `EnableKSPM`, `PrivilegedAnnotation`, `ReadOnlyVolume`, `KubeletPath`
 - `dynakube.tmpl` gains conditional blocks driven by the new fields: KSPM section, per-DynaKube annotations, kubelet path override

--- a/openspec/changes/k8s-distro-aware-installer/proposal.md
+++ b/openspec/changes/k8s-distro-aware-installer/proposal.md
@@ -6,7 +6,7 @@
 
 ## What Changes
 
-- `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE2, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace existence)
+- `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace existence)
 - Detection order enforced: parent distro confirmed first, sub-variant probed only when parent matches (GKE confirmed → Autopilot probe; EKS confirmed → Bottlerocket probe)
 - `InstallKubernetes()` accepts a `distro` parameter; `installKubernetesCmd` passes the detected distribution
 - `dynakubeTemplateData` gains four new fields: `EnableKSPM`, `PrivilegedAnnotation`, `ReadOnlyVolume`, `KubeletPath`
@@ -17,7 +17,7 @@
 
 ### New Capabilities
 
-- `k8s-distribution-detection`: Detecting GKE Autopilot, EKS Bottlerocket, IKS, RKE2, and TKGI from live cluster signals (kubectl probes for node osImage and namespace existence), with correct sub-variant ordering
+- `k8s-distribution-detection`: Detecting GKE Autopilot, EKS Bottlerocket, IKS, RKE, and TKGI from live cluster signals (kubectl probes for node osImage and namespace existence), with correct sub-variant ordering
 - `k8s-distro-aware-manifest`: Generating a DynaKube manifest conditioned on the detected distribution — KSPM block, privileged/readonly annotations, kubeletPath override
 
 ### Modified Capabilities

--- a/openspec/changes/k8s-distro-aware-installer/proposal.md
+++ b/openspec/changes/k8s-distro-aware-installer/proposal.md
@@ -1,0 +1,33 @@
+# Proposal
+
+## Why
+
+`dtwiz install kubernetes` applies a single generic DynaKube manifest regardless of which Kubernetes distribution is running. This causes silent failures on IKS and TKGI (wrong kubelet path), rejected pods on OpenShift (missing SCC annotation), and broken CSI injection on EKS Bottlerocket (immutable rootfs requires read-only volume mode). The installer must detect the distribution and generate a manifest tailored to its constraints.
+
+## What Changes
+
+- `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE2, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace existence)
+- Detection order enforced: sub-variants checked before their parent (GKE Autopilot before GKE, EKS Bottlerocket before EKS)
+- `InstallKubernetes()` accepts a `distro` parameter; `installKubernetesCmd` passes the detected distribution
+- `dynakubeTemplateData` gains four new fields: `EnableKSPM`, `PrivilegedAnnotation`, `ReadOnlyVolume`, `KubeletPath`
+- `dynakube.tmpl` gains conditional blocks driven by the new fields: KSPM section, per-DynaKube annotations, kubelet path override
+- Missing `ClusterRoleBinding` added to the template
+
+## Capabilities
+
+### New Capabilities
+
+- `k8s-distribution-detection`: Detecting GKE Autopilot, EKS Bottlerocket, IKS, RKE2, and TKGI from live cluster signals (kubectl probes for node osImage and namespace existence), with correct sub-variant ordering
+- `k8s-distro-aware-manifest`: Generating a DynaKube manifest conditioned on the detected distribution — KSPM block, privileged/readonly annotations, kubeletPath override
+
+### Modified Capabilities
+
+- `status-command-structure`: Distribution field in `KubernetesInfo` now populated for 5 additional distros; no requirement change, implementation only
+
+## Impact
+
+- `pkg/analyzer/detect_kubernetes.go` — extended with new distros and kubectl probes
+- `pkg/installer/kubernetes.go` — new param, new mapping function
+- `pkg/installer/dynakube.tmpl` — conditional blocks added
+- `cmd/install.go` — passes detected distro to installer
+- No external API changes, no new flags, no breaking changes to existing behavior on already-supported distros

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
@@ -8,16 +8,19 @@ The system SHALL identify a GKE Autopilot cluster by probing the `kube-system` n
 
 #### Scenario: Autopilot cluster detected
 
-- **WHEN** `DetectK8sDistribution` returns `"GKE"` AND `kubectl get namespace kube-system` annotations contain `autopilot.gke.io`
+- **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
+- **WHEN** `kubectl get namespace kube-system` annotations contain `autopilot.gke.io`
 - **THEN** `ProbeK8sSubVariant` returns `"GKE-Autopilot"`
 
 #### Scenario: Standard GKE cluster unchanged
 
-- **WHEN** `DetectK8sDistribution` returns `"GKE"` AND `kube-system` annotations do NOT contain `autopilot.gke.io`
+- **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
+- **WHEN** `kube-system` annotations do NOT contain `autopilot.gke.io`
 - **THEN** `ProbeK8sSubVariant` returns `"GKE"`
 
 #### Scenario: Probe fails gracefully
 
+- **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
 - **WHEN** the `kubectl get namespace kube-system` call returns an error or times out
 - **THEN** `ProbeK8sSubVariant` returns the parent distro unchanged (`"GKE"`)
 
@@ -27,16 +30,19 @@ The system SHALL identify an EKS Bottlerocket cluster by checking node `osImage`
 
 #### Scenario: Bottlerocket nodes detected
 
-- **WHEN** `DetectK8sDistribution` returns `"EKS"` AND `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` output contains "Bottlerocket"
+- **GIVEN** `DetectK8sDistribution` has returned `"EKS"`
+- **WHEN** `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` output contains "Bottlerocket"
 - **THEN** `ProbeK8sSubVariant` returns `"EKS-Bottlerocket"`
 
 #### Scenario: Standard EKS nodes unchanged
 
-- **WHEN** `DetectK8sDistribution` returns `"EKS"` AND node osImage output does NOT contain "Bottlerocket"
+- **GIVEN** `DetectK8sDistribution` has returned `"EKS"`
+- **WHEN** node osImage output does NOT contain "Bottlerocket"
 - **THEN** `ProbeK8sSubVariant` returns `"EKS"`
 
 #### Scenario: Probe fails gracefully
 
+- **GIVEN** `DetectK8sDistribution` has returned `"EKS"`
 - **WHEN** the node osImage kubectl call returns an error or times out
 - **THEN** `ProbeK8sSubVariant` returns `"EKS"`
 
@@ -46,6 +52,7 @@ The system SHALL identify an IBM Kubernetes Service cluster when the API server 
 
 #### Scenario: IKS server URL matched
 
+- **GIVEN** the kubeconfig current context points to a cluster
 - **WHEN** the cluster server URL contains `.containers.cloud.ibm.com`
 - **THEN** `DetectK8sDistribution` returns `"IKS"`
 
@@ -55,6 +62,7 @@ The system SHALL identify an RKE2 cluster when the server gitVersion contains `+
 
 #### Scenario: RKE2 gitVersion matched
 
+- **GIVEN** the cluster is reachable and `kubectl version` succeeds
 - **WHEN** the server gitVersion string contains `+rke2`
 - **THEN** `DetectK8sDistribution` returns `"RKE2"`
 
@@ -64,11 +72,13 @@ The system SHALL identify a TKGI cluster by checking whether the `pks-system` na
 
 #### Scenario: TKGI namespace found
 
-- **WHEN** no other distro signal matches AND `kubectl get namespace pks-system --ignore-not-found` returns a non-empty result
+- **GIVEN** no other distro signal matches the cluster
+- **WHEN** `kubectl get namespace pks-system --ignore-not-found` returns a non-empty result
 - **THEN** `ProbeK8sSubVariant` (or a fallback probe) returns `"TKGI"`
 
 #### Scenario: Namespace absent
 
+- **GIVEN** no other distro signal matches the cluster
 - **WHEN** `pks-system` namespace does not exist
 - **THEN** detection falls through to `"kubernetes"` default
 
@@ -78,10 +88,12 @@ The system SHALL invoke sub-variant kubectl probes only after the parent distrib
 
 #### Scenario: Autopilot probe skipped on non-GKE cluster
 
+- **GIVEN** the cluster has been analyzed
 - **WHEN** `DetectK8sDistribution` returns any value other than `"GKE"`
 - **THEN** the `kube-system` annotation probe is NOT executed
 
 #### Scenario: Bottlerocket probe skipped on non-EKS cluster
 
+- **GIVEN** the cluster has been analyzed
 - **WHEN** `DetectK8sDistribution` returns any value other than `"EKS"`
 - **THEN** the node osImage probe is NOT executed

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
@@ -56,15 +56,15 @@ The system SHALL identify an IBM Kubernetes Service cluster when the API server 
 - **WHEN** the cluster server URL contains `.containers.cloud.ibm.com`
 - **THEN** `DetectK8sDistribution` returns `"IKS"`
 
-### Requirement: Detect RKE2 by server version
+### Requirement: Detect RKE by server version
 
-The system SHALL identify an RKE2 cluster when the server gitVersion contains `+rke2`. The returned distribution string SHALL be `"RKE2"`.
+The system SHALL identify an RKE cluster when the server gitVersion contains `+rke2` (Rancher Kubernetes Engine 2, not RKE1). The returned distribution string SHALL be `"RKE"`.
 
-#### Scenario: RKE2 gitVersion matched
+#### Scenario: RKE gitVersion matched
 
 - **GIVEN** the cluster is reachable and `kubectl version` succeeds
 - **WHEN** the server gitVersion string contains `+rke2`
-- **THEN** `DetectK8sDistribution` returns `"RKE2"`
+- **THEN** `DetectK8sDistribution` returns `"RKE"`
 
 ### Requirement: Detect TKGI by namespace probe
 

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
@@ -1,0 +1,87 @@
+# K8s Distribution Detection
+
+## ADDED Requirements
+
+### Requirement: Detect GKE Autopilot as distinct from GKE Standard
+
+The system SHALL identify a GKE Autopilot cluster by probing the `kube-system` namespace annotations for the `autopilot.gke.io` key after the parent GKE distro is confirmed. The returned distribution string SHALL be `"GKE-Autopilot"`.
+
+#### Scenario: Autopilot cluster detected
+
+- **WHEN** `DetectK8sDistribution` returns `"GKE"` AND `kubectl get namespace kube-system` annotations contain `autopilot.gke.io`
+- **THEN** `ProbeK8sSubVariant` returns `"GKE-Autopilot"`
+
+#### Scenario: Standard GKE cluster unchanged
+
+- **WHEN** `DetectK8sDistribution` returns `"GKE"` AND `kube-system` annotations do NOT contain `autopilot.gke.io`
+- **THEN** `ProbeK8sSubVariant` returns `"GKE"`
+
+#### Scenario: Probe fails gracefully
+
+- **WHEN** the `kubectl get namespace kube-system` call returns an error or times out
+- **THEN** `ProbeK8sSubVariant` returns the parent distro unchanged (`"GKE"`)
+
+### Requirement: Detect EKS Bottlerocket as distinct from EKS Standard
+
+The system SHALL identify an EKS Bottlerocket cluster by checking node `osImage` fields after the parent EKS distro is confirmed. The returned distribution string SHALL be `"EKS-Bottlerocket"`.
+
+#### Scenario: Bottlerocket nodes detected
+
+- **WHEN** `DetectK8sDistribution` returns `"EKS"` AND `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` output contains "Bottlerocket"
+- **THEN** `ProbeK8sSubVariant` returns `"EKS-Bottlerocket"`
+
+#### Scenario: Standard EKS nodes unchanged
+
+- **WHEN** `DetectK8sDistribution` returns `"EKS"` AND node osImage output does NOT contain "Bottlerocket"
+- **THEN** `ProbeK8sSubVariant` returns `"EKS"`
+
+#### Scenario: Probe fails gracefully
+
+- **WHEN** the node osImage kubectl call returns an error or times out
+- **THEN** `ProbeK8sSubVariant` returns `"EKS"`
+
+### Requirement: Detect IKS by server URL
+
+The system SHALL identify an IBM Kubernetes Service cluster when the API server URL contains `.containers.cloud.ibm.com`. The returned distribution string SHALL be `"IKS"`.
+
+#### Scenario: IKS server URL matched
+
+- **WHEN** the cluster server URL contains `.containers.cloud.ibm.com`
+- **THEN** `DetectK8sDistribution` returns `"IKS"`
+
+### Requirement: Detect RKE2 by server version
+
+The system SHALL identify an RKE2 cluster when the server gitVersion contains `+rke2`. The returned distribution string SHALL be `"RKE2"`.
+
+#### Scenario: RKE2 gitVersion matched
+
+- **WHEN** the server gitVersion string contains `+rke2`
+- **THEN** `DetectK8sDistribution` returns `"RKE2"`
+
+### Requirement: Detect TKGI by namespace probe
+
+The system SHALL identify a TKGI cluster by checking whether the `pks-system` namespace exists after no other distro is matched. The returned distribution string SHALL be `"TKGI"`.
+
+#### Scenario: TKGI namespace found
+
+- **WHEN** no other distro signal matches AND `kubectl get namespace pks-system --ignore-not-found` returns a non-empty result
+- **THEN** `ProbeK8sSubVariant` (or a fallback probe) returns `"TKGI"`
+
+#### Scenario: Namespace absent
+
+- **WHEN** `pks-system` namespace does not exist
+- **THEN** detection falls through to `"kubernetes"` default
+
+### Requirement: Sub-variant probes run only when parent distro matches
+
+The system SHALL invoke sub-variant kubectl probes only after the parent distribution is confirmed, to avoid unnecessary API calls on non-matching clusters.
+
+#### Scenario: Autopilot probe skipped on non-GKE cluster
+
+- **WHEN** `DetectK8sDistribution` returns any value other than `"GKE"`
+- **THEN** the `kube-system` annotation probe is NOT executed
+
+#### Scenario: Bottlerocket probe skipped on non-EKS cluster
+
+- **WHEN** `DetectK8sDistribution` returns any value other than `"EKS"`
+- **THEN** the node osImage probe is NOT executed

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -1,0 +1,122 @@
+# K8s Distro-Aware Manifest
+
+## ADDED Requirements
+
+### Requirement: InstallKubernetes accepts distribution parameter
+
+The system SHALL accept a `distro string` parameter in `InstallKubernetes()`. When empty, it SHALL default to `"kubernetes"` behavior.
+
+#### Scenario: Distro wired from command
+
+- **WHEN** `installKubernetesCmd` runs AND the analyzer has detected a Kubernetes cluster
+- **THEN** the detected `Distribution` value from `KubernetesInfo` SHALL be passed to `InstallKubernetes()`
+
+#### Scenario: Empty distro falls back to default
+
+- **WHEN** `InstallKubernetes()` receives an empty `distro` string
+- **THEN** the rendered manifest SHALL match the `"kubernetes"` (generic) distro behavior — KSPM enabled, no annotations, no kubeletPath override
+
+### Requirement: KSPM block included only for standard Linux distributions
+
+The system SHALL include the `kspm.mappedHostPaths` block and `kspmNodeConfigurationCollector` image reference in the rendered manifest only for distributions where standard Linux host paths are accessible.
+
+#### Scenario: KSPM rendered for EKS
+
+- **WHEN** distro is `"EKS"`
+- **THEN** rendered manifest contains `mappedHostPaths` with all 7 paths and `kspmNodeConfigurationCollector` image ref
+
+#### Scenario: KSPM rendered for AKS
+
+- **WHEN** distro is `"AKS"`
+- **THEN** rendered manifest contains `mappedHostPaths` block
+
+#### Scenario: KSPM rendered for generic kubernetes
+
+- **WHEN** distro is `"kubernetes"` or empty
+- **THEN** rendered manifest contains `mappedHostPaths` block
+
+#### Scenario: KSPM omitted for GKE
+
+- **WHEN** distro is `"GKE"` or `"GKE-Autopilot"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+#### Scenario: KSPM omitted for OpenShift
+
+- **WHEN** distro is `"OpenShift"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+#### Scenario: KSPM omitted for Bottlerocket
+
+- **WHEN** distro is `"EKS-Bottlerocket"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+#### Scenario: KSPM omitted for RKE2
+
+- **WHEN** distro is `"RKE2"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+#### Scenario: KSPM omitted for IKS
+
+- **WHEN** distro is `"IKS"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+#### Scenario: KSPM omitted for TKGI
+
+- **WHEN** distro is `"TKGI"`
+- **THEN** rendered manifest does NOT contain `mappedHostPaths`
+
+### Requirement: OpenShift manifests carry privileged annotation on both DynaKubes
+
+The system SHALL add `feature.dynatrace.com/oneagent-privileged: "true"` to the metadata annotations of both DynaKube objects when the distribution is OpenShift.
+
+#### Scenario: Annotation present on both DynaKubes
+
+- **WHEN** distro is `"OpenShift"`
+- **THEN** both the monitoring DynaKube and the agents DynaKube in the rendered manifest contain `feature.dynatrace.com/oneagent-privileged: "true"`
+
+#### Scenario: Annotation absent on non-OpenShift distros
+
+- **WHEN** distro is any value other than `"OpenShift"`
+- **THEN** neither DynaKube in the rendered manifest contains `oneagent-privileged`
+
+### Requirement: Bottlerocket manifests carry readonly-volume annotation on both DynaKubes
+
+The system SHALL add `feature.dynatrace.com/injection-readonly-volume: "true"` to the metadata annotations of both DynaKube objects when the distribution is EKS-Bottlerocket.
+
+#### Scenario: Annotation present on both DynaKubes
+
+- **WHEN** distro is `"EKS-Bottlerocket"`
+- **THEN** both DynaKube objects in the rendered manifest contain `feature.dynatrace.com/injection-readonly-volume: "true"`
+
+#### Scenario: Annotation absent on non-Bottlerocket distros
+
+- **WHEN** distro is any value other than `"EKS-Bottlerocket"`
+- **THEN** neither DynaKube contains `injection-readonly-volume`
+
+### Requirement: Non-standard kubelet paths set in manifest for IKS and TKGI
+
+The system SHALL set the appropriate `kubeletPath` in the rendered DynaKube spec when the distribution uses a non-default kubelet data directory.
+
+#### Scenario: IKS kubeletPath set
+
+- **WHEN** distro is `"IKS"`
+- **THEN** rendered manifest contains `kubeletPath: /var/data/kubelet`
+
+#### Scenario: TKGI kubeletPath set
+
+- **WHEN** distro is `"TKGI"`
+- **THEN** rendered manifest contains `kubeletPath: /var/vcap/data/kubelet`
+
+#### Scenario: kubeletPath absent for standard distros
+
+- **WHEN** distro is GKE, EKS, AKS, OpenShift, RKE2, or generic kubernetes
+- **THEN** rendered manifest does NOT contain `kubeletPath`
+
+### Requirement: ClusterRoleBinding included in all rendered manifests
+
+The system SHALL include a `ClusterRoleBinding` for `dynatrace-kubernetes-monitoring-sensitive` in every rendered manifest, binding to the `dynatrace-activegate` service account.
+
+#### Scenario: ClusterRoleBinding present
+
+- **WHEN** any distro string is passed to `InstallKubernetes()`
+- **THEN** rendered manifest contains a `ClusterRoleBinding` referencing `dynatrace-kubernetes-monitoring-sensitive`

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -58,10 +58,10 @@ The system SHALL include the `kspm.mappedHostPaths` block and `kspmNodeConfigura
 - **WHEN** distro is `"EKS-Bottlerocket"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
-#### Scenario: KSPM omitted for RKE2
+#### Scenario: KSPM omitted for RKE
 
 - **GIVEN** `InstallKubernetes()` is called
-- **WHEN** distro is `"RKE2"`
+- **WHEN** distro is `"RKE"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for IKS
@@ -127,7 +127,7 @@ The system SHALL set the appropriate `kubeletPath` in the rendered DynaKube spec
 #### Scenario: kubeletPath absent for standard distros
 
 - **GIVEN** `InstallKubernetes()` is called
-- **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE2, or generic kubernetes
+- **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE, or generic kubernetes
 - **THEN** rendered manifest does NOT contain `kubeletPath`
 
 ### Requirement: ClusterRoleBinding included in all rendered manifests

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -8,12 +8,14 @@ The system SHALL accept a `distro string` parameter in `InstallKubernetes()`. Wh
 
 #### Scenario: Distro wired from command
 
-- **WHEN** `installKubernetesCmd` runs AND the analyzer has detected a Kubernetes cluster
-- **THEN** the detected `Distribution` value from `KubernetesInfo` SHALL be passed to `InstallKubernetes()`
+- **GIVEN** the analyzer has detected a Kubernetes cluster with a non-empty `Distribution` in `KubernetesInfo`
+- **WHEN** `installKubernetesCmd` runs
+- **THEN** the detected `Distribution` value SHALL be passed to `InstallKubernetes()`
 
 #### Scenario: Empty distro falls back to default
 
-- **WHEN** `InstallKubernetes()` receives an empty `distro` string
+- **GIVEN** `InstallKubernetes()` is called with an empty `distro` string
+- **WHEN** the manifest is rendered
 - **THEN** the rendered manifest SHALL match the `"kubernetes"` (generic) distro behavior — KSPM enabled, no annotations, no kubeletPath override
 
 ### Requirement: KSPM block included only for standard Linux distributions
@@ -22,46 +24,55 @@ The system SHALL include the `kspm.mappedHostPaths` block and `kspmNodeConfigura
 
 #### Scenario: KSPM rendered for EKS
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"EKS"`
 - **THEN** rendered manifest contains `mappedHostPaths` with all 7 paths and `kspmNodeConfigurationCollector` image ref
 
 #### Scenario: KSPM rendered for AKS
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"AKS"`
 - **THEN** rendered manifest contains `mappedHostPaths` block
 
 #### Scenario: KSPM rendered for generic kubernetes
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"kubernetes"` or empty
 - **THEN** rendered manifest contains `mappedHostPaths` block
 
 #### Scenario: KSPM omitted for GKE
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"GKE"` or `"GKE-Autopilot"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for OpenShift
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"OpenShift"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for Bottlerocket
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"EKS-Bottlerocket"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for RKE2
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"RKE2"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for IKS
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"IKS"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
 #### Scenario: KSPM omitted for TKGI
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"TKGI"`
 - **THEN** rendered manifest does NOT contain `mappedHostPaths`
 
@@ -71,11 +82,13 @@ The system SHALL add `feature.dynatrace.com/oneagent-privileged: "true"` to the 
 
 #### Scenario: Annotation present on both DynaKubes
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"OpenShift"`
 - **THEN** both the monitoring DynaKube and the agents DynaKube in the rendered manifest contain `feature.dynatrace.com/oneagent-privileged: "true"`
 
 #### Scenario: Annotation absent on non-OpenShift distros
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is any value other than `"OpenShift"`
 - **THEN** neither DynaKube in the rendered manifest contains `oneagent-privileged`
 
@@ -85,11 +98,13 @@ The system SHALL add `feature.dynatrace.com/injection-readonly-volume: "true"` t
 
 #### Scenario: Annotation present on both DynaKubes
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"EKS-Bottlerocket"`
 - **THEN** both DynaKube objects in the rendered manifest contain `feature.dynatrace.com/injection-readonly-volume: "true"`
 
 #### Scenario: Annotation absent on non-Bottlerocket distros
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is any value other than `"EKS-Bottlerocket"`
 - **THEN** neither DynaKube contains `injection-readonly-volume`
 
@@ -99,17 +114,20 @@ The system SHALL set the appropriate `kubeletPath` in the rendered DynaKube spec
 
 #### Scenario: IKS kubeletPath set
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"IKS"`
 - **THEN** rendered manifest contains `kubeletPath: /var/data/kubelet`
 
 #### Scenario: TKGI kubeletPath set
 
+- **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"TKGI"`
 - **THEN** rendered manifest contains `kubeletPath: /var/vcap/data/kubelet`
 
 #### Scenario: kubeletPath absent for standard distros
 
-- **WHEN** distro is GKE, EKS, AKS, OpenShift, RKE2, or generic kubernetes
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE2, or generic kubernetes
 - **THEN** rendered manifest does NOT contain `kubeletPath`
 
 ### Requirement: ClusterRoleBinding included in all rendered manifests
@@ -118,5 +136,6 @@ The system SHALL include a `ClusterRoleBinding` for `dynatrace-kubernetes-monito
 
 #### Scenario: ClusterRoleBinding present
 
-- **WHEN** any distro string is passed to `InstallKubernetes()`
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** any distro string is passed
 - **THEN** rendered manifest contains a `ClusterRoleBinding` referencing `dynatrace-kubernetes-monitoring-sensitive`

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Extend Distribution Detection
 
 - [ ] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
-- [ ] 1.2 Add RKE2 detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2`, return `"RKE2"`; check before generic `"kubernetes"` fallback
+- [ ] 1.2 Add RKE detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2` (RKE2, not RKE1), return `"RKE"`; check before generic `"kubernetes"` fallback
 - [ ] 1.3 Add `ProbeK8sSubVariant(distro string) string` function in `pkg/analyzer/detect_kubernetes.go` — accepts parent distro, runs conditional kubectl probes, returns refined distro or parent unchanged
 - [ ] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
 - [ ] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
@@ -12,7 +12,7 @@
 
 ## 2. Detection Unit Tests
 
-- [ ] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE2 (gitVersion signal)
+- [ ] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE (gitVersion `+rke2` signal)
 - [ ] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when annotation present, GKE→GKE when absent, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
 - [ ] 2.3 Run `make test` and `make lint` — all pass
 
@@ -26,7 +26,7 @@
 ## 4. Distro-to-Template Mapping
 
 - [ ] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
-- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/empty; `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI
+- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/empty; `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE maps to no KSPM, no annotations, no kubeletPath
 - [ ] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
 
 ## 5. Update DynaKube Template
@@ -39,6 +39,6 @@
 
 ## 6. Manifest Assertion Tests
 
-- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE2`, `TKGI`, `kubernetes`
+- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE`, `TKGI`, `kubernetes`
 - [ ] 6.2 For each row assert specific substrings present or absent in rendered YAML: `mappedHostPaths` present/absent per KSPM expectation, correct annotation key present/absent, `kubeletPath` value present/absent with correct path, `ClusterRoleBinding` always present
 - [ ] 6.3 Run `make test` and `make lint` — all pass

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## 1. Extend Distribution Detection
+
+- [ ] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
+- [ ] 1.2 Add RKE2 detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2`, return `"RKE2"`; check before generic `"kubernetes"` fallback
+- [ ] 1.3 Add `ProbeK8sSubVariant(distro string) string` function in `pkg/analyzer/detect_kubernetes.go` — accepts parent distro, runs conditional kubectl probes, returns refined distro or parent unchanged
+- [ ] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
+- [ ] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
+- [ ] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found` with 5s timeout; return `"TKGI"` if output is non-empty
+- [ ] 1.7 Call `ProbeK8sSubVariant` from `detectKubernetes()` in `pkg/analyzer/detect_kubernetes.go` — after `DetectK8sDistribution()` returns, pass result through probe, store final value in `info.Distribution`
+
+## 2. Detection Unit Tests
+
+- [ ] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE2 (gitVersion signal)
+- [ ] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when annotation present, GKE→GKE when absent, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
+- [ ] 2.3 Run `make test` and `make lint` — all pass
+
+## 3. Wire Distro into Installer Signature
+
+- [ ] 3.1 Add `distro string` parameter to `InstallKubernetes()` in `pkg/installer/kubernetes.go` — position after `name`, before `dryRun`
+- [ ] 3.2 Update `installKubernetesCmd` in `cmd/install.go` to call `analyzer.DetectKubernetes()` (or read from a pre-run `AnalyzeSystem()` result), extract `Distribution`, pass it to `InstallKubernetes()`
+- [ ] 3.3 Update dry-run output in `InstallKubernetes()` to print detected distro: `fmt.Printf("  Distribution: %s\n", distro)`
+- [ ] 3.4 Run `make build` — confirm compiles; run `make test` — confirm no regressions
+
+## 4. Distro-to-Template Mapping
+
+- [ ] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
+- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/empty; `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI
+- [ ] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
+
+## 5. Update DynaKube Template
+
+- [ ] 5.1 Wrap KSPM block in `dynakube.tmpl` with `{{if .EnableKSPM}} ... {{end}}` — covers both `kspm.mappedHostPaths` and `templates.kspmNodeConfigurationCollector` blocks
+- [ ] 5.2 Add conditional annotation block to DynaKube #1 (monitoring) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}` and equivalent for `ReadOnlyVolume`
+- [ ] 5.3 Add identical conditional annotation block to DynaKube #2 (agents) metadata in `dynakube.tmpl`
+- [ ] 5.4 Add conditional kubelet path field to both DynaKube specs in `dynakube.tmpl`: `{{if .KubeletPath}}  kubeletPath: {{.KubeletPath}}{{end}}`
+- [ ] 5.5 Add `ClusterRoleBinding` resource to `dynakube.tmpl` — bind `dynatrace-kubernetes-monitoring-sensitive` ClusterRole to `dynatrace-activegate` ServiceAccount in `dynatrace` namespace
+
+## 6. Manifest Assertion Tests
+
+- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE2`, `TKGI`, `kubernetes`
+- [ ] 6.2 For each row assert specific substrings present or absent in rendered YAML: `mappedHostPaths` present/absent per KSPM expectation, correct annotation key present/absent, `kubeletPath` value present/absent with correct path, `ClusterRoleBinding` always present
+- [ ] 6.3 Run `make test` and `make lint` — all pass


### PR DESCRIPTION
## Chore Description

Initializes OpenSpec documentation for the feature which updates the existing implementation of the `dtwiz install kubernetes` command by:
- extending K8S distribution detection;
- updating DynaKube template logic.

## What changed and why?
<!-- Describe the change. For dependency updates, note the version diff and any breaking changes. -->

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] No unintended behavior changes were introduced.
- [x] CHANGELOG and/or documentation was updated where necessary.
