### PR TITLE
fix: uninstall OneAgent completely on Linux

### DIFF
--- a/pkg/installer/oneagent_uninstall.go
+++ b/pkg/installer/oneagent_uninstall.go
@@ -35,8 +35,11 @@ func UninstallOneAgent(dryRun bool) error {
 
 func uninstallOneAgentLinux(dryRun bool) error {
 	logger.Debug("checking for OneAgent uninstall script", "path", linuxUninstallScript)
-	if _, err := os.Stat(linuxUninstallScript); os.IsNotExist(err) {
-		return fmt.Errorf("OneAgent uninstall script not found at %s — is OneAgent installed?", linuxUninstallScript)
+	if _, err := os.Stat(linuxUninstallScript); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("OneAgent uninstall script not found at %s — is OneAgent installed?", linuxUninstallScript)
+		}
+		return fmt.Errorf("cannot access OneAgent uninstall script at %s: %w", linuxUninstallScript, err)
 	}
 
 	header := color.New(color.FgMagenta, color.Bold)
@@ -55,7 +58,15 @@ func uninstallOneAgentLinux(dryRun bool) error {
 	fmt.Println()
 
 	if dryRun {
-		fmt.Println("[dry-run] Would run the OneAgent uninstall script. No changes made.")
+		fmt.Println("[dry-run] Would run:")
+		if needsSudo {
+			fmt.Printf("  sudo %s\n", linuxUninstallScript)
+			fmt.Printf("  sudo rm -rf %s\n", linuxInstallDir)
+		} else {
+			fmt.Printf("  %s\n", linuxUninstallScript)
+			fmt.Printf("  rm -rf %s\n", linuxInstallDir)
+		}
+		fmt.Println("No changes made.")
 		return nil
 	}
 
@@ -83,44 +94,43 @@ func uninstallOneAgentLinux(dryRun bool) error {
 
 	// The Dynatrace uninstall script removes agent/ contents but leaves the
 	// parent install directory as an empty stub. Clean it up.
+	cleanupOK := true
 	if err := removeResidualDir(linuxInstallDir, needsSudo); err != nil {
+		cleanupOK = false
 		logger.Warn("could not remove residual install directory", "path", linuxInstallDir, "error", err)
 		fmt.Printf("  Warning: could not remove %s: %v\n", linuxInstallDir, err)
 	}
 
-	// A permission error on stat doesn't mean the directory is absent.
-	if _, statErr := os.Stat(linuxStateDir); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(linuxStateDir); statErr == nil {
 		logger.Debug("state directory preserved by uninstall script", "path", linuxStateDir)
 		fmt.Printf("  Note: configuration preserved at %s\n", linuxStateDir)
 	}
 
-	color.New(color.FgGreen, color.Bold).Println("\n  OneAgent uninstalled successfully.")
+	if cleanupOK {
+		color.New(color.FgGreen, color.Bold).Println("\n  OneAgent uninstalled successfully.")
+	} else {
+		color.New(color.FgYellow, color.Bold).Println("\n  OneAgent uninstalled (residual directory could not be removed; see warning above).")
+	}
 	return nil
 }
 
 func removeResidualDir(path string, needsSudo bool) error {
+	if info, err := os.Stat(path); err == nil {
+		if !info.IsDir() {
+			logger.Debug("residual path is not a directory, skipping", "path", path)
+			return nil
+		}
+	} else if os.IsNotExist(err) {
+		logger.Debug("residual directory already absent", "path", path)
+		return nil
+	}
+
 	if needsSudo {
-		// Skip stat — a permission error on stat does not mean sudo rm -rf will
-		// fail, and rm -rf is a no-op when the path is absent (-f suppresses the
-		// "no such file" error).
 		logger.Debug("removing residual install directory", "path", path, "needs_sudo", true)
 		if err := RunCommand("sudo", "rm", "-rf", path); err != nil {
 			return fmt.Errorf("sudo rm -rf %s: %w", path, err)
 		}
 		logger.Verbose("removed residual install directory", "path", path)
-		return nil
-	}
-
-	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		logger.Debug("residual directory already absent", "path", path)
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("stat %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		logger.Debug("residual path is not a directory, skipping", "path", path)
 		return nil
 	}
 

--- a/pkg/installer/oneagent_uninstall.go
+++ b/pkg/installer/oneagent_uninstall.go
@@ -6,11 +6,18 @@ import (
 	"runtime"
 
 	"github.com/fatih/color"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 const (
-	// Linux: standard uninstall script path.
 	linuxUninstallScript = "/opt/dynatrace/oneagent/agent/uninstall.sh"
+
+	// Stub directory left behind by the uninstall script; we clean it up.
+	linuxInstallDir = "/opt/dynatrace/oneagent"
+
+	// Preserved by the uninstall script for potential reinstall.
+	linuxStateDir = "/var/lib/dynatrace/oneagent"
 )
 
 // UninstallOneAgent removes Dynatrace OneAgent from the current host.
@@ -28,7 +35,7 @@ func UninstallOneAgent(dryRun bool) error {
 }
 
 func uninstallOneAgentLinux(dryRun bool) error {
-	// Verify the uninstall script exists.
+	logger.Debug("checking for OneAgent uninstall script", "path", linuxUninstallScript)
 	if _, err := os.Stat(linuxUninstallScript); os.IsNotExist(err) {
 		return fmt.Errorf("OneAgent uninstall script not found at %s — is OneAgent installed?", linuxUninstallScript)
 	}
@@ -41,7 +48,9 @@ func uninstallOneAgentLinux(dryRun bool) error {
 	fmt.Println()
 	fmt.Printf("  Uninstall script:  %s\n", linuxUninstallScript)
 
-	if NeedsSudo() {
+	needsSudo := NeedsSudo()
+	logger.Debug("privilege check", "needs_sudo", needsSudo)
+	if needsSudo {
 		fmt.Println("  Privileges:        sudo required (current user is not root)")
 	}
 	fmt.Println()
@@ -63,16 +72,62 @@ func uninstallOneAgentLinux(dryRun bool) error {
 
 	// Run the uninstall script, prepending sudo if needed.
 	args := []string{linuxUninstallScript}
-	if NeedsSudo() {
+	if needsSudo {
 		args = append([]string{"sudo"}, args...)
 	}
+	logger.Debug("running uninstall script", "argv", args)
 
 	fmt.Println("  Running OneAgent uninstall script...")
 	if err := RunCommand(args[0], args[1:]...); err != nil {
 		return fmt.Errorf("OneAgent uninstall failed: %w", err)
 	}
+	logger.Verbose("uninstall script completed successfully")
+
+	// The Dynatrace uninstall script removes agent/ contents but leaves the
+	// parent install directory as an empty stub. Clean it up.
+	if err := removeResidualDir(linuxInstallDir, needsSudo); err != nil {
+		logger.Warn("could not remove residual install directory", "path", linuxInstallDir, "error", err)
+		fmt.Printf("  Warning: could not remove %s: %v\n", linuxInstallDir, err)
+	}
+
+	// Inform the user about the preserved state directory (intentionally kept
+	// by the uninstall script for potential reinstall).
+	if _, statErr := os.Stat(linuxStateDir); statErr == nil {
+		logger.Debug("state directory preserved by uninstall script", "path", linuxStateDir)
+		fmt.Printf("  Note: configuration preserved at %s\n", linuxStateDir)
+	}
 
 	color.New(color.FgGreen, color.Bold).Println("\n  OneAgent uninstalled successfully.")
+	return nil
+}
+
+func removeResidualDir(path string, needsSudo bool) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		logger.Debug("residual directory already absent", "path", path)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		logger.Debug("residual path is not a directory, skipping", "path", path)
+		return nil
+	}
+
+	logger.Debug("removing residual install directory", "path", path, "needs_sudo", needsSudo)
+
+	if needsSudo {
+		if err := RunCommand("sudo", "rm", "-rf", path); err != nil {
+			return fmt.Errorf("sudo rm -rf %s: %w", path, err)
+		}
+	} else {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("rm -rf %s: %w", path, err)
+		}
+	}
+
+	logger.Verbose("removed residual install directory", "path", path)
 	return nil
 }
 

--- a/pkg/installer/oneagent_uninstall.go
+++ b/pkg/installer/oneagent_uninstall.go
@@ -16,7 +16,6 @@ const (
 	// Stub directory left behind by the uninstall script; we clean it up.
 	linuxInstallDir = "/opt/dynatrace/oneagent"
 
-	// Preserved by the uninstall script for potential reinstall.
 	linuxStateDir = "/var/lib/dynatrace/oneagent"
 )
 
@@ -70,7 +69,6 @@ func uninstallOneAgentLinux(dryRun bool) error {
 	}
 	fmt.Println()
 
-	// Run the uninstall script, prepending sudo if needed.
 	args := []string{linuxUninstallScript}
 	if needsSudo {
 		args = append([]string{"sudo"}, args...)
@@ -90,9 +88,8 @@ func uninstallOneAgentLinux(dryRun bool) error {
 		fmt.Printf("  Warning: could not remove %s: %v\n", linuxInstallDir, err)
 	}
 
-	// Inform the user about the preserved state directory (intentionally kept
-	// by the uninstall script for potential reinstall).
-	if _, statErr := os.Stat(linuxStateDir); statErr == nil {
+	// A permission error on stat doesn't mean the directory is absent.
+	if _, statErr := os.Stat(linuxStateDir); !os.IsNotExist(statErr) {
 		logger.Debug("state directory preserved by uninstall script", "path", linuxStateDir)
 		fmt.Printf("  Note: configuration preserved at %s\n", linuxStateDir)
 	}
@@ -102,6 +99,18 @@ func uninstallOneAgentLinux(dryRun bool) error {
 }
 
 func removeResidualDir(path string, needsSudo bool) error {
+	if needsSudo {
+		// Skip stat — a permission error on stat does not mean sudo rm -rf will
+		// fail, and rm -rf is a no-op when the path is absent (-f suppresses the
+		// "no such file" error).
+		logger.Debug("removing residual install directory", "path", path, "needs_sudo", true)
+		if err := RunCommand("sudo", "rm", "-rf", path); err != nil {
+			return fmt.Errorf("sudo rm -rf %s: %w", path, err)
+		}
+		logger.Verbose("removed residual install directory", "path", path)
+		return nil
+	}
+
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		logger.Debug("residual directory already absent", "path", path)
@@ -115,18 +124,10 @@ func removeResidualDir(path string, needsSudo bool) error {
 		return nil
 	}
 
-	logger.Debug("removing residual install directory", "path", path, "needs_sudo", needsSudo)
-
-	if needsSudo {
-		if err := RunCommand("sudo", "rm", "-rf", path); err != nil {
-			return fmt.Errorf("sudo rm -rf %s: %w", path, err)
-		}
-	} else {
-		if err := os.RemoveAll(path); err != nil {
-			return fmt.Errorf("rm -rf %s: %w", path, err)
-		}
+	logger.Debug("removing residual install directory", "path", path, "needs_sudo", false)
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("rm -rf %s: %w", path, err)
 	}
-
 	logger.Verbose("removed residual install directory", "path", path)
 	return nil
 }

--- a/pkg/installer/oneagent_uninstall_test.go
+++ b/pkg/installer/oneagent_uninstall_test.go
@@ -1,0 +1,64 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveResidualDir_PathAbsent(t *testing.T) {
+	dir := t.TempDir()
+	absent := filepath.Join(dir, "nonexistent")
+
+	if err := removeResidualDir(absent, false); err != nil {
+		t.Errorf("expected no error for absent path, got: %v", err)
+	}
+}
+
+func TestRemoveResidualDir_PathIsFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "somefile")
+	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeResidualDir(file, false); err != nil {
+		t.Errorf("expected no error for file path, got: %v", err)
+	}
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		t.Error("file was removed, but removeResidualDir should skip non-directories")
+	}
+}
+
+func TestRemoveResidualDir_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "stub")
+	if err := os.Mkdir(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeResidualDir(target, false); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected directory to be removed")
+	}
+}
+
+func TestRemoveResidualDir_NonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "stub")
+	if err := os.MkdirAll(filepath.Join(target, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "sub", "file.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeResidualDir(target, false); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("expected directory tree to be removed")
+	}
+}


### PR DESCRIPTION
## Description

- [x] Bug fix

After running `dtwiz uninstall oneagent`, the existing uninstall script leaves behind a stub directory at `/opt/dynatrace/oneagent`. This PR removes the leftover directory after the script completes.

## How to test
1. use this PR's snapshot
2. Install OneAgent on a Linux host
3. Run `dtwiz uninstall oneagent`
4. Confirm `/opt/dynatrace/oneagent` no longer exists after uninstall completes: `ls /opt/dynatrace/oneagent`
5. `systemctl status oneagent` should return `Unit oneagent.service could not be found.`
6. `pgrep -a oneagent` should produce no output

## Which other features are affected?
1. None — change is isolated to `pkg/installer/oneagent_uninstall.go`

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
