### PR TITLE
fix(k8s-dt-operator): update the operator to the nightly build

### DIFF
--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -134,7 +134,8 @@ func helmOperatorArgs(helmMajor int) []string {
 	}
 	return []string{
 		"install", "dynatrace-operator",
-		"oci://public.ecr.aws/dynatrace/dynatrace-operator",
+		"oci://ghcr.io/dynatrace/dynatrace-operator",
+		"--version", "0.0.0-nightly-chart",
 		"--create-namespace",
 		"--namespace", "dynatrace",
 		rollbackFlag,
@@ -150,7 +151,8 @@ func helmOperatorUpgradeArgs(helmMajor int) []string {
 	}
 	return []string{
 		"upgrade", "dynatrace-operator",
-		"oci://public.ecr.aws/dynatrace/dynatrace-operator",
+		"oci://ghcr.io/dynatrace/dynatrace-operator",
+		"--version", "0.0.0-nightly-chart",
 		"--namespace", "dynatrace",
 		rollbackFlag,
 	}


### PR DESCRIPTION
## Bug Fix Description

The dynatrace-operator URL is now updated to use the nightly build as opposed to the public dynatrace-operator.

## Root cause

Currently platform tokens still don't work with the public dynatrace-operator, although in a few weeks it'll be deployed and we'll be able to revert this change.

## How to reproduce
1. Run `dtwiz install kubernetes` with the old URL on an AKS cluster: you'll see failures and warnings in pod initialization.

## How to test
1. Run `dtwiz install kubernetes` now with the same cluster, make sure that there's no warnings appearing during pod initialization.

## Which other features are affected?
N/A

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
