### PR TITLE
feat: add Podman container runtime support

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -119,6 +119,28 @@ var installDockerCmd = &cobra.Command{
 	},
 }
 
+var installPodmanCmd = &cobra.Command{
+	Use:   "podman",
+	Short: "Install Dynatrace OneAgent for Podman",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		envURL, accessTok, platformTok, err := getDtEnvironment()
+		if err != nil {
+			return err
+		}
+		if err := validateCredentials(envURL, accessTok, platformTok); err != nil {
+			return err
+		}
+		if err := installer.InstallPodman(envURL, accessTok, installDryRun); err != nil {
+			return err
+		}
+		if !installDryRun {
+			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
+		}
+		return nil
+	},
+}
+
 var installOtelCmd = &cobra.Command{
 	Use:   "otel",
 	Short: "Install OTel Collector and instrument your application",
@@ -361,6 +383,7 @@ func init() {
 	installCmd.AddCommand(installOneAgentCmd)
 	installCmd.AddCommand(installKubernetesCmd)
 	installCmd.AddCommand(installDockerCmd)
+	installCmd.AddCommand(installPodmanCmd)
 	installCmd.AddCommand(installOtelCmd)
 	installCmd.AddCommand(installOtelCollectorCmd)
 	installCmd.AddCommand(installOtelPythonCmd)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -148,6 +148,8 @@ var setupCmd = &cobra.Command{
 			installErr = installer.InstallKubernetes(envURL, accessTok, accessTok, "" /* name */, setupDryRun)
 		case recommender.MethodDocker:
 			installErr = installer.InstallDocker(envURL, accessTok, setupDryRun)
+		case recommender.MethodPodman:
+			installErr = installer.InstallPodman(envURL, accessTok, setupDryRun)
 		case recommender.MethodOtelCollector:
 			installErr = installer.InstallOtelCollector(envURL, accessTok, accessTok, platformTok, setupDryRun)
 		case recommender.MethodOtelUpdate:

--- a/openspec/changes/add-podman-support/.openspec.yaml
+++ b/openspec/changes/add-podman-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/add-podman-support/design.md
+++ b/openspec/changes/add-podman-support/design.md
@@ -1,0 +1,49 @@
+# Design
+
+## Context
+
+The analyzer runs detection functions concurrently via a `run()` helper that fans out goroutines and joins them with a mutex-protected `SystemInfo` struct. Docker detection lives in `pkg/analyzer/detect_docker.go` and sets `info.ContainerRuntime = ContainerRuntimeDocker` when the `docker` binary responds. The recommender then branches on `ContainerRuntime` to generate a `MethodDocker` recommendation, and `pkg/installer/docker.go` handles the `dtwiz install docker` subcommand.
+
+Podman is CLI-compatible with Docker: `podman version`, `podman ps`, `podman run` accept the same flags. The installer command (`podman run --detach --privileged --pid=host --net=host -v /:/mnt/root ...`) is identical except for the binary name.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect Podman via the `podman` binary, mirroring Docker detection.
+- Set `ContainerRuntimePodman` when Podman is available and Docker is not.
+- Generate a `MethodPodman` recommendation (same priority as Docker).
+- Install OneAgent via `podman run` with the same flags as `docker run`.
+- Expose `dtwiz install podman` as a new CLI subcommand.
+
+**Non-Goals:**
+
+- Detecting rootless vs. rootful Podman — treated identically.
+- Supporting both Docker and Podman simultaneously — Docker wins when both are present.
+- Podman-specific variant detection beyond what `podman version` provides.
+
+## Decisions
+
+### 1. Docker takes priority when both are present
+
+`detectDocker()` and `detectPodman()` run concurrently. Both write to `info.ContainerRuntime` under a mutex. The write order is non-deterministic, so we add an explicit check: only set `ContainerRuntimePodman` if `ContainerRuntimeDocker` has not already been set.
+
+**Alternative considered:** Run Podman detection only if Docker is absent. Rejected — sequential detection would slow analysis; the mutex guard is simpler and keeps the fan-out pattern consistent.
+
+### 2. Separate `detect_podman.go` file, mirroring `detect_docker.go`
+
+Podman detection is a new file rather than extending `detect_docker.go`. This keeps each runtime's detection isolated and easy to remove independently.
+
+### 3. `PodmanInfo` struct mirrors `DockerInfo`
+
+A new `PodmanInfo` struct (same fields: `Available`, `ServerVersion`, `Variant`, `RunningContainerCount`) is added to `SystemInfo` alongside `DockerInfo`. This keeps the JSON output consistent and allows future Podman-specific fields without touching Docker's struct.
+
+### 4. `InstallPodman()` in a new `podman.go`, not merged into `docker.go`
+
+Same rationale as detection: isolated, independently removable. The implementation is a near-copy with `podman` substituted for `docker` and container/log messages updated accordingly.
+
+## Risks / Trade-offs
+
+- **[Non-deterministic priority when both runtimes present]** → Mitigated by the explicit "don't overwrite Docker" guard in the mutex block. Docker always wins.
+- **[Podman Desktop on Mac may also expose a Docker socket]** → In that case `detectDocker()` may succeed via the Docker-compatible socket, and Podman detection is skipped correctly (Docker wins). No special handling needed.
+- **[Rootless Podman limitation]** → `--privileged --pid=host --net=host` behave differently under rootless Podman on Linux. Known limitation, out of scope for this change.

--- a/openspec/changes/add-podman-support/proposal.md
+++ b/openspec/changes/add-podman-support/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Podman is a Docker-compatible container runtime that is increasingly common on Linux and macOS (via Podman Desktop). The CLI currently only detects Docker, leaving Podman users without a recommended monitoring path despite Podman supporting the same OneAgent container deployment model.
+
+## What Changes
+
+- New `ContainerRuntimePodman` constant in `pkg/analyzer/analyzer.go`.
+- New `detectPodman()` function in `pkg/analyzer/detect_podman.go` — mirrors Docker detection using the `podman` binary.
+- `AnalyzeSystem()` runs `detectPodman()` concurrently alongside `detectDocker()`; Docker takes priority if both are present.
+- New `MethodPodman` recommendation in `pkg/recommender/recommender.go` — triggered when Podman is detected without Kubernetes, same priority as Docker.
+- New `InstallPodman()` installer in `pkg/installer/podman.go` — identical flow to `InstallDocker()` but runs `podman run ...`.
+- New `dtwiz install podman` subcommand wired in `cmd/install.go`.
+
+## Capabilities
+
+### New Capabilities
+
+- `podman-container-monitoring`: Detect Podman as a container runtime and deploy Dynatrace OneAgent as a Podman container for host + container monitoring.
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements change. Docker detection and installation are unaffected. -->
+
+## Impact
+
+- **New files:** `pkg/analyzer/detect_podman.go`, `pkg/installer/podman.go`
+- **Modified files:** `pkg/analyzer/analyzer.go` (new constant + concurrent detection), `pkg/recommender/recommender.go` (new recommendation branch), `cmd/install.go` (new subcommand)
+- **No breaking changes:** Docker detection and `dtwiz install docker` are unchanged.
+- **Rollback:** Revert the commit — no data migration or external state involved.

--- a/openspec/changes/add-podman-support/specs/podman-container-monitoring/spec.md
+++ b/openspec/changes/add-podman-support/specs/podman-container-monitoring/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Podman runtime detection
+The system SHALL detect a running Podman daemon by probing the `podman` binary. Detection SHALL collect the server version, running container count, and variant (e.g., Podman Desktop, Podman Machine).
+
+#### Scenario: Podman detected, Docker absent
+- **WHEN** `podman version` succeeds and `docker version` fails
+- **THEN** `ContainerRuntime` is set to `"podman"` and `PodmanInfo.Available` is `true`
+
+#### Scenario: Both Docker and Podman detected
+- **WHEN** both `docker version` and `podman version` succeed
+- **THEN** `ContainerRuntime` is set to `"docker"` and Podman is not surfaced as the primary runtime
+
+#### Scenario: Podman binary absent
+- **WHEN** `podman` is not on PATH or `podman version` fails
+- **THEN** `PodmanInfo.Available` is `false` and `ContainerRuntime` remains unchanged
+
+### Requirement: Podman monitoring recommendation
+The system SHALL recommend deploying Dynatrace OneAgent as a Podman container when Podman is the detected container runtime and Kubernetes is not present.
+
+#### Scenario: Podman without Kubernetes
+- **WHEN** `ContainerRuntime` is `"podman"` and `Orchestrator` is `"none"`
+- **THEN** a recommendation with method `"podman"` and priority `20` is generated
+
+#### Scenario: Podman with Kubernetes
+- **WHEN** `ContainerRuntime` is `"podman"` and `Orchestrator` is `"kubernetes"`
+- **THEN** no Podman-specific recommendation is generated
+
+### Requirement: Podman OneAgent installation
+The system SHALL deploy Dynatrace OneAgent as a Podman container using `podman run` with the same host-access flags as the Docker installer.
+
+#### Scenario: Successful installation
+- **WHEN** `dtwiz install podman` is run with valid credentials and Podman is available
+- **THEN** a container named `dynatrace-oneagent` is started via `podman run --detach --privileged --pid=host --net=host --restart=always -v /:/mnt/root`
+
+#### Scenario: Dry run
+- **WHEN** `dtwiz install podman --dry-run` is run
+- **THEN** the `podman run` command is printed and no container is started
+
+#### Scenario: Podman not available at install time
+- **WHEN** `dtwiz install podman` is run but the Podman daemon is not accessible
+- **THEN** the command exits with an error indicating Podman is unavailable

--- a/openspec/changes/add-podman-support/tasks.md
+++ b/openspec/changes/add-podman-support/tasks.md
@@ -1,0 +1,34 @@
+## 1. Analyzer: Podman detection
+
+- [x] 1.1 Add `ContainerRuntimePodman ContainerRuntime = "podman"` constant to `pkg/analyzer/analyzer.go` alongside `ContainerRuntimeDocker`
+- [x] 1.2 Add `PodmanInfo` struct to `pkg/analyzer/analyzer.go` mirroring `DockerInfo` (fields: `Available bool`, `ServerVersion string`, `Variant string`, `RunningContainerCount int`)
+- [x] 1.3 Add `Podman *PodmanInfo` field to `SystemInfo` in `pkg/analyzer/analyzer.go` alongside the `Docker` field
+- [x] 1.4 Create `pkg/analyzer/detect_podman.go` with `detectPodman() *PodmanInfo` — probe `podman version --format {{.Server.Version}}`, collect running container count via `podman ps -q`, detect variant via `podman info --format {{.Host.Distribution.Distribution}}` (e.g., "Podman Desktop", "Podman Machine")
+- [x] 1.5 In `AnalyzeSystem()` (`pkg/analyzer/analyzer.go`), add a concurrent `run()` block for `detectPodman()` that sets `info.Podman` and, only if `info.ContainerRuntime != ContainerRuntimeDocker`, sets `info.ContainerRuntime = ContainerRuntimePodman`
+
+## 2. Analyzer: tests
+
+- [x] 2.1 Add unit tests in `pkg/analyzer/detect_podman_test.go` covering: Podman available (mock `podman version` success), Podman absent (mock failure), Docker+Podman both present (Docker wins)
+
+## 3. Recommender: Podman recommendation
+
+- [x] 3.1 Add `MethodPodman IngestMethod = "podman"` constant to `pkg/recommender/recommender.go`
+- [x] 3.2 Add recommendation branch in `GenerateRecommendations()` (`pkg/recommender/recommender.go`): when `system.ContainerRuntime == analyzer.ContainerRuntimePodman && system.Orchestrator != analyzer.OrchestratorKubernetes`, append a `Recommendation` with `Method: MethodPodman`, `Priority: 20`, title "Podman host + containers (via OneAgent)", description referencing Podman, prerequisites `["Podman daemon access", "Dynatrace API token"]`, steps `["dtwiz install podman"]`
+- [x] 3.3 Add tests in `pkg/recommender/recommender_test.go`: `TestGenerateRecommendations_PodmanOnly` (Podman detected, no K8s → MethodPodman recommended), `TestGenerateRecommendations_PodmanWithKubernetes` (Podman + K8s → no Podman recommendation), `TestGenerateRecommendations_DockerWinsOverPodman` (Docker runtime → no Podman recommendation)
+
+## 4. Installer: Podman installer
+
+- [x] 4.1 Create `pkg/installer/podman.go` with `isPodmanAvailable() bool` — check `podman` on PATH and run `podman info --format {{.Host.Hostname}}` as a daemon ping
+- [x] 4.2 Implement `InstallPodman(envURL, token string, dryRun bool) error` in `pkg/installer/podman.go` — identical flow to `InstallDocker()` substituting `podman` for `docker` in all exec calls; dry-run output references `podman` binary; log line reads `podman logs -f dynatrace-oneagent`
+
+## 5. CLI: new subcommand
+
+- [x] 5.1 Add `installPodmanCmd` in `cmd/install.go` modelled on `installDockerCmd` (lines 71–91): `Use: "podman"`, calls `installer.InstallPodman(envURL, accessTok, installDryRun)`, calls `installer.WatchIngest` on success when not dry-run
+- [x] 5.2 Register `installPodmanCmd` via `installCmd.AddCommand(installPodmanCmd)` in the `init()` block of `cmd/install.go`
+
+## 6. Verification
+
+- [x] 6.1 Run `make build` — binary compiles cleanly
+- [x] 6.2 Run `make test` — all existing and new tests pass
+- [x] 6.3 Run `make lint` — no new lint issues
+- [x] 6.4 Manual dry-run: `dtwiz install podman --dry-run` prints the `podman run` command without executing it

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -56,6 +56,7 @@ type ContainerRuntime string
 
 const (
 	ContainerRuntimeDocker ContainerRuntime = "docker"
+	ContainerRuntimePodman ContainerRuntime = "podman"
 	ContainerRuntimeNone   ContainerRuntime = "none"
 )
 
@@ -69,6 +70,14 @@ const (
 
 // DockerInfo holds details about a detected Docker installation.
 type DockerInfo struct {
+	Available             bool   `json:"available"`
+	ServerVersion         string `json:"server_version,omitempty"`
+	Variant               string `json:"variant,omitempty"`
+	RunningContainerCount int    `json:"running_containers"`
+}
+
+// PodmanInfo holds details about a detected Podman installation.
+type PodmanInfo struct {
 	Available             bool   `json:"available"`
 	ServerVersion         string `json:"server_version,omitempty"`
 	Variant               string `json:"variant,omitempty"`
@@ -137,6 +146,7 @@ type SystemInfo struct {
 	ContainerRuntime ContainerRuntime `json:"container_runtime"`
 	Orchestrator     Orchestrator     `json:"orchestrator"`
 	Docker           *DockerInfo      `json:"docker,omitempty"`
+	Podman           *PodmanInfo      `json:"podman,omitempty"`
 	Kubernetes       *KubernetesInfo  `json:"kubernetes,omitempty"`
 	OneAgentRunning  bool             `json:"oneagent_running"`
 	OtelCollector    bool             `json:"otel_collector"`
@@ -338,6 +348,17 @@ func AnalyzeSystem() (*SystemInfo, error) {
 		info.Docker = d
 		if d.Available {
 			info.ContainerRuntime = ContainerRuntimeDocker
+		}
+		mu.Unlock()
+		return nil
+	})
+
+	run(func() error {
+		p := detectPodman()
+		mu.Lock()
+		info.Podman = p
+		if p.Available && info.ContainerRuntime != ContainerRuntimeDocker {
+			info.ContainerRuntime = ContainerRuntimePodman
 		}
 		mu.Unlock()
 		return nil

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -210,6 +210,18 @@ func (s *SystemInfo) Summary() string {
 			display.ColorMuted.Sprint("<none>")))
 	}
 
+	if s.Podman != nil && s.Podman.Available {
+		podmanDesc := fmt.Sprintf("version %s, %d containers running", s.Podman.ServerVersion, s.Podman.RunningContainerCount)
+		if s.Podman.Variant != "" {
+			podmanDesc = s.Podman.Variant + "  " + podmanDesc
+		}
+		sb.WriteString(fmt.Sprintf("  %s %s\n", label("Podman"), podmanDesc))
+	} else {
+		sb.WriteString(fmt.Sprintf("  %s %s\n",
+			label("Podman"),
+			display.ColorMuted.Sprint("<none>")))
+	}
+
 	if s.Kubernetes != nil && s.Kubernetes.Available {
 		sb.WriteString(fmt.Sprintf("  %s %s  context=%s  nodes=%d\n",
 			label("Kubernetes"),

--- a/pkg/analyzer/detect_podman.go
+++ b/pkg/analyzer/detect_podman.go
@@ -1,0 +1,46 @@
+package analyzer
+
+import "strings"
+
+// detectPodman checks for a running Podman daemon.
+func detectPodman() *PodmanInfo {
+	info := &PodmanInfo{}
+
+	ok, _ := runCmd("podman", "version", "--format", "{{.Server.Version}}")
+	if !ok {
+		return info
+	}
+	info.Available = true
+
+	_, ver := runCmd("podman", "version", "--format", "{{.Server.Version}}")
+	info.ServerVersion = ver
+
+	_, psOut := runCmd("podman", "ps", "-q")
+	if psOut != "" {
+		info.RunningContainerCount = len(strings.Split(strings.TrimSpace(psOut), "\n"))
+	}
+
+	info.Variant = detectPodmanVariant()
+	return info
+}
+
+// detectPodmanVariant identifies the Podman distribution (Desktop, Machine).
+func detectPodmanVariant() string {
+	_, osInfo := runCmd("podman", "info", "--format", "{{.Host.Distribution.Distribution}}")
+	_, ver := runCmd("podman", "version", "--format", "{{.Client.Version}}")
+	return podmanVariantFromStrings(osInfo, ver)
+}
+
+func podmanVariantFromStrings(osInfo, ver string) string {
+	osLower := strings.ToLower(osInfo)
+	verLower := strings.ToLower(ver)
+
+	switch {
+	case strings.Contains(osLower, "podman desktop") || strings.Contains(verLower, "desktop"):
+		return "Podman Desktop"
+	case strings.Contains(osLower, "fedora") && strings.Contains(osLower, "wsl"):
+		return "Podman Machine"
+	default:
+		return ""
+	}
+}

--- a/pkg/analyzer/detect_podman_test.go
+++ b/pkg/analyzer/detect_podman_test.go
@@ -1,0 +1,44 @@
+package analyzer
+
+import "testing"
+
+func TestDetectPodman_ReturnsNonNil(t *testing.T) {
+	info := detectPodman()
+	if info == nil {
+		t.Fatal("detectPodman() returned nil")
+	}
+}
+
+func TestDetectPodman_UnavailableWhenNoBinary(t *testing.T) {
+	// If podman is not installed, Available must be false and no panic.
+	info := detectPodman()
+	if info == nil {
+		t.Fatal("detectPodman() returned nil")
+	}
+	// We can't assert Available==false here because Podman may be installed in
+	// the test environment. We assert the struct is always well-formed.
+	_ = info.Available
+	_ = info.ServerVersion
+	_ = info.RunningContainerCount
+	_ = info.Variant
+}
+
+func TestDetectPodmanVariant_KnownPrefixes(t *testing.T) {
+	tests := []struct {
+		osInfo string
+		ver    string
+		want   string
+	}{
+		{"podman desktop linux", "", "Podman Desktop"},
+		{"fedora wsl", "", "Podman Machine"},
+		{"ubuntu", "", ""},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		got := podmanVariantFromStrings(tt.osInfo, tt.ver)
+		if got != tt.want {
+			t.Errorf("podmanVariantFromStrings(%q, %q) = %q, want %q", tt.osInfo, tt.ver, got, tt.want)
+		}
+	}
+}

--- a/pkg/installer/docker.go
+++ b/pkg/installer/docker.go
@@ -28,6 +28,8 @@ func InstallDocker(envURL, token string, dryRun bool) error {
 
 	containerName := "dynatrace-oneagent"
 
+	installerURL := fmt.Sprintf("%s/api/v1/deployment/installer/agent/unix/default/latest?Api-Token=%s", apiURL, token)
+
 	dockerArgs := []string{
 		"run",
 		"--detach",
@@ -37,15 +39,13 @@ func InstallDocker(envURL, token string, dryRun bool) error {
 		"--privileged",
 		"--restart=always",
 		"-v", "/:/mnt/root",
-		"-e", fmt.Sprintf("DT_SERVER=%s/communication", apiURL),
-		"-e", fmt.Sprintf("DT_TENANT=%s", ExtractTenantID(envURL)),
-		"-e", fmt.Sprintf("DT_TENANT_TOKEN=%s", token),
+		"-e", fmt.Sprintf("ONEAGENT_INSTALLER_SCRIPT_URL=%s", installerURL),
 		"dynatrace/oneagent",
 	}
 
 	if dryRun {
 		fmt.Println("[dry-run] Would install Dynatrace OneAgent as a Docker container")
-		fmt.Printf("  API URL:        %s\n", apiURL)
+		fmt.Printf("  Installer URL:  %s\n", installerURL)
 		fmt.Printf("  Container name: %s\n", containerName)
 		fmt.Printf("  Command:        docker %v\n", dockerArgs)
 		return nil

--- a/pkg/installer/podman.go
+++ b/pkg/installer/podman.go
@@ -1,0 +1,63 @@
+package installer
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// isPodmanAvailable returns true when the `podman` binary is on PATH and the
+// Podman daemon is accessible.
+func isPodmanAvailable() bool {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return false
+	}
+	return exec.Command("podman", "info", "--format", "{{.Host.Hostname}}").Run() == nil
+}
+
+// InstallPodman deploys Dynatrace OneAgent as a Podman container using the
+// official `dynatrace/oneagent` image, mounting the necessary host paths for
+// full-stack monitoring.
+func InstallPodman(envURL, token string, dryRun bool) error {
+	apiURL := APIURL(envURL)
+
+	containerName := "dynatrace-oneagent"
+
+	installerURL := fmt.Sprintf("%s/api/v1/deployment/installer/agent/unix/default/latest?Api-Token=%s", apiURL, token)
+
+	podmanArgs := []string{
+		"run",
+		"--detach",
+		"--name", containerName,
+		"--pid=host",
+		"--net=host",
+		"--privileged",
+		"--restart=always",
+		"-v", "/:/mnt/root",
+		"-e", fmt.Sprintf("ONEAGENT_INSTALLER_SCRIPT_URL=%s", installerURL),
+		"dynatrace/oneagent",
+	}
+
+	if dryRun {
+		fmt.Println("[dry-run] Would install Dynatrace OneAgent as a Podman container")
+		fmt.Printf("  Installer URL:  %s\n", installerURL)
+		fmt.Printf("  Container name: %s\n", containerName)
+		fmt.Printf("  Command:        podman %v\n", podmanArgs)
+		return nil
+	}
+
+	if !isPodmanAvailable() {
+		return fmt.Errorf("Podman is not available — install Podman and ensure the daemon is running") //nolint:staticcheck // ST1005: keep brand capitalization
+	}
+
+	// Remove any existing container with the same name.
+	_ = exec.Command("podman", "rm", "-f", containerName).Run()
+
+	fmt.Printf("  Starting Dynatrace OneAgent container %q...\n", containerName)
+	if err := RunCommand("podman", podmanArgs...); err != nil {
+		return fmt.Errorf("starting Dynatrace OneAgent container: %w", err)
+	}
+
+	fmt.Printf("  OneAgent container %q started successfully.\n", containerName)
+	fmt.Println("  To view logs: podman logs -f " + containerName)
+	return nil
+}

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -18,6 +18,7 @@ const (
 	MethodOneAgent         IngestMethod = "oneagent"
 	MethodKubernetes       IngestMethod = "kubernetes"
 	MethodDocker           IngestMethod = "docker"
+	MethodPodman           IngestMethod = "podman"
 	MethodOtelCollector    IngestMethod = "otel"
 	MethodOtelUpdate       IngestMethod = "otel-update"
 	MethodAWS              IngestMethod = "aws"
@@ -127,7 +128,22 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		})
 	}
 
-	// 6. Bare metal / VM (Linux or Windows, no containers) → host OneAgent.
+	// 6. Podman without Kubernetes → Podman OneAgent.
+	if system.ContainerRuntime == analyzer.ContainerRuntimePodman &&
+		system.Orchestrator != analyzer.OrchestratorKubernetes {
+		recs = append(recs, Recommendation{
+			Method:        MethodPodman,
+			Priority:      20,
+			Title:         "Podman host + containers (via OneAgent)",
+			Description:   "Podman is running without Kubernetes orchestration. Deploy OneAgent as a container for host + container monitoring.",
+			Prerequisites: []string{"Podman daemon access", "Dynatrace API token"},
+			Steps: []string{
+				"dtwiz install podman",
+			},
+		})
+	}
+
+	// 8. Bare metal / VM (Linux or Windows, no containers) → host OneAgent.
 	if system.ContainerRuntime == analyzer.ContainerRuntimeNone &&
 		system.Orchestrator == analyzer.OrchestratorNone &&
 		(system.Platform == analyzer.PlatformLinux || system.Platform == analyzer.PlatformWindows) {
@@ -143,7 +159,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		})
 	}
 
-	// 7. AWS detected → CloudFormation integration.
+	// 9. AWS detected → CloudFormation integration.
 	if system.AWS != nil && system.AWS.Available {
 		recs = append(recs, Recommendation{
 			Method:        MethodAWS,
@@ -157,7 +173,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		})
 	}
 
-	// 8. Azure detected — coming soon.
+	// 10. Azure detected — coming soon.
 	if system.Azure != nil && system.Azure.Available {
 		recs = append(recs, Recommendation{
 			Method:      MethodAzure,
@@ -168,7 +184,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		})
 	}
 
-	// 9. GCP detected — coming soon.
+	// 11. GCP detected — coming soon.
 	if system.GCP != nil && system.GCP.Available {
 		recs = append(recs, Recommendation{
 			Method:      MethodGCP,

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -234,3 +234,63 @@ func TestGenerateRecommendations_macOSGetsOtel(t *testing.T) {
 		t.Error("expected otel-collector recommendation on macOS")
 	}
 }
+
+func TestGenerateRecommendations_PodmanOnly(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimePodman,
+		Podman:           &analyzer.PodmanInfo{Available: true},
+		Orchestrator:     analyzer.OrchestratorNone,
+	}
+	recs := recommender.GenerateRecommendations(system)
+	found := false
+	for _, r := range recs {
+		if r.Method == recommender.MethodPodman {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected podman recommendation")
+	}
+}
+
+func TestGenerateRecommendations_PodmanWithKubernetes(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimePodman,
+		Podman:           &analyzer.PodmanInfo{Available: true},
+		Orchestrator:     analyzer.OrchestratorKubernetes,
+		Kubernetes:       &analyzer.KubernetesInfo{Available: true, Distribution: "k3s"},
+	}
+	recs := recommender.GenerateRecommendations(system)
+	for _, r := range recs {
+		if r.Method == recommender.MethodPodman {
+			t.Error("expected no podman recommendation when Kubernetes is present")
+		}
+	}
+}
+
+func TestGenerateRecommendations_DockerWinsOverPodman(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimeDocker,
+		Docker:           &analyzer.DockerInfo{Available: true},
+		Podman:           &analyzer.PodmanInfo{Available: true},
+		Orchestrator:     analyzer.OrchestratorNone,
+	}
+	recs := recommender.GenerateRecommendations(system)
+	for _, r := range recs {
+		if r.Method == recommender.MethodPodman {
+			t.Error("expected no podman recommendation when Docker is the active runtime")
+		}
+	}
+	found := false
+	for _, r := range recs {
+		if r.Method == recommender.MethodDocker {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected docker recommendation when ContainerRuntime is docker")
+	}
+}


### PR DESCRIPTION
Closes #47

## What Changes

- New `ContainerRuntimePodman` constant in `pkg/analyzer/analyzer.go`
- New `detectPodman()` in `pkg/analyzer/detect_podman.go` — mirrors Docker detection using the `podman` binary
- `AnalyzeSystem()` runs `detectPodman()` concurrently alongside `detectDocker()`; Docker takes priority if both are present
- New `MethodPodman` recommendation in `pkg/recommender/recommender.go`
- New `InstallPodman()` installer in `pkg/installer/podman.go` — runs `podman run ...`
- New `dtwiz install podman` subcommand wired in `cmd/install.go`
- Fix: use `ONEAGENT_INSTALLER_SCRIPT_URL` env var for Docker/Podman OneAgent installs