### PR TITLE
feat: improve project detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OTel Collector is now installed to `~/opentelemetry/` (user home directory) instead of the current working directory to avoid permission issues
 - Recommender doesn't exit early when OneAgent is installed
+- Project detection is faster on large directory trees, no longer depth-limited, skips Windows system directories
 
 ## [0.2.18] - 2026-05-21
 

--- a/openspec/changes/faster-project-detection/.openspec.yaml
+++ b/openspec/changes/faster-project-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/faster-project-detection/design.md
+++ b/openspec/changes/faster-project-detection/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 The scanner in `pkg/installer/otel_runtime_scan.go` is invoked once per runtime (Node/Python/Java/Go) by `dtwiz analyze`, `dtwiz setup`, `dtwiz recommend`, and `dtwiz install otel`. Each call recursively walks the CWD subtree plus two ancestor levels looking for marker files (`package.json`, `pyproject.toml`, etc.). Before this change the walk was sequential, paid `os.Stat` for every marker on every visited directory, called `filepath.EvalSymlinks` on every visited directory for dedup, and stopped at depth 15.
@@ -5,11 +7,13 @@ The scanner in `pkg/installer/otel_runtime_scan.go` is invoked once per runtime 
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Reduce duration of project detection on large home directories and monorepos.
 - Avoid missing deeply nested projects.
 - Keep behavior cross-platform and avoid scanning Windows system directories that produced no useful matches.
 
 **Non-Goals:**
+
 - Changing the public API of `scanProjectDirs` or any caller signatures.
 - Sharing one tree walk across multiple runtimes. Each runtime (Node, Python, Java, Go) still issues its own walk; in practice these run concurrently via `detectAllProjects` and walks after the first benefit from the OS cache populated by the earlier ones, so the overhead is much less than 4×. Merging them into a single walk that checks all marker sets per directory is a potential follow-up.
 - Recommender behavior (separate PR).

--- a/openspec/changes/faster-project-detection/design.md
+++ b/openspec/changes/faster-project-detection/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The scanner in `pkg/installer/otel_runtime_scan.go` is invoked once per runtime (Node/Python/Java/Go) by `dtwiz analyze`, `dtwiz setup`, `dtwiz recommend`, and `dtwiz install otel`. Each call recursively walks the CWD subtree plus two ancestor levels looking for marker files (`package.json`, `pyproject.toml`, etc.). Before this change the walk was sequential, paid `os.Stat` for every marker on every visited directory, called `filepath.EvalSymlinks` on every visited directory for dedup, and stopped at depth 15.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce duration of project detection on large home directories and monorepos.
+- Avoid missing deeply nested projects.
+- Keep behavior cross-platform and avoid scanning Windows system directories that produced no useful matches.
+
+**Non-Goals:**
+- Changing the public API of `scanProjectDirs` or any caller signatures.
+- Sharing one tree walk across multiple runtimes. Each runtime (Node, Python, Java, Go) still issues its own walk; in practice these run concurrently via `detectAllProjects` and walks after the first benefit from the OS cache populated by the earlier ones, so the overhead is much less than 4×. Merging them into a single walk that checks all marker sets per directory is a potential follow-up.
+- Recommender behavior (separate PR).
+
+## Decisions
+
+- **Bounded worker pool over `errgroup`/`WaitGroup`-only.** A buffered channel used as a counting semaphore (`sem`) caps concurrent goroutines at `max(NumCPU*2, 4)`. When the semaphore is full, the parent's `select` falls through `default` and runs the child scan synchronously in the caller's goroutine — keeps goroutine count strictly bounded regardless of fan-out. Alternatives considered: unbounded `go func` (rejected — goroutine explosion on deep trees), `errgroup.SetLimit` (rejected — blocks rather than degrades gracefully).
+- **`ReadDir` hoisted into the walker; entries passed to `visit`.** The walker already had to `ReadDir` for child recursion; passing the result to `visit` lets the project-detection callback do marker matching as a `map[string]struct{}` lookup against entry names — one syscall per dir instead of N stats + 1 ReadDir.
+- **`EvalSymlinks` deferred to match-time.** Matches are rare (a handful per 10k-dir scan), so paying the resolve cost only on match collapses thousands of syscalls into a handful. Dedup happens via `sync.Map.LoadOrStore` on the resolved path; loser of the race returns `true` (skip children) without re-recording.
+- **Depth limit removed rather than raised.** Raising it to 30 or 50 would still risk false negatives. The walker already skips heavy noise dirs (`node_modules`, build outputs, system dirs) and dedups via the `queued` map, so an unlimited walk over a pruned tree is bounded in practice.
+- **`$`-prefix and Windows-system-dir skips in both predicates.** `isIgnoredDir` (used by uninstall) and the local `shouldSkipDir` inside `scanProjectDirs` were drifting; both now apply the `$` prefix rule plus the expanded ignored-names map.
+
+## Risks / Trade-offs
+
+- [Symlink dedup is now best-effort, not pre-emptive] → Before, two paths to the same physical dir would both early-return after dedup; now both will scan their entries (cheap, in-memory) and race on the resolved-path map. Wasted work is small and the walker's `queued` map still prevents identical raw-path revisits. Mitigation: covered by `TestScanProjectDirs_SymlinkDedup` in the existing test suite.
+- [Removed depth limit could in theory walk into pathological symlink loops] → `filepath.EvalSymlinks` is only called on matches, so it does not break symlink cycles on the walk itself. However, the walker's `queued` map keys on raw paths, and the OS-level ignored-dir list excludes the directories where symlink loops typically occur (`.git/`, system dirs). No bug observed in CI or manual testing.
+- [Parallel scan increases syscall pressure briefly] → Mitigated by the semaphore cap and the synchronous fallback on saturation.

--- a/openspec/changes/faster-project-detection/proposal.md
+++ b/openspec/changes/faster-project-detection/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 Project detection (`scanProjectDirs` in `pkg/installer/otel_runtime_scan.go`) was slow on large directory trees and missed deeply nested projects. The scan ran sequentially, paid `os.Stat` for every marker on every directory, resolved symlinks even when no project was found, and capped recursion at 15 levels — combining to make `dtwiz analyze` / `dtwiz setup` noticeably slow when run from a directory above many subprojects, while still missing some.

--- a/openspec/changes/faster-project-detection/proposal.md
+++ b/openspec/changes/faster-project-detection/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Project detection (`scanProjectDirs` in `pkg/installer/otel_runtime_scan.go`) was slow on large directory trees and missed deeply nested projects. The scan ran sequentially, paid `os.Stat` for every marker on every directory, resolved symlinks even when no project was found, and capped recursion at 15 levels — combining to make `dtwiz analyze` / `dtwiz setup` noticeably slow when run from a directory above many subprojects, while still missing some.
+
+## What Changes
+
+- Parallel directory walk in `walkCandidateDirs` using a bounded worker pool (`max(NumCPU*2, 4)` goroutines). When the pool is full, child scans run synchronously in the caller's goroutine — keeps goroutine count strictly bounded.
+- `os.ReadDir` once per directory; entries are reused for both marker matching and child recursion. Marker matching is now a hash lookup against the entry names instead of N `os.Stat` calls per directory.
+- `filepath.EvalSymlinks` deferred to match-time — only called when a directory actually contains marker files (was: every visited directory).
+- Symlink dedup via `sync.Map` keyed by lowercased resolved path, evaluated only on a match — same physical directory reached via two paths is recorded once.
+- Depth limit removed from `walkCandidateDirs` (was capped at 15).
+- Expanded ignored-directory list: Windows system dirs (`Windows`, `System32`, `SysWOW64`, `WinSxS`, `ProgramData`, `AppData`, `$Recycle.Bin`) and any `$`-prefixed directory.
+
+## Capabilities
+
+### New Capabilities
+
+None. The scanner internals are implementation detail, not a behavioral contract worth promoting to a capability spec.
+
+### Modified Capabilities
+
+- `nodejs-project-detection`: add scenarios for the user-visible behavior changes — deeply nested projects are now found (depth cap removed), and the scanner skips Windows system directories. The capability description, marker list, and existing scenarios are unchanged.
+
+## Impact
+
+- **Code**: `pkg/installer/otel_runtime_scan.go` (rewrite of `walkCandidateDirs` + `scanProjectDirs.dirMatches`), `pkg/installer/otel_uninstall.go` (visit callback signature update), `pkg/installer/otel_runtime_scan_test.go` (parallelism test added, removed depth-limit test).
+- **APIs / external contract**: none — the public callers (`detectNodeProjects`, `detectPythonProjects`, `detectJavaProjects`, `detectGoProjects`, `findNodeOtelDirs`) keep identical signatures and return the same `[]ScannedProject` / `[]string` shapes.
+- **Dependencies**: none added.
+- **Risk**: low. Symlink dedup semantics narrowed slightly (only on match, not on every visit) but the walker's own `queued` map still prevents raw-path revisits, and the test suite covers symlink, monorepo, deep-nesting, and parallel-tree scenarios.

--- a/openspec/changes/faster-project-detection/specs/nodejs-project-detection/spec.md
+++ b/openspec/changes/faster-project-detection/specs/nodejs-project-detection/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Deeply nested projects are discovered
+
+The project scanner SHALL NOT impose a recursion depth limit when descending under CWD. Projects nested more than 15 directory levels below CWD SHALL be discovered.
+
+#### Scenario: package.json nested deeper than 15 levels below CWD
+
+- **GIVEN** a `package.json` exists in a directory more than 15 levels below CWD
+- **AND** no excluded directory (e.g. `node_modules`, `.git`) appears anywhere in the path
+- **WHEN** the project scanner runs
+- **THEN** that directory is included as a `ScannedProject`
+
+### Requirement: Windows system directories are excluded from scanning
+
+The project scanner SHALL skip Windows system directories regardless of platform. Specifically the directory names `Windows`, `System32`, `SysWOW64`, `WinSxS`, `ProgramData`, `AppData`, and `$Recycle.Bin`, as well as any directory name beginning with `$`, SHALL be skipped.
+
+#### Scenario: package.json under a Windows system directory is ignored
+
+- **GIVEN** a `package.json` exists inside a directory named `System32` (or any other Windows system directory in the list above) under CWD
+- **WHEN** the project scanner runs
+- **THEN** that `package.json` is NOT included as a `ScannedProject`
+
+#### Scenario: package.json under a $-prefixed directory is ignored
+
+- **GIVEN** a `package.json` exists inside a directory whose name begins with `$` (e.g. `$Recycle.Bin`, `$tmp`)
+- **WHEN** the project scanner runs
+- **THEN** that `package.json` is NOT included as a `ScannedProject`

--- a/openspec/changes/faster-project-detection/specs/nodejs-project-detection/spec.md
+++ b/openspec/changes/faster-project-detection/specs/nodejs-project-detection/spec.md
@@ -1,3 +1,5 @@
+# Node.js Project Detection
+
 ## ADDED Requirements
 
 ### Requirement: Deeply nested projects are discovered

--- a/openspec/changes/faster-project-detection/tasks.md
+++ b/openspec/changes/faster-project-detection/tasks.md
@@ -1,0 +1,33 @@
+## 1. Walker — parallel traversal
+
+- [x] 1.1 Change `walkCandidateDirs` in `pkg/installer/otel_runtime_scan.go` to scan with a bounded worker pool sized at `max(NumCPU*scanConcurrencyPerCPU, minScanConcurrency)`, falling back to synchronous execution when the semaphore is full
+- [x] 1.2 Introduce `queued sync.Map` to dedupe directories across all `scanTree` calls (handles ancestor revisits and symlinks)
+- [x] 1.3 Remove the `maxScanDepth = 15` cap; allow unbounded recursion (bounded in practice by the skip list and `queued`)
+- [x] 1.4 Hoist `os.ReadDir(dir)` to run once per directory; pass the result to the `visit` callback so child recursion and marker matching share one syscall
+- [x] 1.5 Update `visit` signature from `func(dir string) bool` to `func(dir string, entries []os.DirEntry) bool`; update the uninstall caller in `pkg/installer/otel_uninstall.go` (`findNodeOtelDirs`)
+
+## 2. Project scanner — marker matching + symlink dedup
+
+- [x] 2.1 In `scanProjectDirs`, build `markerSet map[string]struct{}` once and match by iterating entries (replacing N `os.Stat` calls per directory)
+- [x] 2.2 Defer `filepath.EvalSymlinks` so it only runs when markers actually match (was: every visited directory)
+- [x] 2.3 Replace the `visitedDirs map[string]bool` + mutex with `matchedProjects sync.Map` keyed by lowercased resolved path; dedup happens at record-time via `LoadOrStore`
+- [x] 2.4 Add `$`-prefix skip rule to `shouldSkipDir` so it stays consistent with `isIgnoredDir`
+- [x] 2.5 Raise `largeScanThreshold` to 10000 and move the follow-up "tip" line to `2*largeScanThreshold`
+
+## 3. Ignored directories — expand for Windows
+
+- [x] 3.1 Add Windows system directories to `ignoredProjectDirNames`: `Windows`, `System32`, `SysWOW64`, `WinSxS`, `ProgramData`, `AppData`, `$Recycle.Bin`
+- [x] 3.2 Add `$`-prefix check to `isIgnoredDir` so any `$`-prefixed name is skipped without explicit listing
+
+## 4. Tests
+
+- [x] 4.1 Add `TestScanProjectDirs_WideParallelTree` — verifies parallel scan correctness over a wide tree
+- [x] 4.2 Add `TestScanProjectDirs_WindowsSystemDirSkipped` — verifies new Windows-dir exclusions
+- [x] 4.3 Add `TestScanProjectDirs_DevDirFound` — guards against false positives in the expanded ignore list (`dev` is not a system dir)
+- [x] 4.4 Remove `TestScanProjectDirs_DepthLimit` (the depth limit it tested has been removed)
+- [x] 4.5 Verify all existing scan tests still pass: `go test ./pkg/installer/...`
+
+## 5. Docs / changelog
+
+- [x] 5.1 Add an `Unreleased` entry to `CHANGELOG.md` noting the project-detection improvements
+- [x] 5.2 Confirm no live openspec specs need updating (scan internals are not part of any behavioral contract)

--- a/openspec/changes/faster-project-detection/tasks.md
+++ b/openspec/changes/faster-project-detection/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. Walker — parallel traversal
 
 - [x] 1.1 Change `walkCandidateDirs` in `pkg/installer/otel_runtime_scan.go` to scan with a bounded worker pool sized at `max(NumCPU*scanConcurrencyPerCPU, minScanConcurrency)`, falling back to synchronous execution when the semaphore is full

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -57,6 +57,7 @@ var ignoredProjectDirNames = map[string]bool{
 	"SysWOW64":     true,
 	"WinSxS":       true,
 	"ProgramData":  true,
+	"AppData":      true,
 	"$Recycle.Bin": true,
 }
 
@@ -192,13 +193,20 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return strings.HasPrefix(name, ".") || excludedDirNames[name] || ignoredProjectDirNames[name]
 	}
 
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
 	var mu sync.Mutex
 	discoveredProjects := make([]ScannedProject, 0)
 	visitedDirs := make(map[string]bool) // normalised path → matched
 
+	// Track scan counts per immediate subdirectory for summarised debug output.
+	var subtreeCounts sync.Map // relative top-level child → *atomic.Int64
+
 	dirMatches := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
-			logger.Debug("skipping ignored dir", "path", dir)
 			return false
 		}
 
@@ -226,6 +234,13 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			fmt.Printf("  Tip: run dtwiz from the directory where your code lives for a faster scan.\n")
 		}
 
+		// Count directories per immediate child of workingDir for debug summary.
+		if rel, relErr := filepath.Rel(workingDir, dir); relErr == nil && rel != "." {
+			topChild := strings.SplitN(rel, string(filepath.Separator), 2)[0]
+			val, _ := subtreeCounts.LoadOrStore(topChild, &atomic.Int64{})
+			val.(*atomic.Int64).Add(1)
+		}
+
 		matchedMarkers := make([]string, 0, len(markers))
 		for _, marker := range markers {
 			if _, statErr := os.Stat(filepath.Join(dir, marker)); statErr == nil {
@@ -234,7 +249,6 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		}
 
 		if len(matchedMarkers) == 0 {
-			logger.Debug("project dir scanned, no markers", "path", dir, "looking_for", strings.Join(markers, ","))
 			return false
 		}
 
@@ -246,12 +260,13 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return true
 	}
 
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return discoveredProjects
-	}
-
 	walkCandidateDirs(workingDir, 2, dirMatches, shouldSkipDir)
+
+	// Emit a single debug summary per top-level subdirectory.
+	subtreeCounts.Range(func(key, value any) bool {
+		logger.Debug("scan summary", "subdir", key.(string), "dirs_checked", value.(*atomic.Int64).Load())
+		return true
+	})
 
 	return discoveredProjects
 }

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
@@ -28,16 +29,11 @@ type ScannedProject struct {
 	RunningProcessIDs []int
 }
 
+// maxScanDepth caps recursion to prevent runaway traversal of deep trees.
+const maxScanDepth = 15
+
 var ignoredProjectDirNames = map[string]bool{
-	"Library":      true,
-	"Applications": true,
-	"System":       true,
-	"Movies":       true,
-	"Music":        true,
-	"Pictures":     true,
-	"Public":       true,
-	".git":         true,
-	".svn":         true,
+	// Project build/dependency artifacts
 	"node_modules": true,
 	"vendor":       true,
 	"venv":         true,
@@ -47,6 +43,20 @@ var ignoredProjectDirNames = map[string]bool{
 	"build":        true,
 	"target":       true,
 	"out":          true,
+	// macOS system directories
+	"Library":      true,
+	"Applications": true,
+	"System":       true,
+	"Movies":       true,
+	"Music":        true,
+	"Pictures":     true,
+	"Public":       true,
+	// Windows system directories — scanning these is slow and never productive
+	"Windows":     true,
+	"System32":    true,
+	"SysWOW64":    true,
+	"WinSxS":      true,
+	"ProgramData": true,
 }
 
 func isIgnoredDir(name string) bool {
@@ -74,31 +84,79 @@ func runInParallel[A any, B any](left func() A, right func() B) (A, B) {
 	return leftResult, rightResult
 }
 
-// walkCandidateDirs scans root and its descendants, then walks up to
-// parentLevels ancestor directories doing the same scan. visit is called
+// walkCandidateDirs scans root and its descendants in parallel, then walks up
+// to parentLevels ancestor directories doing the same scan. visit is called
 // for every candidate directory; returning true means "matched — skip
 // children". shouldSkip decides whether a child entry name is skipped
 // entirely. The parent walk stops as soon as a level produces a match.
 func walkCandidateDirs(root string, parentLevels int, visit func(dir string) bool, shouldSkip func(name string) bool) {
-	var scan func(dir string) bool
-	scan = func(dir string) bool {
-		found := visit(dir)
-		if found {
-			return true
+	concurrency := runtime.NumCPU() * 2
+	if concurrency < 4 {
+		concurrency = 4
+	}
+	// sem bounds the number of goroutines scanning concurrently. When all slots
+	// are taken, child scans fall back to running synchronously in the caller's
+	// goroutine to avoid unbounded goroutine creation.
+	sem := make(chan struct{}, concurrency)
+
+	// queued prevents the same directory from being processed twice across all
+	// scanTree calls (handles symlinks and ancestor re-visits).
+	var queued sync.Map
+	var wg sync.WaitGroup
+
+	var scanDir func(dir string, depth int, anyFound *atomic.Bool)
+	scanDir = func(dir string, depth int, anyFound *atomic.Bool) {
+		defer wg.Done()
+
+		if visit(dir) {
+			if anyFound != nil {
+				anyFound.Store(true)
+			}
+			return // matched: skip children
 		}
+		if depth >= maxScanDepth {
+			return
+		}
+
 		entries, _ := os.ReadDir(dir)
 		for _, entry := range entries {
 			if !entry.IsDir() || shouldSkip(entry.Name()) {
 				continue
 			}
-			if scan(filepath.Join(dir, entry.Name())) {
-				found = true
+			childPath := filepath.Join(dir, entry.Name())
+			if _, loaded := queued.LoadOrStore(childPath, struct{}{}); loaded {
+				continue
+			}
+			nextDepth := depth + 1
+			select {
+			case sem <- struct{}{}:
+				wg.Add(1)
+				go func(p string) {
+					defer func() { <-sem }()
+					scanDir(p, nextDepth, anyFound)
+				}(childPath)
+			default:
+				// Pool saturated — run synchronously.
+				wg.Add(1)
+				scanDir(childPath, nextDepth, anyFound)
 			}
 		}
-		return found
 	}
 
-	scan(root)
+	// scanTree scans dir and all its descendants. Returns true if any directory
+	// in the tree produced a match. Skips dirs already visited.
+	scanTree := func(dir string) bool {
+		if _, loaded := queued.LoadOrStore(dir, struct{}{}); loaded {
+			return false
+		}
+		var found atomic.Bool
+		wg.Add(1)
+		scanDir(dir, 0, &found)
+		wg.Wait()
+		return found.Load()
+	}
+
+	scanTree(root)
 
 	currentDir := root
 	for range parentLevels {
@@ -107,12 +165,17 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string) boo
 			break
 		}
 		logger.Debug("scanning ancestor dir", "path", parentDir)
-		if scan(parentDir) {
+		if scanTree(parentDir) {
 			break
 		}
 		currentDir = parentDir
 	}
 }
+
+// largeScanThreshold is the number of directories checked before printing a
+// progress notice. Trees this large are unusual for normal project directories
+// but common in system paths (C:\Windows, /usr, etc.).
+const largeScanThreshold = 200
 
 func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	excludedDirNames := make(map[string]bool, len(excludeNames))
@@ -124,8 +187,11 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return strings.HasPrefix(name, ".") || excludedDirNames[name] || ignoredProjectDirNames[name]
 	}
 
+	var mu sync.Mutex
 	discoveredProjects := make([]ScannedProject, 0)
-	visitedDirs := make(map[string]bool) // present=visited, value=matched
+	visitedDirs := make(map[string]bool) // normalised path → matched
+
+	var scannedCount atomic.Int64
 
 	dirMatches := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
@@ -137,28 +203,43 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		if err != nil {
 			resolvedDir = dir
 		}
-
 		normalizedDir := strings.ToLower(resolvedDir)
+
+		mu.Lock()
 		if matched, seen := visitedDirs[normalizedDir]; seen {
+			mu.Unlock()
 			return matched
+		}
+		// Pre-mark as unmatched so concurrent goroutines skip this dir rather
+		// than duplicating the stat calls. The value is updated below if markers
+		// are found.
+		visitedDirs[normalizedDir] = false
+		mu.Unlock()
+
+		n := scannedCount.Add(1)
+		if n == largeScanThreshold {
+			fmt.Printf("  Scanning a large directory tree, this may take a moment...\n")
+		} else if n == 500 {
+			fmt.Printf("  Tip: run dtwiz from the directory where your code lives for a faster scan.\n")
 		}
 
 		matchedMarkers := make([]string, 0, len(markers))
 		for _, marker := range markers {
-			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			if _, statErr := os.Stat(filepath.Join(dir, marker)); statErr == nil {
 				matchedMarkers = append(matchedMarkers, marker)
 			}
 		}
 
 		if len(matchedMarkers) == 0 {
 			logger.Debug("project dir scanned, no markers", "path", dir, "looking_for", strings.Join(markers, ","))
-			visitedDirs[normalizedDir] = false
 			return false
 		}
 
 		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
+		mu.Lock()
 		discoveredProjects = append(discoveredProjects, ScannedProject{Path: dir, Markers: matchedMarkers})
 		visitedDirs[normalizedDir] = true
+		mu.Unlock()
 		return true
 	}
 

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -30,7 +30,7 @@ type ScannedProject struct {
 }
 
 // maxScanDepth caps recursion to prevent runaway traversal of deep trees.
-const maxScanDepth = 15
+const maxScanDepth = 150
 
 var ignoredProjectDirNames = map[string]bool{
 	// Project build/dependency artifacts

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -88,10 +88,12 @@ func runInParallel[A any, B any](left func() A, right func() B) (A, B) {
 
 // walkCandidateDirs scans root and its descendants in parallel, then walks up
 // to parentLevels ancestor directories doing the same scan. visit is called
-// for every candidate directory; returning true means "matched — skip
-// children". shouldSkip decides whether a child entry name is skipped
-// entirely. The parent walk stops as soon as a level produces a match.
-func walkCandidateDirs(root string, parentLevels int, visit func(dir string) bool, shouldSkip func(name string) bool) {
+// for every candidate directory with that directory's entries (read once per
+// dir and reused for both marker matching and child recursion). Returning true
+// means "matched — skip children". shouldSkip decides whether a child entry
+// name is skipped entirely. The parent walk stops as soon as a level produces
+// a match.
+func walkCandidateDirs(root string, parentLevels int, visit func(dir string, entries []os.DirEntry) bool, shouldSkip func(name string) bool) {
 	concurrency := runtime.NumCPU() * 2
 	if concurrency < 4 {
 		concurrency = 4
@@ -110,7 +112,9 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string) boo
 	scanDir = func(dir string, depth int, anyFound *atomic.Bool) {
 		defer wg.Done()
 
-		if visit(dir) {
+		entries, _ := os.ReadDir(dir)
+
+		if visit(dir, entries) {
 			if anyFound != nil {
 				anyFound.Store(true)
 			}
@@ -120,7 +124,6 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string) boo
 			return
 		}
 
-		entries, _ := os.ReadDir(dir)
 		for _, entry := range entries {
 			if !entry.IsDir() || shouldSkip(entry.Name()) {
 				continue
@@ -177,7 +180,7 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string) boo
 // largeScanThreshold is the number of directories checked before printing a
 // progress notice. Trees this large are unusual for normal project directories
 // but common in system paths (C:\Windows, /usr, etc.).
-const largeScanThreshold = 200
+const largeScanThreshold = 10000
 
 // globalScanCount is shared across all scanProjectDirs calls so progress
 // messages are only printed once even when scanning for multiple runtimes.
@@ -198,39 +201,30 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return nil
 	}
 
+	markerSet := make(map[string]struct{}, len(markers))
+	for _, m := range markers {
+		markerSet[m] = struct{}{}
+	}
+
 	var mu sync.Mutex
 	discoveredProjects := make([]ScannedProject, 0)
-	visitedDirs := make(map[string]bool) // normalised path → matched
+	// matchedProjects dedups recorded projects when the same physical directory
+	// is reached via multiple paths (symlinks). Resolved lazily — only when
+	// markers actually match.
+	var matchedProjects sync.Map // lowercased resolved path → struct{}
 
 	// Track scan counts per immediate subdirectory for summarised debug output.
 	var subtreeCounts sync.Map // relative top-level child → *atomic.Int64
 
-	dirMatches := func(dir string) bool {
+	dirMatches := func(dir string, entries []os.DirEntry) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
 			return false
 		}
 
-		resolvedDir, err := filepath.EvalSymlinks(dir)
-		if err != nil {
-			resolvedDir = dir
-		}
-		normalizedDir := strings.ToLower(resolvedDir)
-
-		mu.Lock()
-		if matched, seen := visitedDirs[normalizedDir]; seen {
-			mu.Unlock()
-			return matched
-		}
-		// Pre-mark as unmatched so concurrent goroutines skip this dir rather
-		// than duplicating the stat calls. The value is updated below if markers
-		// are found.
-		visitedDirs[normalizedDir] = false
-		mu.Unlock()
-
 		n := globalScanCount.Add(1)
 		if n == largeScanThreshold {
 			fmt.Printf("  Scanning a large directory tree, this may take a moment...\n")
-		} else if n == 1000 {
+		} else if n == 20000 {
 			fmt.Printf("  Tip: run dtwiz from the directory where your code lives for a faster scan.\n")
 		}
 
@@ -241,10 +235,11 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			val.(*atomic.Int64).Add(1)
 		}
 
+		// Marker matching via entry-name lookup — no stat syscalls per marker.
 		matchedMarkers := make([]string, 0, len(markers))
-		for _, marker := range markers {
-			if _, statErr := os.Stat(filepath.Join(dir, marker)); statErr == nil {
-				matchedMarkers = append(matchedMarkers, marker)
+		for _, e := range entries {
+			if _, ok := markerSet[e.Name()]; ok {
+				matchedMarkers = append(matchedMarkers, e.Name())
 			}
 		}
 
@@ -252,10 +247,23 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			return false
 		}
 
+		// Markers matched — resolve symlinks and dedup against prior matches.
+		// EvalSymlinks is deferred to here so the cost is paid only for the
+		// handful of dirs that actually contain a project, not every visited
+		// directory.
+		resolvedDir, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			resolvedDir = dir
+		}
+		if _, loaded := matchedProjects.LoadOrStore(strings.ToLower(resolvedDir), struct{}{}); loaded {
+			// Same physical dir recorded via another path — skip children but
+			// don't add a duplicate.
+			return true
+		}
+
 		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
 		mu.Lock()
 		discoveredProjects = append(discoveredProjects, ScannedProject{Path: dir, Markers: matchedMarkers})
-		visitedDirs[normalizedDir] = true
 		mu.Unlock()
 		return true
 	}

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -186,7 +186,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	}
 
 	shouldSkipDir := func(name string) bool {
-		return strings.HasPrefix(name, ".") || excludedDirNames[name] || ignoredProjectDirNames[name]
+		return strings.HasPrefix(name, ".") || strings.HasPrefix(name, "$") || excludedDirNames[name] || ignoredProjectDirNames[name]
 	}
 
 	workingDir, err := os.Getwd()

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -52,15 +52,16 @@ var ignoredProjectDirNames = map[string]bool{
 	"Pictures":     true,
 	"Public":       true,
 	// Windows system directories — scanning these is slow and never productive
-	"Windows":     true,
-	"System32":    true,
-	"SysWOW64":    true,
-	"WinSxS":      true,
-	"ProgramData": true,
+	"Windows":      true,
+	"System32":     true,
+	"SysWOW64":     true,
+	"WinSxS":       true,
+	"ProgramData":  true,
+	"$Recycle.Bin": true,
 }
 
 func isIgnoredDir(name string) bool {
-	return strings.HasPrefix(name, ".") || ignoredProjectDirNames[name]
+	return strings.HasPrefix(name, ".") || strings.HasPrefix(name, "$") || ignoredProjectDirNames[name]
 }
 
 func runInParallel[A any, B any](left func() A, right func() B) (A, B) {
@@ -177,6 +178,10 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string) boo
 // but common in system paths (C:\Windows, /usr, etc.).
 const largeScanThreshold = 200
 
+// globalScanCount is shared across all scanProjectDirs calls so progress
+// messages are only printed once even when scanning for multiple runtimes.
+var globalScanCount atomic.Int64
+
 func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	excludedDirNames := make(map[string]bool, len(excludeNames))
 	for _, name := range excludeNames {
@@ -190,8 +195,6 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	var mu sync.Mutex
 	discoveredProjects := make([]ScannedProject, 0)
 	visitedDirs := make(map[string]bool) // normalised path → matched
-
-	var scannedCount atomic.Int64
 
 	dirMatches := func(dir string) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
@@ -216,10 +219,10 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		visitedDirs[normalizedDir] = false
 		mu.Unlock()
 
-		n := scannedCount.Add(1)
+		n := globalScanCount.Add(1)
 		if n == largeScanThreshold {
 			fmt.Printf("  Scanning a large directory tree, this may take a moment...\n")
-		} else if n == 500 {
+		} else if n == 1000 {
 			fmt.Printf("  Tip: run dtwiz from the directory where your code lives for a faster scan.\n")
 		}
 

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -29,9 +29,6 @@ type ScannedProject struct {
 	RunningProcessIDs []int
 }
 
-// maxScanDepth caps recursion to prevent runaway traversal of deep trees.
-const maxScanDepth = 150
-
 var ignoredProjectDirNames = map[string]bool{
 	// Project build/dependency artifacts
 	"node_modules": true,
@@ -108,8 +105,8 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 	var queued sync.Map
 	var wg sync.WaitGroup
 
-	var scanDir func(dir string, depth int, anyFound *atomic.Bool)
-	scanDir = func(dir string, depth int, anyFound *atomic.Bool) {
+	var scanDir func(dir string, anyFound *atomic.Bool)
+	scanDir = func(dir string, anyFound *atomic.Bool) {
 		defer wg.Done()
 
 		entries, _ := os.ReadDir(dir)
@@ -120,9 +117,6 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 			}
 			return // matched: skip children
 		}
-		if depth >= maxScanDepth {
-			return
-		}
 
 		for _, entry := range entries {
 			if !entry.IsDir() || shouldSkip(entry.Name()) {
@@ -132,18 +126,17 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 			if _, loaded := queued.LoadOrStore(childPath, struct{}{}); loaded {
 				continue
 			}
-			nextDepth := depth + 1
 			select {
 			case sem <- struct{}{}:
 				wg.Add(1)
 				go func(p string) {
 					defer func() { <-sem }()
-					scanDir(p, nextDepth, anyFound)
+					scanDir(p, anyFound)
 				}(childPath)
 			default:
 				// Pool saturated — run synchronously.
 				wg.Add(1)
-				scanDir(childPath, nextDepth, anyFound)
+				scanDir(childPath, anyFound)
 			}
 		}
 	}
@@ -156,7 +149,7 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 		}
 		var found atomic.Bool
 		wg.Add(1)
-		scanDir(dir, 0, &found)
+		scanDir(dir, &found)
 		wg.Wait()
 		return found.Load()
 	}

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -83,25 +83,22 @@ func runInParallel[A any, B any](left func() A, right func() B) (A, B) {
 	return leftResult, rightResult
 }
 
-// walkCandidateDirs scans root and its descendants in parallel, then walks up
-// to parentLevels ancestor directories doing the same scan. visit is called
-// for every candidate directory with that directory's entries (read once per
-// dir and reused for both marker matching and child recursion). Returning true
-// means "matched — skip children". shouldSkip decides whether a child entry
-// name is skipped entirely. The parent walk stops as soon as a level produces
-// a match.
+// Directory scanning is syscall-bound, so oversubscribe CPUs; the floor keeps
+// 1–2 core VMs from going effectively serial.
+const (
+	scanConcurrencyPerCPU = 2
+	minScanConcurrency    = 4
+)
+
+// walkCandidateDirs scans root + descendants in parallel and walks up to
+// parentLevels ancestors. visit receives each dir's entries (read once, reused
+// for matching and recursion); returning true means matched — skip children.
 func walkCandidateDirs(root string, parentLevels int, visit func(dir string, entries []os.DirEntry) bool, shouldSkip func(name string) bool) {
-	concurrency := runtime.NumCPU() * 2
-	if concurrency < 4 {
-		concurrency = 4
-	}
-	// sem bounds the number of goroutines scanning concurrently. When all slots
-	// are taken, child scans fall back to running synchronously in the caller's
-	// goroutine to avoid unbounded goroutine creation.
+	concurrency := max(runtime.NumCPU()*scanConcurrencyPerCPU, minScanConcurrency)
+	// When full, child scans run synchronously instead of spawning more goroutines.
 	sem := make(chan struct{}, concurrency)
 
-	// queued prevents the same directory from being processed twice across all
-	// scanTree calls (handles symlinks and ancestor re-visits).
+	// Dedup across scanTree calls (symlinks and ancestor revisits).
 	var queued sync.Map
 	var wg sync.WaitGroup
 
@@ -141,8 +138,6 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 		}
 	}
 
-	// scanTree scans dir and all its descendants. Returns true if any directory
-	// in the tree produced a match. Skips dirs already visited.
 	scanTree := func(dir string) bool {
 		if _, loaded := queued.LoadOrStore(dir, struct{}{}); loaded {
 			return false
@@ -170,13 +165,11 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 	}
 }
 
-// largeScanThreshold is the number of directories checked before printing a
-// progress notice. Trees this large are unusual for normal project directories
-// but common in system paths (C:\Windows, /usr, etc.).
+// Trees this large are normal for system paths (C:\Windows, /usr) but unusual
+// for project dirs — print a progress notice when crossed.
 const largeScanThreshold = 10000
 
-// globalScanCount is shared across all scanProjectDirs calls so progress
-// messages are only printed once even when scanning for multiple runtimes.
+// Shared across runtimes so the progress notice prints at most once per session.
 var globalScanCount atomic.Int64
 
 func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
@@ -201,13 +194,10 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 	var mu sync.Mutex
 	discoveredProjects := make([]ScannedProject, 0)
-	// matchedProjects dedups recorded projects when the same physical directory
-	// is reached via multiple paths (symlinks). Resolved lazily — only when
-	// markers actually match.
+	// Dedup matches when the same physical dir is reached via different symlink
+	// paths. Lazy: only resolved on actual match.
 	var matchedProjects sync.Map // lowercased resolved path → struct{}
-
-	// Track scan counts per immediate subdirectory for summarised debug output.
-	var subtreeCounts sync.Map // relative top-level child → *atomic.Int64
+	var subtreeCounts sync.Map   // relative top-level child → *atomic.Int64
 
 	dirMatches := func(dir string, entries []os.DirEntry) bool {
 		if shouldSkipDir(filepath.Base(dir)) {
@@ -217,18 +207,16 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		n := globalScanCount.Add(1)
 		if n == largeScanThreshold {
 			fmt.Printf("  Scanning a large directory tree, this may take a moment...\n")
-		} else if n == 20000 {
+		} else if n == 2*largeScanThreshold {
 			fmt.Printf("  Tip: run dtwiz from the directory where your code lives for a faster scan.\n")
 		}
 
-		// Count directories per immediate child of workingDir for debug summary.
 		if rel, relErr := filepath.Rel(workingDir, dir); relErr == nil && rel != "." {
 			topChild := strings.SplitN(rel, string(filepath.Separator), 2)[0]
 			val, _ := subtreeCounts.LoadOrStore(topChild, &atomic.Int64{})
 			val.(*atomic.Int64).Add(1)
 		}
 
-		// Marker matching via entry-name lookup — no stat syscalls per marker.
 		matchedMarkers := make([]string, 0, len(markers))
 		for _, e := range entries {
 			if _, ok := markerSet[e.Name()]; ok {
@@ -240,18 +228,13 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			return false
 		}
 
-		// Markers matched — resolve symlinks and dedup against prior matches.
-		// EvalSymlinks is deferred to here so the cost is paid only for the
-		// handful of dirs that actually contain a project, not every visited
-		// directory.
+		// EvalSymlinks is paid only on actual matches (rare), not every visited dir.
 		resolvedDir, err := filepath.EvalSymlinks(dir)
 		if err != nil {
 			resolvedDir = dir
 		}
 		if _, loaded := matchedProjects.LoadOrStore(strings.ToLower(resolvedDir), struct{}{}); loaded {
-			// Same physical dir recorded via another path — skip children but
-			// don't add a duplicate.
-			return true
+			return true // dup via symlink: skip children but don't re-record
 		}
 
 		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
@@ -263,11 +246,11 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 	walkCandidateDirs(workingDir, 2, dirMatches, shouldSkipDir)
 
-	// Emit a single debug summary per top-level subdirectory.
 	subtreeCounts.Range(func(key, value any) bool {
 		logger.Debug("scan summary", "subdir", key.(string), "dirs_checked", value.(*atomic.Int64).Load())
 		return true
 	})
+	logger.Debug("scan complete", "total_dirs_checked", globalScanCount.Load())
 
 	return discoveredProjects
 }

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -228,7 +228,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			return false
 		}
 
-		// EvalSymlinks is paid only on actual matches (rare), not every visited dir.
+		// EvalSymlinks runs only on actual matches (rare), not every visited dir.
 		resolvedDir, err := filepath.EvalSymlinks(dir)
 		if err != nil {
 			resolvedDir = dir

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -413,6 +414,126 @@ func TestScanProjectDirs_AncestorWalk(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected sibling project to be found via ancestor walk, got %v", projects)
+	}
+}
+
+func TestIsIgnoredDir_WindowsSystemDirs(t *testing.T) {
+	for _, name := range []string{"Windows", "System32", "SysWOW64", "WinSxS", "ProgramData"} {
+		if !isIgnoredDir(name) {
+			t.Errorf("isIgnoredDir(%q) = false, want true (Windows system dir)", name)
+		}
+	}
+}
+
+func TestIsIgnoredDir_CommonNamesNotIgnored(t *testing.T) {
+	// dev, sys, proc are Linux virtual filesystem names at the root level, but
+	// they are also common project subdirectory names. They must NOT be ignored.
+	for _, name := range []string{"dev", "sys", "proc", "src", "lib", "cmd"} {
+		if isIgnoredDir(name) {
+			t.Errorf("isIgnoredDir(%q) = true, want false (valid project dir name)", name)
+		}
+	}
+}
+
+func TestScanProjectDirs_WindowsSystemDirSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	sysDir := filepath.Join(dir, "System32")
+	if err := os.Mkdir(sysDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sysDir, "go.mod"), []byte("module sys\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, dir)
+	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
+		if strings.Contains(p.Path, "System32") {
+			t.Errorf("Windows system dir 'System32' must be skipped, got %s", p.Path)
+		}
+	}
+}
+
+func TestScanProjectDirs_DevDirFound(t *testing.T) {
+	dir := t.TempDir()
+
+	devDir := filepath.Join(dir, "dev")
+	if err := os.Mkdir(devDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "go.mod"), []byte("module dev\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, dir)
+	found := false
+	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
+		if strings.HasSuffix(filepath.ToSlash(p.Path), "/dev") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("project inside 'dev' directory must be found (not ignored)")
+	}
+}
+
+func TestScanProjectDirs_DepthLimit(t *testing.T) {
+	root := t.TempDir()
+
+	// Build a chain of directories exactly maxScanDepth levels deep (no marker
+	// at any level) and place a marker one level further. The directory at
+	// maxScanDepth is visited but its children are not, so the marker is never
+	// seen.
+	atLimit := root
+	for range maxScanDepth {
+		atLimit = filepath.Join(atLimit, "x")
+	}
+	beyond := filepath.Join(atLimit, "deeper")
+	if err := os.MkdirAll(beyond, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beyond, "go.mod"), []byte("module beyond\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, root)
+	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
+		if p.Path == beyond {
+			t.Errorf("project at depth %d (beyond maxScanDepth=%d) must not be found", maxScanDepth+1, maxScanDepth)
+		}
+	}
+}
+
+func TestScanProjectDirs_WideParallelTree(t *testing.T) {
+	root := t.TempDir()
+
+	// Create 20 sibling project directories. The parallel scan must find all of
+	// them (no goroutine races or lost updates).
+	const siblings = 20
+	names := make([]string, siblings)
+	for i := range siblings {
+		name := fmt.Sprintf("svc-%02d", i)
+		names[i] = name
+		sub := filepath.Join(root, name)
+		if err := os.Mkdir(sub, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module "+name+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	setTestWorkingDir(t, root)
+	projects := scanProjectDirs([]string{"go.mod"}, nil)
+
+	found := make(map[string]bool, siblings)
+	for _, p := range projects {
+		found[filepath.Base(p.Path)] = true
+	}
+	for _, name := range names {
+		if !found[name] {
+			t.Errorf("parallel scan missed project %q; found: %v", name, projects)
+		}
 	}
 }
 

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -477,33 +477,6 @@ func TestScanProjectDirs_DevDirFound(t *testing.T) {
 	}
 }
 
-func TestScanProjectDirs_DepthLimit(t *testing.T) {
-	root := t.TempDir()
-
-	// Build a chain of directories exactly maxScanDepth levels deep (no marker
-	// at any level) and place a marker one level further. The directory at
-	// maxScanDepth is visited but its children are not, so the marker is never
-	// seen.
-	atLimit := root
-	for range maxScanDepth {
-		atLimit = filepath.Join(atLimit, "x")
-	}
-	beyond := filepath.Join(atLimit, "deeper")
-	if err := os.MkdirAll(beyond, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(beyond, "go.mod"), []byte("module beyond\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	setTestWorkingDir(t, root)
-	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
-		if p.Path == beyond {
-			t.Errorf("project at depth %d (beyond maxScanDepth=%d) must not be found", maxScanDepth+1, maxScanDepth)
-		}
-	}
-}
-
 func TestScanProjectDirs_WideParallelTree(t *testing.T) {
 	root := t.TempDir()
 

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -194,12 +194,20 @@ func findNodeOtelDirs() []string {
 	// /private/tmp/.otel (same directory on macOS) are not listed twice.
 	// mu guards dirs and seen since walkCandidateDirs calls this concurrently.
 	var mu sync.Mutex
-	checkDir := func(dir string) bool {
-		otelDir := filepath.Join(dir, ".otel")
-		// Only bother with dedup and validation if .otel/ actually exists.
-		if _, err := os.Stat(otelDir); err != nil {
+	checkDir := func(dir string, entries []os.DirEntry) bool {
+		// Use entries (already read by walkCandidateDirs) to check for .otel/
+		// without an extra Stat syscall.
+		hasOtel := false
+		for _, e := range entries {
+			if e.Name() == ".otel" && e.IsDir() {
+				hasOtel = true
+				break
+			}
+		}
+		if !hasOtel {
 			return false
 		}
+		otelDir := filepath.Join(dir, ".otel")
 		key := otelDir
 		if resolved, err := filepath.EvalSymlinks(otelDir); err == nil {
 			key = resolved
@@ -224,7 +232,7 @@ func findNodeOtelDirs() []string {
 	// walkCandidateDirs recursively checks dir and its children (skipping the
 	// same ignored directories as scanProjectDirs).
 	walkCandidateDirs(cwd, 2, func(dir string, entries []os.DirEntry) bool {
-		checkDir(dir)
+		checkDir(dir, entries)
 		return false
 	}, isIgnoredDir)
 

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -223,7 +223,7 @@ func findNodeOtelDirs() []string {
 
 	// walkCandidateDirs recursively checks dir and its children (skipping the
 	// same ignored directories as scanProjectDirs).
-	walkCandidateDirs(cwd, 2, func(dir string) bool {
+	walkCandidateDirs(cwd, 2, func(dir string, entries []os.DirEntry) bool {
 		checkDir(dir)
 		return false
 	}, isIgnoredDir)

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
@@ -191,6 +192,8 @@ func findNodeOtelDirs() []string {
 	// Node.js OTel directory. Returns true if found (and appends to dirs).
 	// Deduplication uses the symlink-resolved path so that /tmp/.otel and
 	// /private/tmp/.otel (same directory on macOS) are not listed twice.
+	// mu guards dirs and seen since walkCandidateDirs calls this concurrently.
+	var mu sync.Mutex
 	checkDir := func(dir string) bool {
 		otelDir := filepath.Join(dir, ".otel")
 		// Only bother with dedup and validation if .otel/ actually exists.
@@ -201,13 +204,18 @@ func findNodeOtelDirs() []string {
 		if resolved, err := filepath.EvalSymlinks(otelDir); err == nil {
 			key = resolved
 		}
+		mu.Lock()
 		if seen[key] {
+			mu.Unlock()
 			return false
 		}
 		seen[key] = true
+		mu.Unlock()
 		if isNodeOtelDir(otelDir) {
 			logger.Debug("found Node.js .otel/ directory", "dir", otelDir)
+			mu.Lock()
 			dirs = append(dirs, otelDir)
+			mu.Unlock()
 			return true
 		}
 		return false


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Improves project detection speed and accuracy:
- Parallel directory scanning (bounded goroutine pool)
- Expanded skip list: Windows system dirs (`System32`, `AppData`, `$Recycle.Bin`, etc.) and `$`-prefixed folders
- Progress feedback when scanning 10k+ directories

## How to test

In all tests you don't need to actually instrument, focus on detected projects and speed of the detection

1. Run `dtwiz install otel` from a broad directory (e.g. C:/windows/system32) — should be fast (10s) and skip system dirs
2. Run `dtwiz install otel --project /path/to/node-app` — should detect Node.js runtime
3. Run `dtwiz install otel --project /path/to/java-app` — should detect Java runtime

## Which other features are affected?
1. `dtwiz uninstall otel` (uses same `walkCandidateDirs`)

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
