### PR TITLE
feat: extend distribution detection

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -104,7 +104,7 @@ var installKubernetesCmd = &cobra.Command{
 		k8sInfo := analyzer.DetectKubernetes()
 		clusterName := ""
 		distro := ""
-		if k8sInfo != nil {
+		if k8sInfo.Available {
 			clusterName = k8sInfo.Cluster
 			distro = k8sInfo.Distribution
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -103,10 +103,9 @@ var installKubernetesCmd = &cobra.Command{
 		}
 		k8sInfo := analyzer.DetectKubernetes()
 		clusterName := ""
-		distro := ""
+		distro := k8sInfo.Distribution
 		if k8sInfo.Available {
 			clusterName = k8sInfo.Cluster
-			distro = k8sInfo.Distribution
 		}
 		if err := installer.InstallKubernetes(envURL, classicTok, clusterName, distro, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
@@ -100,7 +101,14 @@ var installKubernetesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := installer.InstallKubernetes(envURL, classicTok, "", installDryRun); err != nil {
+		k8sInfo := analyzer.DetectKubernetes()
+		clusterName := ""
+		distro := ""
+		if k8sInfo != nil {
+			clusterName = k8sInfo.Cluster
+			distro = k8sInfo.Distribution
+		}
+		if err := installer.InstallKubernetes(envURL, classicTok, clusterName, distro, installDryRun); err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -150,7 +150,7 @@ var setupCmd = &cobra.Command{
 		case recommender.MethodKubernetes:
 			k8sClusterName := ""
 			k8sDistro := ""
-			if info.Kubernetes != nil {
+			if info.Kubernetes.Available {
 				k8sClusterName = info.Kubernetes.Cluster
 				k8sDistro = info.Kubernetes.Distribution
 			}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -148,7 +148,13 @@ var setupCmd = &cobra.Command{
 				installErr = installer.InstallOneAgent(c.Classic, setupDryRun, false, "")
 			}
 		case recommender.MethodKubernetes:
-			installErr = installer.InstallKubernetes(envURL, classicTok, "" /* name */, setupDryRun)
+			k8sClusterName := ""
+			k8sDistro := ""
+			if info.Kubernetes != nil {
+				k8sClusterName = info.Kubernetes.Cluster
+				k8sDistro = info.Kubernetes.Distribution
+			}
+			installErr = installer.InstallKubernetes(envURL, classicTok, k8sClusterName, k8sDistro, setupDryRun)
 		case recommender.MethodDocker:
 			installErr = installer.InstallDocker(envURL, classicTok, setupDryRun)
 		case recommender.MethodOtelCollector:

--- a/openspec/changes/k8s-distro-aware-installer/design.md
+++ b/openspec/changes/k8s-distro-aware-installer/design.md
@@ -22,11 +22,11 @@
 
 ## Decisions
 
-### 1. Pass `distro string` into `InstallKubernetes()` rather than re-detecting inside it
+### 1. Pass `clusterName` and `distro` into `InstallKubernetes()` rather than re-detecting inside it
 
-The analyzer already runs before `installKubernetesCmd` executes. Re-detecting inside the installer would duplicate kubectl calls and add latency. The command layer fetches `SystemInfo`, reads `info.Kubernetes.Distribution`, and passes it down. If analyzer hasn't run (dry-run or future non-interactive path), the empty string falls through to the `"kubernetes"` default case in `distroTemplateData()`.
+The analyzer already runs before `installKubernetesCmd` executes and populates `KubernetesInfo.Cluster` and `KubernetesInfo.Distribution`. Passing both from the caller avoids redundant `kubectl config view` and probe calls. When called standalone (e.g. `dtwiz install kubernetes` without a prior analyze), `clusterName` is empty and `InstallKubernetes()` falls back to its internal `fetchClusterName()`. `distro` empty falls through to the `"kubernetes"` default case in `distroTemplateData()`.
 
-Alternative considered: detect inside `InstallKubernetes()`. Rejected — violates single-responsibility, adds ~3 kubectl calls to install path already covered by analyze.
+Alternative considered: detect inside `InstallKubernetes()`. Rejected — violates single-responsibility, adds kubectl calls to the install path already covered by analyze.
 
 ### 2. New fields on `dynakubeTemplateData` over per-distro template files
 
@@ -36,22 +36,27 @@ Alternative considered: per-distro YAML files embedded as separate `//go:embed` 
 
 ### 3. Sub-variant detection requires live kubectl probes beyond the existing 4-string signature
 
-`DetectK8sDistribution(context, cluster, serverURL, serverVersion string)` is a pure function — fast, testable, no I/O. GKE Autopilot and EKS Bottlerocket cannot be distinguished from their parents using only these four strings. Two new probes are needed:
+`DetectK8sDistribution(context, cluster, serverURL, serverVersion string)` is a pure function — fast, testable, no I/O. GKE Autopilot and EKS Bottlerocket cannot be distinguished from their parents using only these four strings. Three probes are needed:
 
 - Autopilot: `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` — check for `autopilot.gke.io`
 - Bottlerocket: `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` — check for "Bottlerocket"
+- TKGI: `kubectl get namespace pks-system --ignore-not-found -o jsonpath={.status.phase}` — check for `"Active"` (not merely non-empty, to avoid false positives from migrated clusters with a `Terminating` namespace)
 
-These probes run only after the parent distro is confirmed (GKE or EKS), keeping the happy path fast. The pure `DetectK8sDistribution()` function remains unchanged for unit-testability; a new `ProbeK8sSubVariant(distro string) string` function wraps the kubectl calls.
+These probes run only after the parent distro is confirmed, keeping the happy path fast. The pure `DetectK8sDistribution()` function remains unchanged for unit-testability; `ProbeK8sSubVariant(distro string) string` runs the kubectl calls and delegates classification to `ClassifyK8sSubVariant(distro, output string, err error) string`.
 
 ### 4. Detection order: resolve sub-variants after parent match
 
 `ProbeK8sSubVariant` is called after `DetectK8sDistribution` returns the parent distro. This keeps the existing pure function contract intact and avoids adding kubectl calls to every detection path.
 
+### 5. Classification logic extracted into a pure function for testability
+
+`ClassifyK8sSubVariant` contains all the decision rules (string checks on kubectl output) with no I/O. This allows the full test matrix to be expressed as a plain table test without PATH injection or fake subprocesses, matching the pattern used for `TestDetectK8sDistribution`.
+
 ## Risks / Trade-offs
 
 `ProbeK8sSubVariant` kubectl calls add latency on GKE and EKS paths (~1–2s per probe with 5s timeout) → mitigated by running probes only when parent matches, with short timeouts and graceful fallback to parent distro on error.
 
-TKGI detection via `pks-system` namespace may produce false positives on clusters that previously ran TKGI but were migrated → acceptable edge case; user can override with `--platform` flag (future).
+TKGI detection via `pks-system` namespace phase check reduces false positives from migrated clusters (a `Terminating` namespace no longer triggers `"TKGI"`), but a stale `Active` namespace on a non-TKGI cluster remains a theoretical edge case → acceptable; user can override with `--platform` flag (future).
 
 `dynakube.tmpl` conditional blocks increase template complexity → mitigated by table-driven manifest assertion tests per distro.
 

--- a/openspec/changes/k8s-distro-aware-installer/proposal.md
+++ b/openspec/changes/k8s-distro-aware-installer/proposal.md
@@ -6,9 +6,10 @@
 
 ## What Changes
 
-- `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace existence)
+- `DetectK8sDistribution()` extended with 5 missing distributions: GKE Autopilot, EKS Bottlerocket, IKS, RKE, TKGI — including sub-variant probing via live kubectl calls (node osImage, namespace active phase)
 - Detection order enforced: parent distro confirmed first, sub-variant probed only when parent matches (GKE confirmed → Autopilot probe; EKS confirmed → Bottlerocket probe)
-- `InstallKubernetes()` accepts a `distro` parameter; `installKubernetesCmd` passes the detected distribution
+- Sub-variant classification extracted into pure `ClassifyK8sSubVariant(distro, output string, err error) string` for unit-testability without subprocess invocation
+- `InstallKubernetes()` accepts `clusterName` and `distro` parameters; callers pass both from the already-detected `KubernetesInfo` to avoid redundant kubectl calls; empty `clusterName` falls back to internal derivation
 - `dynakubeTemplateData` gains four new fields: `EnableKSPM`, `PrivilegedAnnotation`, `ReadOnlyVolume`, `KubeletPath`
 - `dynakube.tmpl` gains conditional blocks driven by the new fields: KSPM section, per-DynaKube annotations, kubelet path override
 - Missing `ClusterRoleBinding` added to the template
@@ -26,8 +27,8 @@
 
 ## Impact
 
-- `pkg/analyzer/detect_kubernetes.go` — extended with new distros and kubectl probes
-- `pkg/installer/kubernetes.go` — new param, new mapping function
+- `pkg/analyzer/detect_kubernetes.go` — extended with new distros, kubectl probes, and `ClassifyK8sSubVariant`
+- `pkg/installer/kubernetes.go` — `clusterName` + `distro` params, new mapping function
 - `pkg/installer/dynakube.tmpl` — conditional blocks added
-- `cmd/install.go` — passes detected distro to installer
+- `cmd/install.go`, `cmd/setup.go` — pass detected `Cluster` and `Distribution` from `KubernetesInfo`
 - No external API changes, no new flags, no breaking changes to existing behavior on already-supported distros

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
@@ -68,19 +68,35 @@ The system SHALL identify an RKE cluster when the server gitVersion contains `+r
 
 ### Requirement: Detect TKGI by namespace probe
 
-The system SHALL identify a TKGI cluster by checking whether the `pks-system` namespace exists after no other distro is matched. The returned distribution string SHALL be `"TKGI"`.
+The system SHALL identify a TKGI cluster by checking whether the `pks-system` namespace exists and is `Active` after no other distro is matched. The returned distribution string SHALL be `"TKGI"`.
 
-#### Scenario: TKGI namespace found
+#### Scenario: TKGI namespace active
 
 - **GIVEN** no other distro signal matches the cluster
-- **WHEN** `kubectl get namespace pks-system --ignore-not-found` returns a non-empty result
-- **THEN** `ProbeK8sSubVariant` (or a fallback probe) returns `"TKGI"`
+- **WHEN** `kubectl get namespace pks-system --ignore-not-found -o jsonpath={.status.phase}` returns `"Active"`
+- **THEN** `ClassifyK8sSubVariant` returns `"TKGI"`
 
 #### Scenario: Namespace absent
 
 - **GIVEN** no other distro signal matches the cluster
-- **WHEN** `pks-system` namespace does not exist
+- **WHEN** `pks-system` namespace does not exist (empty output from `--ignore-not-found`)
 - **THEN** detection falls through to `"kubernetes"` default
+
+#### Scenario: Namespace exists but inactive
+
+- **GIVEN** no other distro signal matches the cluster
+- **WHEN** `pks-system` namespace exists but `.status.phase` is not `"Active"` (e.g. `"Terminating"`)
+- **THEN** detection falls through to `"kubernetes"` default
+
+### Requirement: Sub-variant classification logic is pure and separately testable
+
+The system SHALL implement sub-variant classification as `ClassifyK8sSubVariant(distro, output string, err error) string` — a pure function that takes the parent distro, kubectl output, and probe error, and returns the refined distro. `ProbeK8sSubVariant` SHALL invoke the kubectl probe and delegate the classification decision to `ClassifyK8sSubVariant`.
+
+#### Scenario: Error propagates to parent distro
+
+- **GIVEN** any parent distro
+- **WHEN** `ClassifyK8sSubVariant` is called with a non-nil `err`
+- **THEN** it returns the parent distro unchanged, regardless of `output`
 
 ### Requirement: Sub-variant probes run only when parent distro matches
 

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -2,15 +2,21 @@
 
 ## ADDED Requirements
 
-### Requirement: InstallKubernetes accepts distribution parameter
+### Requirement: InstallKubernetes accepts clusterName and distribution parameters
 
-The system SHALL accept a `distro string` parameter in `InstallKubernetes()`. When empty, it SHALL default to `"kubernetes"` behavior.
+The system SHALL accept a `clusterName string` and a `distro string` parameter in `InstallKubernetes()`. When `clusterName` is empty it SHALL be derived from the current kubectl context. When `distro` is empty it SHALL default to `"kubernetes"` behavior.
 
-#### Scenario: Distro wired from command
+#### Scenario: clusterName and distro wired from detected KubernetesInfo
 
-- **GIVEN** the analyzer has detected a Kubernetes cluster with a non-empty `Distribution` in `KubernetesInfo`
-- **WHEN** `installKubernetesCmd` runs
-- **THEN** the detected `Distribution` value SHALL be passed to `InstallKubernetes()`
+- **GIVEN** the analyzer has detected a Kubernetes cluster with non-empty `Cluster` and `Distribution` in `KubernetesInfo`
+- **WHEN** `installKubernetesCmd` or `setup` runs
+- **THEN** both `Cluster` and `Distribution` SHALL be passed to `InstallKubernetes()`, avoiding a redundant kubectl call inside the installer
+
+#### Scenario: Empty clusterName falls back to kubectl context
+
+- **GIVEN** `InstallKubernetes()` is called with an empty `clusterName` string
+- **WHEN** the installer runs
+- **THEN** the cluster name SHALL be derived from `kubectl config view` and sanitized for use as a Kubernetes resource name
 
 #### Scenario: Empty distro falls back to default
 

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -4,10 +4,10 @@
 
 - [x] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
 - [x] 1.2 Add RKE detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2` (RKE2, not RKE1), return `"RKE"`; check before generic `"kubernetes"` fallback
-- [x] 1.3 Add `ProbeK8sSubVariant(distro string) string` function in `pkg/analyzer/detect_kubernetes.go` — accepts parent distro, runs conditional kubectl probes, returns refined distro or parent unchanged
+- [x] 1.3 Add `ProbeK8sSubVariant(distro string) string` and `ClassifyK8sSubVariant(distro, output string, err error) string` in `pkg/analyzer/detect_kubernetes.go` — `ProbeK8sSubVariant` runs kubectl and delegates classification to the pure `ClassifyK8sSubVariant`; on error `ClassifyK8sSubVariant` returns parent distro unchanged
 - [x] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
 - [x] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
-- [x] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found` with 5s timeout; return `"TKGI"` if output is non-empty
+- [x] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found -o jsonpath={.status.phase}` with 5s timeout; return `"TKGI"` only if output is `"Active"`
 - [x] 1.7 Call `ProbeK8sSubVariant` from `detectKubernetes()` in `pkg/analyzer/detect_kubernetes.go` — after `DetectK8sDistribution()` returns, pass result through probe, store final value in `info.Distribution`
 
 ## 2. Detection Unit Tests
@@ -18,8 +18,8 @@
 
 ## 3. Wire Distro into Installer Signature
 
-- [x] 3.1 Add `distro string` parameter to `InstallKubernetes()` in `pkg/installer/kubernetes.go` — position after `name`, before `dryRun`
-- [x] 3.2 Update `installKubernetesCmd` in `cmd/install.go` to call `analyzer.DetectKubernetes()` (or read from a pre-run `AnalyzeSystem()` result), extract `Distribution`, pass it to `InstallKubernetes()`
+- [x] 3.1 Add `clusterName string` and `distro string` parameters to `InstallKubernetes()` in `pkg/installer/kubernetes.go` — `clusterName` replaces `name`, position before `distro` and `dryRun`; empty `clusterName` falls back to internal `fetchClusterName()`
+- [x] 3.2 Update `installKubernetesCmd` in `cmd/install.go` and `setup.go` to call `analyzer.DetectKubernetes()` (or read from pre-run `AnalyzeSystem()` result), extract both `Cluster` and `Distribution`, pass both to `InstallKubernetes()` to avoid redundant kubectl calls
 - [x] 3.3 Update dry-run output in `InstallKubernetes()` to print detected distro: `fmt.Printf("  Distribution: %s\n", distro)`
 - [x] 3.4 Run `make build` — confirm compiles; run `make test` — confirm no regressions
 

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -2,26 +2,26 @@
 
 ## 1. Extend Distribution Detection
 
-- [ ] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
-- [ ] 1.2 Add RKE detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2` (RKE2, not RKE1), return `"RKE"`; check before generic `"kubernetes"` fallback
-- [ ] 1.3 Add `ProbeK8sSubVariant(distro string) string` function in `pkg/analyzer/detect_kubernetes.go` — accepts parent distro, runs conditional kubectl probes, returns refined distro or parent unchanged
-- [ ] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
-- [ ] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
-- [ ] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found` with 5s timeout; return `"TKGI"` if output is non-empty
-- [ ] 1.7 Call `ProbeK8sSubVariant` from `detectKubernetes()` in `pkg/analyzer/detect_kubernetes.go` — after `DetectK8sDistribution()` returns, pass result through probe, store final value in `info.Distribution`
+- [x] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
+- [x] 1.2 Add RKE detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2` (RKE2, not RKE1), return `"RKE"`; check before generic `"kubernetes"` fallback
+- [x] 1.3 Add `ProbeK8sSubVariant(distro string) string` function in `pkg/analyzer/detect_kubernetes.go` — accepts parent distro, runs conditional kubectl probes, returns refined distro or parent unchanged
+- [x] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
+- [x] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
+- [x] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found` with 5s timeout; return `"TKGI"` if output is non-empty
+- [x] 1.7 Call `ProbeK8sSubVariant` from `detectKubernetes()` in `pkg/analyzer/detect_kubernetes.go` — after `DetectK8sDistribution()` returns, pass result through probe, store final value in `info.Distribution`
 
 ## 2. Detection Unit Tests
 
-- [ ] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE (gitVersion `+rke2` signal)
-- [ ] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when annotation present, GKE→GKE when absent, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
-- [ ] 2.3 Run `make test` and `make lint` — all pass
+- [x] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE (gitVersion `+rke2` signal)
+- [x] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when annotation present, GKE→GKE when absent, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
+- [x] 2.3 Run `make test` and `make lint` — all pass
 
 ## 3. Wire Distro into Installer Signature
 
-- [ ] 3.1 Add `distro string` parameter to `InstallKubernetes()` in `pkg/installer/kubernetes.go` — position after `name`, before `dryRun`
-- [ ] 3.2 Update `installKubernetesCmd` in `cmd/install.go` to call `analyzer.DetectKubernetes()` (or read from a pre-run `AnalyzeSystem()` result), extract `Distribution`, pass it to `InstallKubernetes()`
-- [ ] 3.3 Update dry-run output in `InstallKubernetes()` to print detected distro: `fmt.Printf("  Distribution: %s\n", distro)`
-- [ ] 3.4 Run `make build` — confirm compiles; run `make test` — confirm no regressions
+- [x] 3.1 Add `distro string` parameter to `InstallKubernetes()` in `pkg/installer/kubernetes.go` — position after `name`, before `dryRun`
+- [x] 3.2 Update `installKubernetesCmd` in `cmd/install.go` to call `analyzer.DetectKubernetes()` (or read from a pre-run `AnalyzeSystem()` result), extract `Distribution`, pass it to `InstallKubernetes()`
+- [x] 3.3 Update dry-run output in `InstallKubernetes()` to print detected distro: `fmt.Printf("  Distribution: %s\n", distro)`
+- [x] 3.4 Run `make build` — confirm compiles; run `make test` — confirm no regressions
 
 ## 4. Distro-to-Template Mapping
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -344,7 +344,7 @@ func AnalyzeSystem() (*SystemInfo, error) {
 	})
 
 	run(func() error {
-		k := detectKubernetes()
+		k := DetectKubernetes()
 		mu.Lock()
 		info.Kubernetes = k
 		if k.Available {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,7 +1,6 @@
 package analyzer_test
 
 import (
-	"errors"
 	"runtime"
 	"testing"
 
@@ -48,72 +47,5 @@ func TestAnalyzeSystem_SummaryNotEmpty(t *testing.T) {
 	s := info.Summary()
 	if s == "" {
 		t.Error("Summary() returned empty string")
-	}
-}
-
-func TestDetectK8sDistribution(t *testing.T) {
-	tests := []struct {
-		context   string
-		cluster   string
-		serverURL string
-		version   string
-		want      string
-	}{
-		{"gke_project_region_cluster", "", "", "", "GKE"},
-		{"arn:aws:eks:us-east-1:123:cluster/my-cluster", "", "", "", "EKS"},
-		{"my-cluster-context", "", "https://my-cluster-abc123.hcp.eastus.azmk8s.io:443", "", "AKS"},
-		{"my-aks-context", "my-cluster.azmk8s.io", "", "", "AKS"},
-		{"openshift-context", "", "", "", "OpenShift"},
-		{"minikube", "", "", "", "minikube"},
-		{"kind-mycluster", "", "", "", "kind"},
-		{"docker-desktop", "", "", "v1.30.0-k3s1", "k3s"},
-		{"some-other-context", "", "", "v1.30.0", "kubernetes"},
-		// IKS: server URL signal
-		{"prod-context", "", "https://c1.us-south.containers.cloud.ibm.com:31234", "", "IKS"},
-		// RKE: gitVersion +rke2 signal
-		{"rke-context", "", "", "v1.28.9+rke2r1", "RKE"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.context, func(t *testing.T) {
-			got := analyzer.DetectK8sDistribution(tt.context, tt.cluster, tt.serverURL, tt.version)
-			if got != tt.want {
-				t.Errorf("DetectK8sDistribution(%q, %q, %q, %q) = %q, want %q",
-					tt.context, tt.cluster, tt.serverURL, tt.version, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestClassifyK8sSubVariant(t *testing.T) {
-	errProbe := errors.New("exit status 1")
-
-	tests := []struct {
-		distro string
-		output string
-		err    error
-		want   string
-	}{
-		{"GKE", `{"autopilot.gke.io/enabled":"true"}`, nil, "GKE-Autopilot"},
-		{"GKE", `{"other-annotation":"value"}`, nil, "GKE"},
-		{"GKE", "", errProbe, "GKE"},
-		{"EKS", "Bottlerocket OS 1.14.0", nil, "EKS-Bottlerocket"},
-		{"EKS", "Amazon Linux 2", nil, "EKS"},
-		{"EKS", "", errProbe, "EKS"},
-		{"kubernetes", "Active", nil, "TKGI"},
-		{"kubernetes", "", nil, "kubernetes"},
-		{"kubernetes", "Terminating", nil, "kubernetes"},
-		{"kubernetes", "", errProbe, "kubernetes"},
-		{"AKS", "", nil, "AKS"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.distro, func(t *testing.T) {
-			got := analyzer.ClassifyK8sSubVariant(tt.distro, tt.output, tt.err)
-			if got != tt.want {
-				t.Errorf("ClassifyK8sSubVariant(%q, %q, %v) = %q, want %q",
-					tt.distro, tt.output, tt.err, got, tt.want)
-			}
-		})
 	}
 }

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,6 +1,7 @@
 package analyzer_test
 
 import (
+	"errors"
 	"runtime"
 	"testing"
 
@@ -67,6 +68,10 @@ func TestDetectK8sDistribution(t *testing.T) {
 		{"kind-mycluster", "", "", "", "kind"},
 		{"docker-desktop", "", "", "v1.30.0-k3s1", "k3s"},
 		{"some-other-context", "", "", "v1.30.0", "kubernetes"},
+		// IKS: server URL signal
+		{"prod-context", "", "https://c1.us-south.containers.cloud.ibm.com:31234", "", "IKS"},
+		// RKE: gitVersion +rke2 signal
+		{"rke-context", "", "", "v1.28.9+rke2r1", "RKE"},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +80,39 @@ func TestDetectK8sDistribution(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("DetectK8sDistribution(%q, %q, %q, %q) = %q, want %q",
 					tt.context, tt.cluster, tt.serverURL, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyK8sSubVariant(t *testing.T) {
+	errProbe := errors.New("exit status 1")
+
+	tests := []struct {
+		distro string
+		output string
+		err    error
+		want   string
+	}{
+		{"GKE", `{"autopilot.gke.io/enabled":"true"}`, nil, "GKE-Autopilot"},
+		{"GKE", `{"other-annotation":"value"}`, nil, "GKE"},
+		{"GKE", "", errProbe, "GKE"},
+		{"EKS", "Bottlerocket OS 1.14.0", nil, "EKS-Bottlerocket"},
+		{"EKS", "Amazon Linux 2", nil, "EKS"},
+		{"EKS", "", errProbe, "EKS"},
+		{"kubernetes", "Active", nil, "TKGI"},
+		{"kubernetes", "", nil, "kubernetes"},
+		{"kubernetes", "Terminating", nil, "kubernetes"},
+		{"kubernetes", "", errProbe, "kubernetes"},
+		{"AKS", "", nil, "AKS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.distro, func(t *testing.T) {
+			got := analyzer.ClassifyK8sSubVariant(tt.distro, tt.output, tt.err)
+			if got != tt.want {
+				t.Errorf("ClassifyK8sSubVariant(%q, %q, %v) = %q, want %q",
+					tt.distro, tt.output, tt.err, got, tt.want)
 			}
 		})
 	}

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -52,11 +52,6 @@ func DetectKubernetes() *KubernetesInfo {
 	return info
 }
 
-// detectKubernetes is the internal alias used by AnalyzeSystem.
-func detectKubernetes() *KubernetesInfo {
-	return DetectKubernetes()
-}
-
 // parseK8sServerVersion extracts gitVersion from `kubectl version -o json` output.
 func parseK8sServerVersion(out string) string {
 	var v struct {

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -18,6 +18,7 @@ func DetectKubernetes() *KubernetesInfo {
 
 	ok, _ := runCmd("kubectl", "cluster-info", "--request-timeout=5s")
 	if !ok {
+		info.Distribution = "None was detected"
 		return info
 	}
 	info.Available = true
@@ -67,8 +68,8 @@ func parseK8sServerVersion(out string) string {
 
 // DetectK8sDistribution heuristically identifies the Kubernetes distribution.
 // It is exported for testing.
-func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) string {
-	ctxLower := strings.ToLower(context)
+func DetectK8sDistribution(kubeCtx, cluster, serverURL, serverVersion string) string {
+	ctxLower := strings.ToLower(kubeCtx)
 	clusterLower := strings.ToLower(cluster)
 	serverURLLower := strings.ToLower(serverURL)
 	verLower := strings.ToLower(serverVersion)
@@ -104,38 +105,48 @@ func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) st
 	if strings.Contains(verLower, "+rke2") {
 		return "RKE"
 	}
-	// minikube
-	if ctxLower == "minikube" || strings.Contains(ctxLower, "minikube") {
-		return "minikube"
-	}
-	// kind
-	if strings.HasPrefix(ctxLower, "kind-") {
-		return "kind"
-	}
 
 	return "kubernetes"
 }
 
+type cmdRunner func(timeout time.Duration, cmd string, args ...string) (string, error)
+
 // ProbeK8sSubVariant runs conditional kubectl probes to refine the parent distribution.
 // On error or timeout the parent distro is returned unchanged.
 func ProbeK8sSubVariant(distro string) string {
+	return probeK8sSubVariant(distro, runCmdWithTimeout)
+}
+
+func probeK8sSubVariant(distro string, run cmdRunner) string {
 	switch distro {
 	case "GKE":
-		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "kube-system",
+		output, err := run(5*time.Second, "kubectl", "get", "namespace", "kube-system",
 			"-o", "jsonpath={.metadata.annotations}")
 		if err != nil {
 			display.PrintWarning("GKE Autopilot probe", err)
 		}
 		return ClassifyK8sSubVariant(distro, output, err)
 	case "EKS":
-		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "nodes",
+		output, err := run(5*time.Second, "kubectl", "get", "nodes",
 			"-o", "jsonpath={.items[*].status.nodeInfo.osImage}")
 		if err != nil {
 			display.PrintWarning("EKS Bottlerocket probe", err)
 		}
 		return ClassifyK8sSubVariant(distro, output, err)
 	case "kubernetes":
-		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "pks-system",
+		minikubeOut, minikubeErr := run(5*time.Second, "kubectl", "get", "nodes",
+			"-l", "minikube.k8s.io/name", "--no-headers", "-o", "name")
+		if minikubeErr == nil && strings.TrimSpace(minikubeOut) != "" {
+			return "minikube"
+		}
+
+		kindOut, kindErr := run(5*time.Second, "kubectl", "get", "nodes",
+			"-o", "jsonpath={.items[0].spec.providerID}")
+		if kindErr == nil && strings.HasPrefix(strings.TrimSpace(kindOut), "kind://") {
+			return "kind"
+		}
+
+		output, err := run(5*time.Second, "kubectl", "get", "namespace", "pks-system",
 			"--ignore-not-found", "-o", "jsonpath={.status.phase}")
 		if err != nil {
 			display.PrintWarning("TKGI namespace probe", err)
@@ -177,7 +188,6 @@ func runCmdWithTimeout(timeout time.Duration, command string, args ...string) (s
 	c := exec.CommandContext(ctx, command, args...)
 	var buf bytes.Buffer
 	c.Stdout = &buf
-	c.Stderr = &buf
 	err := c.Run()
 	return strings.TrimSpace(buf.String()), err
 }

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -126,21 +126,21 @@ func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) st
 func ProbeK8sSubVariant(distro string) string {
 	switch distro {
 	case "GKE":
-		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "kube-system",
+		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "kube-system",
 			"-o", "jsonpath={.metadata.annotations}")
 		if err != nil {
 			display.PrintWarning("GKE Autopilot probe", err)
 		}
 		return ClassifyK8sSubVariant(distro, output, err)
 	case "EKS":
-		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "nodes",
+		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "nodes",
 			"-o", "jsonpath={.items[*].status.nodeInfo.osImage}")
 		if err != nil {
 			display.PrintWarning("EKS Bottlerocket probe", err)
 		}
 		return ClassifyK8sSubVariant(distro, output, err)
 	case "kubernetes":
-		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "pks-system",
+		output, err := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "pks-system",
 			"--ignore-not-found", "-o", "jsonpath={.status.phase}")
 		if err != nil {
 			display.PrintWarning("TKGI namespace probe", err)
@@ -175,8 +175,8 @@ func ClassifyK8sSubVariant(distro, output string, err error) string {
 	return distro
 }
 
-// runCmdWithTimeout runs the command with a hard deadline, returning (error, trimmed output).
-func runCmdWithTimeout(timeout time.Duration, command string, args ...string) (error, string) {
+// runCmdWithTimeout runs the command with a hard deadline, returning (trimmed output, error).
+func runCmdWithTimeout(timeout time.Duration, command string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	c := exec.CommandContext(ctx, command, args...)
@@ -184,5 +184,5 @@ func runCmdWithTimeout(timeout time.Duration, command string, args ...string) (e
 	c.Stdout = &buf
 	c.Stderr = &buf
 	err := c.Run()
-	return err, strings.TrimSpace(buf.String())
+	return strings.TrimSpace(buf.String()), err
 }

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -1,13 +1,19 @@
 package analyzer
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
-// detectKubernetes checks for a reachable Kubernetes cluster.
-func detectKubernetes() *KubernetesInfo {
+// DetectKubernetes checks for a reachable Kubernetes cluster.
+func DetectKubernetes() *KubernetesInfo {
 	info := &KubernetesInfo{}
 
 	ok, _ := runCmd("kubectl", "cluster-info", "--request-timeout=5s")
@@ -41,8 +47,14 @@ func detectKubernetes() *KubernetesInfo {
 		info.NodeCount = len(strings.Split(strings.TrimSpace(nodesOut), "\n"))
 	}
 
-	info.Distribution = DetectK8sDistribution(ctx, cluster, serverURL, info.ServerVersion)
+	parent := DetectK8sDistribution(ctx, cluster, serverURL, info.ServerVersion)
+	info.Distribution = ProbeK8sSubVariant(parent)
 	return info
+}
+
+// detectKubernetes is the internal alias used by AnalyzeSystem.
+func detectKubernetes() *KubernetesInfo {
+	return DetectKubernetes()
 }
 
 // parseK8sServerVersion extracts gitVersion from `kubectl version -o json` output.
@@ -81,6 +93,10 @@ func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) st
 		strings.Contains(ctxLower, "aks") {
 		return "AKS"
 	}
+	// IKS
+	if strings.Contains(serverURLLower, ".containers.cloud.ibm.com") {
+		return "IKS"
+	}
 	// OpenShift
 	if strings.Contains(ctxLower, "openshift") || strings.Contains(verLower, "openshift") {
 		return "OpenShift"
@@ -88,6 +104,10 @@ func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) st
 	// k3s
 	if strings.Contains(verLower, "k3s") {
 		return "k3s"
+	}
+	// RKE (RKE2 — gitVersion contains +rke2)
+	if strings.Contains(verLower, "+rke2") {
+		return "RKE"
 	}
 	// minikube
 	if ctxLower == "minikube" || strings.Contains(ctxLower, "minikube") {
@@ -99,4 +119,70 @@ func DetectK8sDistribution(context, cluster, serverURL, serverVersion string) st
 	}
 
 	return "kubernetes"
+}
+
+// ProbeK8sSubVariant runs conditional kubectl probes to refine the parent distribution.
+// On error or timeout the parent distro is returned unchanged.
+func ProbeK8sSubVariant(distro string) string {
+	switch distro {
+	case "GKE":
+		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "kube-system",
+			"-o", "jsonpath={.metadata.annotations}")
+		if err != nil {
+			display.PrintWarning("GKE Autopilot probe", err)
+		}
+		return ClassifyK8sSubVariant(distro, output, err)
+	case "EKS":
+		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "nodes",
+			"-o", "jsonpath={.items[*].status.nodeInfo.osImage}")
+		if err != nil {
+			display.PrintWarning("EKS Bottlerocket probe", err)
+		}
+		return ClassifyK8sSubVariant(distro, output, err)
+	case "kubernetes":
+		err, output := runCmdWithTimeout(5*time.Second, "kubectl", "get", "namespace", "pks-system",
+			"--ignore-not-found", "-o", "jsonpath={.status.phase}")
+		if err != nil {
+			display.PrintWarning("TKGI namespace probe", err)
+		}
+		return ClassifyK8sSubVariant(distro, output, err)
+	default:
+		return distro
+	}
+}
+
+// ClassifyK8sSubVariant applies sub-variant detection rules given the parent
+// distro, kubectl output, and whether the kubectl call succeeded.
+// It is exported for testing.
+func ClassifyK8sSubVariant(distro, output string, err error) string {
+	if err != nil {
+		return distro
+	}
+	switch distro {
+	case "GKE":
+		if strings.Contains(output, "autopilot.gke.io") {
+			return "GKE-Autopilot"
+		}
+	case "EKS":
+		if strings.Contains(strings.ToLower(output), "bottlerocket") {
+			return "EKS-Bottlerocket"
+		}
+	case "kubernetes":
+		if strings.TrimSpace(output) == "Active" {
+			return "TKGI"
+		}
+	}
+	return distro
+}
+
+// runCmdWithTimeout runs the command with a hard deadline, returning (error, trimmed output).
+func runCmdWithTimeout(timeout time.Duration, command string, args ...string) (error, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, command, args...)
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+	err := c.Run()
+	return err, strings.TrimSpace(buf.String())
 }

--- a/pkg/analyzer/detect_kubernetes_test.go
+++ b/pkg/analyzer/detect_kubernetes_test.go
@@ -1,0 +1,206 @@
+package analyzer
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDetectK8sDistribution(t *testing.T) {
+	tests := []struct {
+		context   string
+		cluster   string
+		serverURL string
+		version   string
+		want      string
+	}{
+		{"gke_project_region_cluster", "", "", "", "GKE"},
+		{"arn:aws:eks:us-east-1:123:cluster/my-cluster", "", "", "", "EKS"},
+		{"my-cluster-context", "", "https://my-cluster-abc123.hcp.eastus.azmk8s.io:443", "", "AKS"},
+		{"my-aks-context", "my-cluster.azmk8s.io", "", "", "AKS"},
+		{"openshift-context", "", "", "", "OpenShift"},
+		{"docker-desktop", "", "", "v1.30.0-k3s1", "k3s"},
+		{"some-other-context", "", "", "v1.30.0", "kubernetes"},
+		// IKS: server URL signal
+		{"prod-context", "", "https://c1.us-south.containers.cloud.ibm.com:31234", "", "IKS"},
+		// RKE: gitVersion +rke2 signal
+		{"rke-context", "", "", "v1.28.9+rke2r1", "RKE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.context, func(t *testing.T) {
+			got := DetectK8sDistribution(tt.context, tt.cluster, tt.serverURL, tt.version)
+			if got != tt.want {
+				t.Errorf("DetectK8sDistribution(%q, %q, %q, %q) = %q, want %q",
+					tt.context, tt.cluster, tt.serverURL, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+type fakeCall struct {
+	out string
+	err error
+}
+
+func TestProbeK8sSubVariant(t *testing.T) {
+	errProbe := errors.New("exit status 1")
+
+	tests := []struct {
+		name   string
+		distro string
+		calls  []fakeCall
+		want   string
+	}{
+		// GKE → Autopilot
+		{
+			name:   "GKE Autopilot detected",
+			distro: "GKE",
+			calls:  []fakeCall{{"autopilot.gke.io/enabled:true", nil}},
+			want:   "GKE-Autopilot",
+		},
+		{
+			name:   "GKE Standard unchanged",
+			distro: "GKE",
+			calls:  []fakeCall{{"other-annotation:value", nil}},
+			want:   "GKE",
+		},
+		{
+			name:   "GKE probe error falls back to parent",
+			distro: "GKE",
+			calls:  []fakeCall{{"", errProbe}},
+			want:   "GKE",
+		},
+
+		// EKS → Bottlerocket
+		{
+			name:   "EKS Bottlerocket detected",
+			distro: "EKS",
+			calls:  []fakeCall{{"Bottlerocket OS 1.14.0", nil}},
+			want:   "EKS-Bottlerocket",
+		},
+		{
+			name:   "EKS Standard unchanged",
+			distro: "EKS",
+			calls:  []fakeCall{{"Amazon Linux 2", nil}},
+			want:   "EKS",
+		},
+		{
+			name:   "EKS probe error falls back to parent",
+			distro: "EKS",
+			calls:  []fakeCall{{"", errProbe}},
+			want:   "EKS",
+		},
+
+		// kubernetes → minikube (first probe: minikube node label)
+		{
+			name:   "minikube detected via node label",
+			distro: "kubernetes",
+			calls:  []fakeCall{{"node/minikube", nil}},
+			want:   "minikube",
+		},
+
+		// kubernetes → kind (second probe: providerID)
+		{
+			name:   "kind detected via providerID",
+			distro: "kubernetes",
+			calls: []fakeCall{
+				{"", nil},                  // minikube label probe: empty → not minikube
+				{"kind://docker/...", nil}, // kind providerID probe
+			},
+			want: "kind",
+		},
+
+		// kubernetes → TKGI (third probe: pks-system namespace)
+		{
+			name:   "TKGI detected via pks-system namespace",
+			distro: "kubernetes",
+			calls: []fakeCall{
+				{"", nil},
+				{"", nil},
+				{"Active", nil},
+			},
+			want: "TKGI",
+		},
+
+		// kubernetes → generic fallthrough
+		{
+			name:   "generic kubernetes when no probe matches",
+			distro: "kubernetes",
+			calls:  []fakeCall{{"", nil}, {"", nil}, {"", nil}},
+			want:   "kubernetes",
+		},
+		{
+			name:   "TKGI namespace Terminating falls through to kubernetes",
+			distro: "kubernetes",
+			calls:  []fakeCall{{"", nil}, {"", nil}, {"Terminating", nil}},
+			want:   "kubernetes",
+		},
+		{
+			name:   "TKGI probe error falls through to kubernetes",
+			distro: "kubernetes",
+			calls:  []fakeCall{{"", nil}, {"", nil}, {"", errProbe}},
+			want:   "kubernetes",
+		},
+
+		// unrecognised distro passes through unchanged
+		{
+			name:   "unknown distro unchanged",
+			distro: "AKS",
+			calls:  nil,
+			want:   "AKS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callIdx := 0
+			fake := func(_ time.Duration, _ string, _ ...string) (string, error) {
+				if callIdx >= len(tt.calls) {
+					t.Fatalf("unexpected extra kubectl call (index %d)", callIdx)
+				}
+				c := tt.calls[callIdx]
+				callIdx++
+				return c.out, c.err
+			}
+
+			got := probeK8sSubVariant(tt.distro, fake)
+			if got != tt.want {
+				t.Errorf("probeK8sSubVariant(%q) = %q, want %q", tt.distro, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyK8sSubVariant(t *testing.T) {
+	errProbe := errors.New("exit status 1")
+
+	tests := []struct {
+		distro string
+		output string
+		err    error
+		want   string
+	}{
+		{"GKE", `{"autopilot.gke.io/enabled":"true"}`, nil, "GKE-Autopilot"},
+		{"GKE", `{"other-annotation":"value"}`, nil, "GKE"},
+		{"GKE", "", errProbe, "GKE"},
+		{"EKS", "Bottlerocket OS 1.14.0", nil, "EKS-Bottlerocket"},
+		{"EKS", "Amazon Linux 2", nil, "EKS"},
+		{"EKS", "", errProbe, "EKS"},
+		{"kubernetes", "Active", nil, "TKGI"},
+		{"kubernetes", "", nil, "kubernetes"},
+		{"kubernetes", "Terminating", nil, "kubernetes"},
+		{"kubernetes", "", errProbe, "kubernetes"},
+		{"AKS", "", nil, "AKS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.distro, func(t *testing.T) {
+			got := ClassifyK8sSubVariant(tt.distro, tt.output, tt.err)
+			if got != tt.want {
+				t.Errorf("ClassifyK8sSubVariant(%q, %q, %v) = %q, want %q",
+					tt.distro, tt.output, tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -66,5 +66,5 @@ func PrintError(label string, err error) {
 }
 
 func PrintWarning(label string, err error) {
-	_, _ = fmt.Fprintf(color.Output, "  %s: %s\n", ColorDefault.Sprint(label), ColorWarning.Sprintf("⚠ %s", err))
+	_, _ = fmt.Fprintf(color.Error, "  %s: %s\n", ColorDefault.Sprint(label), ColorWarning.Sprintf("⚠ %s", err))
 }

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -64,3 +64,7 @@ func ClearPending() {
 func PrintError(label string, err error) {
 	_, _ = fmt.Fprintf(color.Output, "  %s: %s\n", ColorDefault.Sprint(label), ColorError.Sprintf("✗ %s", err))
 }
+
+func PrintWarning(label string, err error) {
+	_, _ = fmt.Fprintf(color.Output, "  %s: %s\n", ColorDefault.Sprint(label), ColorWarning.Sprintf("⚠ %s", err))
+}

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -107,8 +107,26 @@ func TestPrintError_FormatsLabelAndError(t *testing.T) {
 	}
 }
 
+func captureErrorOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	origError := color.Error
+	color.Error = &buf
+	t.Cleanup(func() { color.Error = origError })
+
+	origNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = origNoColor })
+
+	fn()
+
+	return buf.String()
+}
+
 func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := captureErrorOutput(t, func() {
 		PrintWarning("EKS Bottlerocket probe", errors.New("exit status 1"))
 	})
 	want := "  EKS Bottlerocket probe: ⚠ exit status 1\n"
@@ -119,7 +137,7 @@ func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
 
 func TestPrintWarning_DiffersFromPrintError(t *testing.T) {
 	err := errors.New("kubectl timeout")
-	warning := captureOutput(t, func() { PrintWarning("probe", err) })
+	warning := captureErrorOutput(t, func() { PrintWarning("probe", err) })
 	errOut := captureOutput(t, func() { PrintError("probe", err) })
 	if warning == errOut {
 		t.Error("PrintWarning() and PrintError() should produce different output (⚠ vs ✗)")

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -107,6 +107,25 @@ func TestPrintError_FormatsLabelAndError(t *testing.T) {
 	}
 }
 
+func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
+	got := captureOutput(t, func() {
+		PrintWarning("EKS Bottlerocket probe", errors.New("exit status 1"))
+	})
+	want := "  EKS Bottlerocket probe: ⚠ exit status 1\n"
+	if got != want {
+		t.Errorf("PrintWarning() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintWarning_DiffersFromPrintError(t *testing.T) {
+	err := errors.New("kubectl timeout")
+	warning := captureOutput(t, func() { PrintWarning("probe", err) })
+	errOut := captureOutput(t, func() { PrintError("probe", err) })
+	if warning == errOut {
+		t.Error("PrintWarning() and PrintError() should produce different output (⚠ vs ✗)")
+	}
+}
+
 func TestPrintFlagLine_DiffersFromPrintStatusLine(t *testing.T) {
 	label, message := "DTWIZ_ALL_RUNTIMES", "✓ enabled (cli)"
 	flagLine := captureOutput(t, func() { PrintFlagLine(label, message, ColorOK) })

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -354,6 +354,7 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 	display.ColorMessage.Println("  Dynatrace Kubernetes Integration")
 	fmt.Println()
 	fmt.Printf("  Cluster name:  %s\n", clusterName)
+	fmt.Printf("  Distribution:  %s\n", distro)
 	fmt.Printf("  API URL:       %s\n\n", apiURL)
 	fmt.Printf("  %s\n", sep)
 	display.ColorMessage.Println("  dynakube.yaml manifest to be applied:")

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -285,23 +285,31 @@ func fetchClusterName(fallback string) string {
 	return name
 }
 
+// resolveClusterName returns a sanitized Kubernetes resource name for the DynaKube CR.
+// Priority: explicit name → kubectl context → tenant ID derived from envURL → "dynakube".
+func resolveClusterName(name, envURL string) string {
+	if name != "" {
+		return sanitizeK8sName(name)
+	}
+	if resolved := fetchClusterName(sanitizeK8sName(ExtractTenantID(envURL))); resolved != "" {
+		return resolved
+	}
+	return "dynakube"
+}
+
 // InstallKubernetes deploys the Dynatrace Operator on a Kubernetes cluster.
 //
 // Parameters:
+// Parameters:
 //   - envURL:      Dynatrace environment URL
 //   - token:       platform token used for both apiToken and dataIngestToken in the DynaKube Secret
-//   - clusterName: DynaKube CR name (auto-derived from envURL if empty)
+//   - clusterName: DynaKube CR name; when empty, it is derived from the current kubectl context (falling back to a value derived from envURL)
 //   - distro:      detected Kubernetes distribution (e.g. "GKE", "EKS"); empty falls back to defaults
 //   - dryRun:      when true, only print what would be done
 func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) error {
 	apiURL := APIURL(envURL)
 
-	if clusterName == "" {
-		clusterName = fetchClusterName(sanitizeK8sName(ExtractTenantID(envURL)))
-		if clusterName == "" {
-			clusterName = "dynakube"
-		}
-	}
+	clusterName = resolveClusterName(clusterName, envURL)
 
 	// --- Build manifest ---
 	tmplData := dynakubeTemplateData{

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -288,23 +288,24 @@ func fetchClusterName(fallback string) string {
 // InstallKubernetes deploys the Dynatrace Operator on a Kubernetes cluster.
 //
 // Parameters:
-//   - envURL:  Dynatrace environment URL
-//   - token:   platform token used for both apiToken and dataIngestToken in the DynaKube Secret
-//   - name:    DynaKube CR name (auto-derived from envURL if empty)
-//   - dryRun:  when true, only print what would be done
-func InstallKubernetes(envURL, token, name string, dryRun bool) error {
+//   - envURL:      Dynatrace environment URL
+//   - token:       platform token used for both apiToken and dataIngestToken in the DynaKube Secret
+//   - clusterName: DynaKube CR name (auto-derived from envURL if empty)
+//   - distro:      detected Kubernetes distribution (e.g. "GKE", "EKS"); empty falls back to defaults
+//   - dryRun:      when true, only print what would be done
+func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) error {
 	apiURL := APIURL(envURL)
 
-	if name == "" {
-		name = fetchClusterName(sanitizeK8sName(ExtractTenantID(envURL)))
-		if name == "" {
-			name = "dynakube"
+	if clusterName == "" {
+		clusterName = fetchClusterName(sanitizeK8sName(ExtractTenantID(envURL)))
+		if clusterName == "" {
+			clusterName = "dynakube"
 		}
 	}
 
 	// --- Build manifest ---
 	tmplData := dynakubeTemplateData{
-		ClusterName:      name,
+		ClusterName:      clusterName,
 		APIURL:           apiURL + "/api",
 		APIToken:         token,
 		DataIngestToken:  token,
@@ -335,12 +336,13 @@ func InstallKubernetes(envURL, token, name string, dryRun bool) error {
 
 	if dryRun {
 		fmt.Println("[dry-run] Would deploy Dynatrace Operator on Kubernetes")
-		fmt.Printf("  API URL:    %s\n", apiURL)
-		fmt.Printf("  DynaKube:   %s\n", name)
+		fmt.Printf("  API URL:      %s\n", apiURL)
+		fmt.Printf("  DynaKube:     %s\n", clusterName)
+		fmt.Printf("  Distribution: %s\n", distro)
 		fmt.Println("  Steps:")
 		fmt.Println("    1. Ensure Helm is installed")
 		fmt.Printf("    2. %s\n", helmCmd)
-		fmt.Printf("    3. kubectl apply Secret + DynaKube CRs (cluster: %s)\n", name)
+		fmt.Printf("    3. kubectl apply Secret + DynaKube CRs (cluster: %s)\n", clusterName)
 		fmt.Println("    4. Wait for pods to become ready")
 		return nil
 	}
@@ -351,7 +353,7 @@ func InstallKubernetes(envURL, token, name string, dryRun bool) error {
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace Kubernetes Integration")
 	fmt.Println()
-	fmt.Printf("  Cluster name:  %s\n", name)
+	fmt.Printf("  Cluster name:  %s\n", clusterName)
 	fmt.Printf("  API URL:       %s\n\n", apiURL)
 	fmt.Printf("  %s\n", sep)
 	display.ColorMessage.Println("  dynakube.yaml manifest to be applied:")


### PR DESCRIPTION
## Feature Description

Extends K8s distribution detection with 5 previously missing distros and wires the detected distribution and cluster name into the Kubernetes installer.

**Detection additions:**
- `DetectK8sDistribution`: IKS (server URL), RKE (gitVersion `+rke2`)
- `ProbeK8sSubVariant`: live kubectl probes for GKE Autopilot (kube-system annotations), EKS Bottlerocket (node osImage), TKGI (pks-system namespace active phase)
- `ClassifyK8sSubVariant`: pure function containing classification rules, extracted for testability

**Installer wiring:**
- `InstallKubernetes` now accepts `clusterName` and `distro`; both passed from already-detected `KubernetesInfo` in `install` and `setup` commands, avoiding redundant kubectl calls
- Distribution shown in both dry-run and live preview output

## How to test

Since there'll be another subtask PR, I plan to test for more distributions then. Right now only the ones you have available will be enough.

```sh
# Dry-run against a live cluster (I did with AKS and minikube so far, GCP to be setup for testing)
dtwiz install kubernetes --dry-run

# Verify distribution is detected and printed
dtwiz analyze 
```

## Which other features are affected?
1. `dtwiz setup` — also passes cluster name and distro to the installer now

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.