### PR TITLE
chore: check if Python exists before listing projects

### DIFF
--- a/pkg/installer/demo_test.go
+++ b/pkg/installer/demo_test.go
@@ -45,6 +45,7 @@ func TestConfirmProceedAutoConfirm(t *testing.T) {
 func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 	dir := t.TempDir()
 	setTestWorkingDir(t, dir)
+	setTestStdin(t, "y\n")
 
 	output := captureStdout(t, func() {
 		err := InstallOtelCollectorWithProject(

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -96,7 +96,7 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 		}
 		// Python's binary may exist as a non-functional stub even when no real
 		// interpreter is installed, so run it to verify it's usable.
-		available := true
+		var available bool
 		if rt.binName == "python3" || rt.binName == "python" {
 			_, err := detectPython()
 			available = err == nil

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -83,6 +83,8 @@ func detectGoRuntimeProjects() []detectedProject {
 	return detected
 }
 
+// detectAllProjects filters runtimes to those with a usable binary and scans
+// for projects in parallel across all enabled runtimes.
 func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 	type result struct {
 		projects []detectedProject
@@ -241,12 +243,12 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
 	fmt.Println()
 
+	runtimes := detectAvailableRuntimes()
+
 	cp, err := prepareCollectorPlan(envURL, token)
 	if err != nil {
 		return err
 	}
-
-	runtimes := detectAvailableRuntimes()
 
 	var plan InstrumentationPlan
 	if projectPath != "" {
@@ -282,25 +284,23 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 		plan = createRuntimePlan(proj, cp.apiURL, token, envURL, platformToken)
 	} else {
 		projects := detectAllProjects(runtimes)
-		if len(projects) > 0 {
-			for {
-				display.ColorMessage.Println("  Detected projects:")
-				display.PrintSectionDivider()
-				printProjectList(projects)
+		for {
+			display.ColorMessage.Println("  Detected projects:")
+			display.PrintSectionDivider()
+			printProjectList(projects)
 
-				selected, ok := selectProject(projects)
-				if !ok {
-					break
-				}
-				plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
-				if plan != nil {
-					break
-				}
-				// Project can't be auto-instrumented; ask if the user wants to try another.
-				again, err := confirmProceed("  Select another project?")
-				if err != nil || !again {
-					break
-				}
+			selected, ok := selectProject(projects)
+			if !ok {
+				break
+			}
+			plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
+			if plan != nil {
+				break
+			}
+			// Project can't be auto-instrumented; ask if the user wants to try another.
+			again, err := confirmProceed("  Select another project?")
+			if err != nil || !again {
+				break
 			}
 		}
 	}

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -94,7 +94,17 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 			logger.Debug("skipping runtime (disabled)", "runtime", rt.name)
 			continue
 		}
-		if _, err := exec.LookPath(rt.binName); err != nil {
+		// Python's binary may exist as a non-functional stub even when no real
+		// interpreter is installed, so run it to verify it's usable.
+		available := true
+		if rt.binName == "python3" || rt.binName == "python" {
+			_, err := detectPython()
+			available = err == nil
+		} else {
+			_, err := exec.LookPath(rt.binName)
+			available = err == nil
+		}
+		if !available {
 			fmt.Printf("  Skipping %s instrumentation — '%s' not found on PATH.\n", rt.name, rt.binName)
 			continue
 		}

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -141,9 +141,6 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 }
 
 func printProjectList(projects []detectedProject) {
-	if len(projects) == 0 {
-		fmt.Println("  No projects detected.")
-	}
 	for i, p := range projects {
 		line := fmt.Sprintf("  [%d]  %s  %s  (%s)", i+1, p.Runtime, p.Path, strings.Join(p.Markers, ", "))
 		if len(p.RunningProcessIDs) > 0 {
@@ -281,23 +278,34 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 		plan = createRuntimePlan(proj, cp.apiURL, token, envURL, platformToken)
 	} else {
 		projects := detectAllProjects(runtimes)
-		for {
-			display.ColorMessage.Println("  Detected projects:")
-			display.PrintSectionDivider()
-			printProjectList(projects)
+		if len(projects) == 0 {
+			fmt.Println("  No projects detected.")
+			cont, err := confirmProceed("  Continue installation?")
+			if err != nil {
+				return fmt.Errorf("reading confirmation: %w", err)
+			}
+			if !cont {
+				return ErrInstallCancelled
+			}
+		} else {
+			for {
+				display.ColorMessage.Println("  Detected projects:")
+				display.PrintSectionDivider()
+				printProjectList(projects)
 
-			selected, ok := selectProject(projects)
-			if !ok {
-				break
-			}
-			plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
-			if plan != nil {
-				break
-			}
-			// Project can't be auto-instrumented; ask if the user wants to try another.
-			again, err := confirmProceed("  Select another project?")
-			if err != nil || !again {
-				break
+				selected, ok := selectProject(projects)
+				if !ok {
+					break
+				}
+				plan = createRuntimePlan(selected, cp.apiURL, token, envURL, platformToken)
+				if plan != nil {
+					break
+				}
+				// Project can't be auto-instrumented; ask if the user wants to try another.
+				again, err := confirmProceed("  Select another project?")
+				if err != nil || !again {
+					break
+				}
 			}
 		}
 	}

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -254,6 +254,21 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 		if runtime == "" {
 			return fmt.Errorf("could not detect runtime from project path: %s", projectPath)
 		}
+		// Verify the runtime binary is actually available before proceeding.
+		switch runtime {
+		case "Python":
+			if _, err := detectPython(); err != nil {
+				return fmt.Errorf("Python runtime not available: %w", err)
+			}
+		case "Java":
+			if _, err := exec.LookPath("java"); err != nil {
+				return fmt.Errorf("Java runtime not available: 'java' not found on PATH")
+			}
+		case "Node.js":
+			if _, err := exec.LookPath("node"); err != nil {
+				return fmt.Errorf("Node.js runtime not available: 'node' not found on PATH")
+			}
+		}
 		projects := []ScannedProject{{Path: projectPath}}
 		switch runtime {
 		case "Java":

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -256,21 +256,6 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 		if runtime == "" {
 			return fmt.Errorf("could not detect runtime from project path: %s", projectPath)
 		}
-		// Verify the runtime binary is actually available before proceeding.
-		switch runtime {
-		case "Python":
-			if _, err := detectPython(); err != nil {
-				return fmt.Errorf("Python runtime not available: %w", err)
-			}
-		case "Java":
-			if _, err := exec.LookPath("java"); err != nil {
-				return fmt.Errorf("Java runtime not available: 'java' not found on PATH")
-			}
-		case "Node.js":
-			if _, err := exec.LookPath("node"); err != nil {
-				return fmt.Errorf("Node.js runtime not available: 'node' not found on PATH")
-			}
-		}
 		projects := []ScannedProject{{Path: projectPath}}
 		switch runtime {
 		case "Java":

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -99,15 +99,24 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 		// Python's binary may exist as a non-functional stub even when no real
 		// interpreter is installed, so run it to verify it's usable.
 		var available bool
+		var stubOnly bool
 		if rt.binName == "python3" || rt.binName == "python" {
 			_, err := detectPython()
 			available = err == nil
+			if !available {
+				_, lookErr := exec.LookPath(rt.binName)
+				stubOnly = lookErr == nil // binary found but not usable
+			}
 		} else {
 			_, err := exec.LookPath(rt.binName)
 			available = err == nil
 		}
 		if !available {
-			fmt.Printf("  Skipping %s instrumentation — '%s' not found on PATH.\n", rt.name, rt.binName)
+			if stubOnly {
+				fmt.Printf("  Skipping %s instrumentation — '%s' found on PATH but not usable.\n", rt.name, rt.binName)
+			} else {
+				fmt.Printf("  Skipping %s instrumentation — '%s' not found on PATH.\n", rt.name, rt.binName)
+			}
 			continue
 		}
 		active = append(active, rt)
@@ -132,6 +141,9 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 }
 
 func printProjectList(projects []detectedProject) {
+	if len(projects) == 0 {
+		fmt.Println("  No projects detected.")
+	}
 	for i, p := range projects {
 		line := fmt.Sprintf("  [%d]  %s  %s  (%s)", i+1, p.Runtime, p.Path, strings.Join(p.Markers, ", "))
 		if len(p.RunningProcessIDs) > 0 {

--- a/pkg/installer/otel_python.go
+++ b/pkg/installer/otel_python.go
@@ -76,7 +76,12 @@ func DetectPythonPlanFromPath(projectPath, apiURL, token string) *PythonInstrume
 	if _, err := detectPython(); err != nil {
 		return nil
 	}
+	return detectPythonPlanWithConfirmedRuntime(projectPath, apiURL, token)
+}
 
+// detectPythonPlanWithConfirmedRuntime builds the plan assuming Python is already confirmed usable.
+// Call this when detectPython() or validatePythonPrerequisites() has already run in the same invocation.
+func detectPythonPlanWithConfirmedRuntime(projectPath, apiURL, token string) *PythonInstrumentationPlan {
 	if projectPath != "" {
 		projects := []ScannedProject{{Path: projectPath}}
 		processes := detectPythonProcesses()
@@ -286,7 +291,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 			return fmt.Errorf("project path not found: %s", projectPath)
 		}
 	}
-	if err := validatePythonPrerequisites(); err != nil {
+	if _, err := validatePythonPrerequisites(); err != nil {
 		return err
 	}
 
@@ -318,7 +323,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 	display.ColorMessage.Println("  Dynatrace Python Auto-Instrumentation")
 	fmt.Println("  " + sep)
 
-	plan := DetectPythonPlanFromPath(projectPath, apiURL, token)
+	plan := detectPythonPlanWithConfirmedRuntime(projectPath, apiURL, token)
 	if plan == nil {
 		printManualInstructions(envVars)
 		return nil

--- a/pkg/installer/otel_python_venv.go
+++ b/pkg/installer/otel_python_venv.go
@@ -36,23 +36,23 @@ func detectPython() (string, error) {
 	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH") //nolint:staticcheck // ST1005: keep brand capitalization
 }
 
-func validatePythonPrerequisites() error {
+func validatePythonPrerequisites() (string, error) {
 	pythonBin, err := detectPython()
 	if err != nil {
-		return err
+		return "", err
 	}
 	logger.Debug("validating python prerequisites", "python", pythonBin)
 	if out, err := exec.Command(pythonBin, "-m", "pip", "--version").CombinedOutput(); err != nil {
 		logger.Debug("python pip check failed", "python", pythonBin, "output", strings.TrimSpace(string(out)), "error", err)
-		return fmt.Errorf("pip is not available for the detected Python 3 interpreter (%s): %w\n    %s", pythonBin, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("pip is not available for the detected Python 3 interpreter (%s): %w\n    %s", pythonBin, err, strings.TrimSpace(string(out)))
 	}
 	logger.Debug("python pip check succeeded", "python", pythonBin)
 	if out, err := exec.Command(pythonBin, "-m", "venv", "--help").CombinedOutput(); err != nil {
 		logger.Debug("python venv check failed", "python", pythonBin, "output", strings.TrimSpace(string(out)), "error", err)
-		return fmt.Errorf("venv module is not available for the detected Python 3 interpreter (%s) — on Debian/Ubuntu run: apt install python3-venv: %w\n    %s", pythonBin, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("venv module is not available for the detected Python 3 interpreter (%s) — on Debian/Ubuntu run: apt install python3-venv: %w\n    %s", pythonBin, err, strings.TrimSpace(string(out)))
 	}
 	logger.Debug("python venv check succeeded", "python", pythonBin)
-	return nil
+	return pythonBin, nil
 }
 
 func resolveVenvBinary(projectPath, name string) string {

--- a/pkg/installer/otel_python_venv_test.go
+++ b/pkg/installer/otel_python_venv_test.go
@@ -11,7 +11,7 @@ import (
 func TestValidatePythonPrerequisites_PythonNotFound(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
-	err := validatePythonPrerequisites()
+	_, err := validatePythonPrerequisites()
 	if err == nil || !strings.Contains(err.Error(), "Python 3") {
 		t.Fatalf("expected Python 3 error, got %v", err)
 	}
@@ -22,7 +22,7 @@ func TestValidatePythonPrerequisites_PipNotFound(t *testing.T) {
 	t.Setenv("PATH", pythonDir)
 	t.Setenv("DTWIZ_TEST_FAIL_PIP", "1")
 
-	err := validatePythonPrerequisites()
+	_, err := validatePythonPrerequisites()
 	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "pip") {
 		t.Fatalf("expected pip error, got %v", err)
 	}
@@ -33,7 +33,7 @@ func TestValidatePythonPrerequisites_VenvNotFound(t *testing.T) {
 	t.Setenv("PATH", pythonDir)
 	t.Setenv("DTWIZ_TEST_FAIL_VENV", "1")
 
-	err := validatePythonPrerequisites()
+	_, err := validatePythonPrerequisites()
 	if err == nil {
 		t.Fatal("expected venv error, got nil")
 	}
@@ -49,7 +49,7 @@ func TestValidatePythonPrerequisites_AllPresent(t *testing.T) {
 	pythonDir := requireFakePython3(t)
 	t.Setenv("PATH", pythonDir)
 
-	if err := validatePythonPrerequisites(); err != nil {
+	if _, err := validatePythonPrerequisites(); err != nil {
 		t.Fatalf("validatePythonPrerequisites() error = %v", err)
 	}
 }

--- a/pkg/installer/otel_test.go
+++ b/pkg/installer/otel_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -313,6 +314,28 @@ func TestDetectAllProjects_SkipsDisabled(t *testing.T) {
 	projects := detectAllProjects(runtimes)
 	if len(projects) != 0 {
 		t.Errorf("expected 0 projects when all runtimes are disabled, got %d: %v", len(projects), projects)
+	}
+}
+
+// TestDetectAllProjects_SkipsPythonStub verifies that a python3 binary on PATH
+// that does not output "Python 3.x" (e.g. a Windows Store stub that exits
+// silently) is treated as unavailable and excluded from the active runtimes.
+func TestDetectAllProjects_SkipsPythonStub(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based stubs only work on Unix")
+	}
+	dir := t.TempDir()
+	// A stub that exists on PATH but produces no output — simulates the Windows
+	// Store App Execution Alias behaviour in a non-interactive subprocess.
+	createStubFile(t, filepath.Join(dir, "python3"), "#!/bin/sh\nexit 0\n", 0o755)
+	t.Setenv("PATH", dir)
+
+	runtimes := []runtimeInfo{
+		{name: "Python", binName: "python3", enabled: true, detect: detectPythonRuntimeProjects},
+	}
+	projects := detectAllProjects(runtimes)
+	if len(projects) != 0 {
+		t.Errorf("expected Python to be skipped when stub produces no version output, got %d project(s)", len(projects))
 	}
 }
 


### PR DESCRIPTION
## Description

- [x] Bug fix

On Windows, `python3`or `python` may appear on PATH but is not a real interpreter. `dtwiz install otel` was using `exec.LookPath` to check for Python availability, which finds the stub and silently treats Python as available.

**Changes:**
- Replace `exec.LookPath` with `detectPython()` for Python availability in `detectAllProjects` — actually runs the interpreter and checks for `Python 3.x` output, catching non-functional stubs
- Remove the `if len(projects) > 0` guard around the project selection loop so it always runs — when no runtimes are installed the user sees the list with `[1] Skip` instead of being silently dropped into a collector-only install

## How to test
1. On Windows with no Python installed (Store stub present): run `dtwiz install otel` — confirm "Skipping Python" appears and the project selection loop is shown
2. Remove all supported runtimes from PATH and run `dtwiz install otel` — confirm the project selection loop is shown with `[1] Skip`

## Which other features are affected?
None.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.