### PR TITLE
feat: use accessToken only through flags

### DIFF
--- a/.claude/skills/dtwiz-otel/SKILL.md
+++ b/.claude/skills/dtwiz-otel/SKILL.md
@@ -34,7 +34,7 @@ pkg/installer/
 
 ```
 InstallOtelCollectorWithProject()
-├── Validate DT credentials (DT_ENVIRONMENT + DT_ACCESS_TOKEN or DT_PLATFORM_TOKEN)
+├── Validate DT credentials (DT_ENVIRONMENT + DT_PLATFORM_TOKEN; --access-token is opt-in)
 ├── prepareCollectorPlan() — download binary, generate config, find running collectors
 ├── detectAvailableRuntimes() — check for Python, Java, Node.js, Go on PATH
 ├── detectAllProjects() — parallel scan across enabled runtimes
@@ -70,8 +70,8 @@ Process detection is OS-specific (see AGENTS.md); each runtime has its own heuri
 ```go
 // Credentials — never written to disk
 DT_ENVIRONMENT    // e.g. https://abc123.live.dynatrace.com
-DT_ACCESS_TOKEN   // Classic API token (dt0c01.*)
-DT_PLATFORM_TOKEN // Platform API token (dt0s16.*)
+DT_PLATFORM_TOKEN // Platform API token (dt0s16.*) — required; used for API access
+// Access token (dt0c01.*) is opt-in and flag-only: pass --access-token explicitly
 
 // OTel env vars injected into instrumented processes
 OTEL_SERVICE_NAME

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Two URL families — getting this wrong causes 404s or auth errors:
 
 `AuthHeader()`: `dt0c01.*` → `Api-Token <token>`, everything else → `Bearer <token>`.
 
-Credentials resolved from: `--environment`/`--access-token`/`--platform-token` flags → `DT_ENVIRONMENT`/`DT_ACCESS_TOKEN`/`DT_PLATFORM_TOKEN` env vars.
+Credentials resolved from: `--environment` flag → `DT_ENVIRONMENT` env var; `--platform-token` flag → `DT_PLATFORM_TOKEN` env var. The Classic API **access token is opt-in and flag-only**: `--access-token` activates access-token auth and is intentionally **not** read from `DT_ACCESS_TOKEN`, so a leftover env var can never silently switch Classic API calls onto it. When `--access-token` is absent, the platform token is used for Classic API calls too.
 
 ## Key design rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Access-token auth is now opt-in and flag-only: it activates only when `--access-token` is passed explicitly and is no longer read from the `DT_ACCESS_TOKEN` env var. This prevents a leftover `DT_ACCESS_TOKEN` from silently switching Classic API calls off the platform token. When `--access-token` is absent, the platform token is used for Classic API calls.
+
 ## [0.2.22] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Run the following commands in your terminal/console to install and launch `dtwiz
 
 ```bash
 export DT_ENVIRONMENT="https://<your-tenant-domain>"
-export DT_ACCESS_TOKEN="dt0c01.XXXX..."
 export DT_PLATFORM_TOKEN="dt0s16.XXXX..."
 source <(curl -sSL https://raw.githubusercontent.com/dynatrace-oss/dtwiz/main/scripts/install.sh)
 dtwiz setup
@@ -26,7 +25,6 @@ dtwiz setup
 
 ```powershell
 $env:DT_ENVIRONMENT="https://<your-tenant-domain>"
-$env:DT_ACCESS_TOKEN="dt0c01.XXXX..."
 $env:DT_PLATFORM_TOKEN="dt0s16.XXXX..."
 irm https://raw.githubusercontent.com/dynatrace-oss/dtwiz/main/scripts/install.ps1 | iex
 dtwiz setup
@@ -39,8 +37,9 @@ Set the following environment variables before running `dtwiz`:
 | Variable | Description |
 |----------|-------------|
 | `DT_ENVIRONMENT` | Your Dynatrace environment URL (e.g. `https://<your-tenant-domain>`) |
-| `DT_ACCESS_TOKEN` | Classic API token (`dt0c01.*`) — used for OneAgent installer download, OTel ingest, etc. |
-| `DT_PLATFORM_TOKEN` | Platform token (`dt0s16.*`) — used for AWS integration and DQL log verification |
+| `DT_PLATFORM_TOKEN` | Platform token (`dt0s16.*`) — primary credential; used for Platform/DQL and (by default) Classic API calls |
+
+For legacy environments where the platform token lacks Classic API access, opt into a Classic API token (`dt0c01.*`) by passing `--access-token` explicitly. It is intentionally **not** read from `DT_ACCESS_TOKEN` — so a leftover env var can never silently change which token authenticates Classic API calls.
 
 ## Installation
 
@@ -137,7 +136,6 @@ dtwiz install demo --yes    # skip confirmation
 ```bash
 # 1. Set credentials
 export DT_ENVIRONMENT="https://<your-tenant-domain>"
-export DT_ACCESS_TOKEN="dt0c01.XXXX..."
 export DT_PLATFORM_TOKEN="dt0s16.XXXX..."
 
 # 2. Analyze the current system
@@ -191,4 +189,4 @@ dtwiz/
     └── installer/    # Shared utilities + per-method stubs
 ```
 
-Credentials are read from `DT_ENVIRONMENT`, `DT_ACCESS_TOKEN`, and `DT_PLATFORM_TOKEN` environment variables — `dtwiz` never stores tokens itself.
+Credentials are read from the `DT_ENVIRONMENT` and `DT_PLATFORM_TOKEN` environment variables (or the `--environment` / `--platform-token` flags); a legacy Classic API access token is supplied only via the explicit `--access-token` flag. `dtwiz` never stores tokens itself.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -24,13 +24,10 @@ func environmentHint() string {
 }
 
 // accessToken returns the Dynatrace API access token from the --access-token
-// flag or the DT_ACCESS_TOKEN env var (flag takes precedence).
-// Returns an empty string when neither is set.
+// flag. Access-token auth is opt-in and activates only when the flag is
+// passed explicitly on the command line.
 func accessToken() string {
-	if accessTokenFlag != "" {
-		return accessTokenFlag
-	}
-	return os.Getenv("DT_ACCESS_TOKEN")
+	return accessTokenFlag
 }
 
 // platformToken returns a Dynatrace platform token (dt0s16.*) from the

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -51,6 +51,70 @@ func TestCheckClassicAccess_NetworkFailure(t *testing.T) {
 	}
 }
 
+func TestAccessToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		flag   string
+		envVar string
+		want   string
+	}{
+		{"flag set returns flag value", "dt0c01.fromflag", "", "dt0c01.fromflag"},
+		{"flag empty returns empty even when env var set", "", "dt0c01.fromenv", ""},
+		{"flag wins, env var ignored", "dt0c01.fromflag", "dt0c01.fromenv", "dt0c01.fromflag"},
+		{"both empty returns empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := accessTokenFlag
+			accessTokenFlag = tt.flag
+			defer func() { accessTokenFlag = orig }()
+			t.Setenv("DT_ACCESS_TOKEN", tt.envVar)
+
+			if got := accessToken(); got != tt.want {
+				t.Errorf("accessToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDtEnvironment_AccessTokenFlagOnly(t *testing.T) {
+	t.Setenv("DT_ENVIRONMENT", "https://abc12345.dynatracelabs.com/")
+	t.Setenv("DT_PLATFORM_TOKEN", "dt0s16.platform")
+	// A leftover access-token env var must never activate access-token auth.
+	t.Setenv("DT_ACCESS_TOKEN", "dt0c01.leftover")
+
+	t.Run("flag unset — access token empty despite env var", func(t *testing.T) {
+		orig := accessTokenFlag
+		accessTokenFlag = ""
+		defer func() { accessTokenFlag = orig }()
+
+		_, accessTok, platformTok, err := getDtEnvironment()
+		if err != nil {
+			t.Fatalf("getDtEnvironment() unexpected error: %v", err)
+		}
+		if accessTok != "" {
+			t.Errorf("accessTok = %q, want empty (env var must not activate access-token auth)", accessTok)
+		}
+		if platformTok != "dt0s16.platform" {
+			t.Errorf("platformTok = %q, want %q", platformTok, "dt0s16.platform")
+		}
+	})
+
+	t.Run("flag set — access token from flag", func(t *testing.T) {
+		orig := accessTokenFlag
+		accessTokenFlag = "dt0c01.fromflag"
+		defer func() { accessTokenFlag = orig }()
+
+		_, accessTok, _, err := getDtEnvironment()
+		if err != nil {
+			t.Fatalf("getDtEnvironment() unexpected error: %v", err)
+		}
+		if accessTok != "dt0c01.fromflag" {
+			t.Errorf("accessTok = %q, want %q", accessTok, "dt0c01.fromflag")
+		}
+	})
+}
+
 func TestValidateCredentials(t *testing.T) {
 	const platformTok = "dt0s16.platform"
 	const accessTok = "dt0c01.access"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().CountVarP(&verbosityFlag, "verbose", "v", "verbose output")
 	rootCmd.PersistentFlags().StringVar(&environmentFlag, "environment", "", "Dynatrace environment URL (also read from DT_ENVIRONMENT)")
 	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token (also read from DT_PLATFORM_TOKEN)")
-	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token for legacy environments (opt-in; must be passed explicitly — not read from env)")
+	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token for legacy environments (opt-in; must be passed explicitly — not read from the environment variables)")
 
 	featureflags.RegisterFlags(rootCmd.PersistentFlags())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,9 @@ Set your Dynatrace credentials via environment variables:
 
   export DT_ENVIRONMENT=https://<your-tenant-domain>
   export DT_PLATFORM_TOKEN=dt0s16.****
-  export DT_ACCESS_TOKEN=dt0c01.****        # optional, for legacy environments
+
+For legacy environments you can opt into a Classic API access token by passing
+--access-token explicitly (it is intentionally not read from the environment).
 
 Then use dtwiz commands to analyze and instrument your system.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -103,7 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().CountVarP(&verbosityFlag, "verbose", "v", "verbose output")
 	rootCmd.PersistentFlags().StringVar(&environmentFlag, "environment", "", "Dynatrace environment URL (also read from DT_ENVIRONMENT)")
 	rootCmd.PersistentFlags().StringVar(&platformTokenFlag, "platform-token", "", "Dynatrace platform token (also read from DT_PLATFORM_TOKEN)")
-	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token for legacy environments (also read from DT_ACCESS_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&accessTokenFlag, "access-token", "", "Dynatrace API access token for legacy environments (opt-in; must be passed explicitly — not read from env)")
 
 	featureflags.RegisterFlags(rootCmd.PersistentFlags())
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -62,7 +62,6 @@ var statusCmd = &cobra.Command{
 			printCredentialStatus("Access Token", envURL, CredentialToken{
 				value:         accessTok,
 				cliName:       "access-token",
-				envName:       "DT_ACCESS_TOKEN",
 				tokenVerifyFn: checkAccessToken,
 				getUrlFn:      installer.APIURL,
 			})
@@ -126,7 +125,11 @@ func printExtensionsStatus() {
 
 func printCredentialStatus(label, envURL string, token CredentialToken) {
 	if token.value == "" {
-		display.PrintStatusLine(label, fmt.Sprintf("✗ not set (use --%s or %s)", token.cliName, token.envName), display.ColorError)
+		hint := fmt.Sprintf("✗ not set (use --%s)", token.cliName)
+		if token.envName != "" {
+			hint = fmt.Sprintf("✗ not set (use --%s or %s)", token.cliName, token.envName)
+		}
+		display.PrintStatusLine(label, hint, display.ColorError)
 		return
 	}
 	if envURL != "" {

--- a/openspec/changes/access-token-flag-only/.openspec.yaml
+++ b/openspec/changes/access-token-flag-only/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/access-token-flag-only/design.md
+++ b/openspec/changes/access-token-flag-only/design.md
@@ -1,0 +1,32 @@
+## Context
+
+Credentials are resolved in `cmd/auth.go`. `accessToken()` currently returns the `--access-token` flag value, falling back to `os.Getenv("DT_ACCESS_TOKEN")`. `validateCredentials()` validates the platform token via DQL (hard requirement) and, when an explicit access token is set (`accessTok != "" && accessTok != platformTok`), returns it as the Classic API token without probing; otherwise it uses the platform token for API calls. `dtwiz status` renders the Access Token row only when `accessToken() != ""`.
+
+The problem is the env-var fallback: a stale `DT_ACCESS_TOKEN` in the shell is indistinguishable from an intentional one and silently changes which token authenticates Classic API calls.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Access-token auth activates only via an explicit, per-invocation signal (`--access-token`).
+- A leftover `DT_ACCESS_TOKEN` env var can never activate access-token auth.
+- Behavior when no access token is supplied is unchanged: platform token used for Classic API calls.
+
+**Non-Goals:**
+- No access-token content validation in the setup/install path. The token stays trusted-on-use there, exactly as today.
+- No change to platform-token DQL validation, URL families, or `AuthHeader()` scheme selection.
+- No new flag is introduced.
+
+## Decisions
+
+**The value-bearing `--access-token` flag is the opt-in signal — not a separate boolean.** A flag that carries a token value is inherently explicit (you cannot "leftover" a value typed on the command line this invocation), and it carries both intent and a usable value. A separate boolean (e.g. `--access-token-authentication`) was rejected: it would split intent from value, create ambiguous states (boolean without token, token without boolean), and still leave the token sourced from the banned env var.
+
+**Implementation is a one-line behavior change:** `accessToken()` returns only `accessTokenFlag`, dropping the `os.Getenv("DT_ACCESS_TOKEN")` fallback. Everything downstream already keys off `accessToken()` being empty, so `validateCredentials()` and the `status` Access Token row require no logic changes — only the source narrows.
+
+## Risks / Trade-offs
+
+- **[Breaking change for env-var-only users (e.g. CI)]** → Documented in CHANGELOG and README; migration is mechanical: `--access-token "$DT_ACCESS_TOKEN"`. Falling through to platform-token auth is the intended, safer default, not a silent failure.
+- **[Dead "not set" hint branch in `status`]** → `printCredentialStatus` for the access token is only reached when the flag is set, so its `DT_ACCESS_TOKEN` "not set" hint is now unreachable. Left as-is (harmless); not pruned to keep the change minimal.
+
+## Migration Plan
+
+Ship in the next release. Rollback is restoring the `os.Getenv` fallback and prior doc strings — no persisted state or data migration.

--- a/openspec/changes/access-token-flag-only/design.md
+++ b/openspec/changes/access-token-flag-only/design.md
@@ -1,3 +1,5 @@
+# Design: Access Token Flag-Only
+
 ## Context
 
 Credentials are resolved in `cmd/auth.go`. `accessToken()` currently returns the `--access-token` flag value, falling back to `os.Getenv("DT_ACCESS_TOKEN")`. `validateCredentials()` validates the platform token via DQL (hard requirement) and, when an explicit access token is set (`accessTok != "" && accessTok != platformTok`), returns it as the Classic API token without probing; otherwise it uses the platform token for API calls. `dtwiz status` renders the Access Token row only when `accessToken() != ""`.
@@ -7,11 +9,13 @@ The problem is the env-var fallback: a stale `DT_ACCESS_TOKEN` in the shell is i
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Access-token auth activates only via an explicit, per-invocation signal (`--access-token`).
 - A leftover `DT_ACCESS_TOKEN` env var can never activate access-token auth.
 - Behavior when no access token is supplied is unchanged: platform token used for Classic API calls.
 
 **Non-Goals:**
+
 - No access-token content validation in the setup/install path. The token stays trusted-on-use there, exactly as today.
 - No change to platform-token DQL validation, URL families, or `AuthHeader()` scheme selection.
 - No new flag is introduced.

--- a/openspec/changes/access-token-flag-only/proposal.md
+++ b/openspec/changes/access-token-flag-only/proposal.md
@@ -1,3 +1,5 @@
+# Proposal: Access Token Flag-Only
+
 ## Why
 
 The Classic API access token (`dt0c01.*`) is resolved from either the `--access-token` flag **or** the `DT_ACCESS_TOKEN` env var. A leftover `DT_ACCESS_TOKEN` exported in a user's shell therefore silently switches API calls off the platform token and onto an access token the user never intended to use for this invocation — with no way to tell an intentional token from a stale one. As Dynatrace deprecates access tokens, the safe default is platform-token auth, and access-token use should require an explicit, per-invocation signal.

--- a/openspec/changes/access-token-flag-only/proposal.md
+++ b/openspec/changes/access-token-flag-only/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The Classic API access token (`dt0c01.*`) is resolved from either the `--access-token` flag **or** the `DT_ACCESS_TOKEN` env var. A leftover `DT_ACCESS_TOKEN` exported in a user's shell therefore silently switches API calls off the platform token and onto an access token the user never intended to use for this invocation — with no way to tell an intentional token from a stale one. As Dynatrace deprecates access tokens, the safe default is platform-token auth, and access-token use should require an explicit, per-invocation signal.
+
+## What Changes
+
+- **BREAKING**: Access-token auth is now opt-in and **flag-only**. It activates only when `--access-token` is passed explicitly on the command line. `DT_ACCESS_TOKEN` is no longer read as an activation source.
+- When `--access-token` is absent, the platform token is used for API calls (unchanged behavior for the no-access-token case).
+- `accessToken()` returns only the `--access-token` flag value; the `os.Getenv("DT_ACCESS_TOKEN")` fallback is removed.
+- `dtwiz status` shows the Access Token row only when `--access-token` is provided (it is no longer triggered by the env var).
+- Help text, README, AGENTS.md, and the OneAgent download error hint no longer present `DT_ACCESS_TOKEN` as a way to enable access-token auth.
+- **Out of scope (explicitly):** no access-token content validation is added to the setup/install path. The token remains trusted-on-use there, exactly as before.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `platform-token-primary-auth`: the "Access token is optional; used as Classic API fallback" requirement and the status-output requirement change — access-token auth is gated on the explicit `--access-token` flag and is no longer sourced from `DT_ACCESS_TOKEN`.
+
+## Impact
+
+- **Code**: `cmd/auth.go` (`accessToken()` drops env fallback), `cmd/root.go` (flag help + root `Long` text), `cmd/status.go` (Access Token row gating, already flag-driven via `accessToken()`), `pkg/installer/oneagent/download.go` (error hint).
+- **Docs**: `README.md`, `AGENTS.md`, `CHANGELOG.md`.
+- **Behavioral / compat**: users (e.g. CI pipelines) relying on `DT_ACCESS_TOKEN` alone will fall through to platform-token auth for Classic API calls. They must switch to `--access-token "$DT_ACCESS_TOKEN"`. Called out in CHANGELOG.
+- **Tests**: add `cmd` unit tests covering `accessToken()` flag-only resolution and `getDtEnvironment()` / `validateCredentials()` behavior with and without the flag (env var present must not activate access-token auth).
+
+## Rollback
+
+Revert is low-risk and self-contained: restore the `os.Getenv("DT_ACCESS_TOKEN")` fallback in `accessToken()` and the prior help/doc strings. No persisted state or migrations are involved.

--- a/openspec/changes/access-token-flag-only/specs/platform-token-primary-auth/spec.md
+++ b/openspec/changes/access-token-flag-only/specs/platform-token-primary-auth/spec.md
@@ -1,3 +1,5 @@
+# Delta Spec: Platform Token Primary Auth
+
 ## MODIFIED Requirements
 
 ### Requirement: Access token is optional; used as Classic API fallback

--- a/openspec/changes/access-token-flag-only/specs/platform-token-primary-auth/spec.md
+++ b/openspec/changes/access-token-flag-only/specs/platform-token-primary-auth/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Access token is optional; used as Classic API fallback
+
+Access token is optional and **opt-in via the `--access-token` flag only**. It activates for Classic API calls solely when `--access-token` is passed explicitly on the command line. The `DT_ACCESS_TOKEN` environment variable SHALL NOT be read as an activation source, so a leftover env var can never switch Classic API calls onto access-token auth. When `--access-token` is absent, the platform token is used for Classic API calls. This opt-in path exists only until all Classic API endpoints accept platform tokens.
+
+#### Scenario: Access token provided via flag
+
+- **GIVEN** `--access-token dt0c01.****` is passed and differs from the platform token
+- **WHEN** the user runs any command requiring Classic API access
+- **THEN** the access token is used for Classic API calls and `--debug` logs `classic API auth: using explicit access token`
+
+#### Scenario: DT_ACCESS_TOKEN set but flag absent
+
+- **GIVEN** `DT_ACCESS_TOKEN` is exported but `--access-token` is NOT passed
+- **WHEN** the user runs any command
+- **THEN** the access token is ignored and the platform token is used for API calls
+
+#### Scenario: No access token configured
+
+- **GIVEN** Only `DT_PLATFORM_TOKEN` (or `--platform-token`) is set
+- **WHEN** the user runs any install command (e.g. `dtwiz install otel --dry-run`)
+- **THEN** the command completes using the platform token for Classic API calls
+
+---
+
+### Requirement: Status output labels access token as optional fallback
+
+`dtwiz status` SHALL show the Access Token row only when `--access-token` is provided. The row SHALL NOT be triggered by the `DT_ACCESS_TOKEN` env var.
+
+#### Scenario: Access token flag provided
+
+- **GIVEN** `--access-token` is passed and `DT_ENVIRONMENT` resolves to a reachable environment
+- **WHEN** the user runs `dtwiz status`
+- **THEN** the output shows a `Platform Token` row and an `Access Token` row
+
+#### Scenario: Flag absent (env var ignored)
+
+- **GIVEN** `--access-token` is NOT passed, even if `DT_ACCESS_TOKEN` is exported
+- **WHEN** the user runs `dtwiz status`
+- **THEN** no Access Token row is shown and only the `Platform Token` row appears

--- a/openspec/changes/access-token-flag-only/tasks.md
+++ b/openspec/changes/access-token-flag-only/tasks.md
@@ -1,0 +1,17 @@
+## 1. Code (already implemented)
+
+- [x] 1.1 `cmd/auth.go`: `accessToken()` returns only `accessTokenFlag`; drop the `os.Getenv("DT_ACCESS_TOKEN")` fallback
+- [x] 1.2 `cmd/root.go`: update `--access-token` flag help and root `Long` text to state the token is opt-in and not read from env
+- [x] 1.3 `pkg/installer/oneagent/download.go`: drop `DT_ACCESS_TOKEN` from the 401/403 error hint
+- [x] 1.4 Docs: update `README.md` and `AGENTS.md`; add `Changed` entry to `CHANGELOG.md`
+
+## 2. Tests
+
+- [x] 2.1 `cmd/auth_test.go`: add `TestAccessToken` — flag set returns flag value; flag empty returns "" even when `DT_ACCESS_TOKEN` env var is set (use `t.Setenv`); restore `accessTokenFlag` after each case
+- [x] 2.2 `cmd/auth_test.go`: add `TestGetDtEnvironment_AccessTokenFlagOnly` — with env + platform-token set and `DT_ACCESS_TOKEN` exported but the flag unset, `getDtEnvironment()` returns an empty `accessTok`; with the flag set it returns the flag value
+
+## 3. Verify
+
+- [x] 3.1 `make test` — all pass
+- [x] 3.2 `make lint` — no new issues
+- [x] 3.3 `openspec validate access-token-flag-only` passes

--- a/openspec/changes/access-token-flag-only/tasks.md
+++ b/openspec/changes/access-token-flag-only/tasks.md
@@ -1,3 +1,5 @@
+# Tasks: Access Token Flag-Only
+
 ## 1. Code (already implemented)
 
 - [x] 1.1 `cmd/auth.go`: `accessToken()` returns only `accessTokenFlag`; drop the `os.Getenv("DT_ACCESS_TOKEN")` fallback

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,8 +20,7 @@ type Client struct {
 }
 
 // ClassicClient calls the Classic Dynatrace API (no .apps. in URL),
-// authenticated with the platform token by default or an explicit access token
-// when --access-token is provided.
+// authenticated with the token configured when constructing the client.
 type ClassicClient struct {
 	http    *resty.Client
 	baseURL string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,15 +13,15 @@ import (
 )
 
 // Client is the top-level HTTP client for Dynatrace API calls.
-// It exposes a ClassicClient (Classic API, DT_ACCESS_TOKEN) and a
-// PlatformClient (Platform/Apps API, DT_PLATFORM_TOKEN).
+// It exposes a ClassicClient (Classic API) and a PlatformClient (Platform/Apps API).
 type Client struct {
 	Classic  *ClassicClient
 	Platform *PlatformClient
 }
 
-// ClassicClient calls the Classic Dynatrace API (no .apps. in URL)
-// authenticated with DT_ACCESS_TOKEN.
+// ClassicClient calls the Classic Dynatrace API (no .apps. in URL),
+// authenticated with the platform token by default or an explicit access token
+// when --access-token is provided.
 type ClassicClient struct {
 	http    *resty.Client
 	baseURL string

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -69,9 +69,9 @@ func TestPrintStatusLine_FormatsLabelAndMessage(t *testing.T) {
 
 func TestPrintStatusLine_ErrorMessage(t *testing.T) {
 	got := captureOutput(t, func() {
-		PrintStatusLine("Access Token", "✗ not set (use --access-token or DT_ACCESS_TOKEN)", ColorError)
+		PrintStatusLine("Access Token", "✗ not set (use --access-token)", ColorError)
 	})
-	want := "  Access Token:  ✗ not set (use --access-token or DT_ACCESS_TOKEN)\n"
+	want := "  Access Token:  ✗ not set (use --access-token)\n"
 	if got != want {
 		t.Errorf("PrintStatusLine() = %q, want %q", got, want)
 	}

--- a/pkg/installer/oneagent/download.go
+++ b/pkg/installer/oneagent/download.go
@@ -101,7 +101,7 @@ func DownloadInstaller(c *client.ClassicClient, env Environment) (string, error)
 		if resp.StatusCode() == http.StatusForbidden || resp.StatusCode() == http.StatusUnauthorized {
 			return "", fmt.Errorf(
 				"installer download failed (%d) — if using a platform token, ensure it has the InstallerDownload scope; "+
-					"or pass a dt0c01.* access token with --access-token or DT_ACCESS_TOKEN.\n"+
+					"or pass a dt0c01.* access token with --access-token.\n"+
 					"Run with --debug for the API error detail",
 				resp.StatusCode(),
 			)

--- a/skills/dtwiz/SKILL.md
+++ b/skills/dtwiz/SKILL.md
@@ -15,11 +15,12 @@ Go CLI that detects your environment and deploys the best Dynatrace monitoring m
 
 ```bash
 export DT_ENVIRONMENT=https://<your-tenant-domain>
-export DT_ACCESS_TOKEN=dt0c01.****
-export DT_PLATFORM_TOKEN=dt0s16.****    # optional, needed for AWS installer
+export DT_PLATFORM_TOKEN=dt0s16.****
 ```
 
-Or pass per-command: `--environment`, `--access-token`, `--platform-token`.
+Or pass per-command: `--environment`, `--platform-token`.
+
+For environments where the access token is required, pass `--access-token dt0c01.****` explicitly.
 
 ## Recommended Initialization
 


### PR DESCRIPTION
## Description

- [x] New feature

Access-token auth is now opt-in and flag-only. Previously, `DT_ACCESS_TOKEN` being set in the environment was enough to activate access-token auth for Classic API calls. This means a leftover environment variable from a previous session could silently change which token authenticates your requests. Now it only activates when `--access-token` is passed explicitly on the command line.

## How to test

**Without access token (default path):**
1. Export only `DT_ENVIRONMENT` and `DT_PLATFORM_TOKEN` (unset `DT_ACCESS_TOKEN` if present)
2. Run `dtwiz status` — only the Platform Token row should appear, no Access Token row
3. Run `dtwiz install otel` — should complete without errors using the platform token

**With a leftover env var (the bug this fixes):**
1. Export `DT_ENVIRONMENT`, `DT_PLATFORM_TOKEN`, and a stale `DT_ACCESS_TOKEN`
2. Run `dtwiz status` — the Access Token row should **not** appear; the env var must be ignored
3. Run any install command — it should use the platform token, not the access token

**With explicit access token (legacy path):**
1. Export `DT_ENVIRONMENT` and `DT_PLATFORM_TOKEN`
2. Run `dtwiz status --access-token <your-dt0c01-token>` — both Platform Token and Access Token rows should appear and validate
3. Run an install command with `--access-token <token>` — should use the access token for Classic API calls
(DISCLAIMER: if you don't have a proper access token, use a broken one and test if authentication error happens)

## Which other features are affected?

1. `dtwiz status` — the Access Token row is no longer shown when `DT_ACCESS_TOKEN` is set without the flag
2. Any workflow relying solely on `DT_ACCESS_TOKEN` being exported (e.g. CI pipelines) must migrate to passing `--access-token "$DT_ACCESS_TOKEN"` explicitly

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
