### PR TITLE
feat: add distro handling to yaml rendering

### DIFF
--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distribution-detection/spec.md
@@ -4,24 +4,26 @@
 
 ### Requirement: Detect GKE Autopilot as distinct from GKE Standard
 
-The system SHALL identify a GKE Autopilot cluster by probing the `kube-system` namespace annotations for the `autopilot.gke.io` key after the parent GKE distro is confirmed. The returned distribution string SHALL be `"GKE-Autopilot"`.
+The system SHALL identify a GKE Autopilot cluster by checking node names after the parent GKE distro is confirmed. GKE Autopilot nodes always use the `gk3-` name prefix; GKE Standard nodes use `gke-`. The returned distribution string SHALL be `"GKE-Autopilot"`.
+
+Note: the `autopilot.gke.io` annotation previously used for this check is absent on current GKE Autopilot clusters. The `cloud.google.com/gke-provisioning` node label is also unreliable (reports `standard` on Autopilot nodes). Node name prefix is the officially documented signal per GKE Autopilot node naming conventions.
 
 #### Scenario: Autopilot cluster detected
 
 - **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
-- **WHEN** `kubectl get namespace kube-system` annotations contain `autopilot.gke.io`
+- **WHEN** `kubectl get nodes -o jsonpath={.items[*].metadata.name}` returns at least one node name starting with `gk3-`
 - **THEN** `ProbeK8sSubVariant` returns `"GKE-Autopilot"`
 
 #### Scenario: Standard GKE cluster unchanged
 
 - **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
-- **WHEN** `kube-system` annotations do NOT contain `autopilot.gke.io`
+- **WHEN** all node names start with `gke-` (no `gk3-` prefix found)
 - **THEN** `ProbeK8sSubVariant` returns `"GKE"`
 
 #### Scenario: Probe fails gracefully
 
 - **GIVEN** `DetectK8sDistribution` has returned `"GKE"`
-- **WHEN** the `kubectl get namespace kube-system` call returns an error or times out
+- **WHEN** the `kubectl get nodes` call returns an error or times out
 - **THEN** `ProbeK8sSubVariant` returns the parent distro unchanged (`"GKE"`)
 
 ### Requirement: Detect EKS Bottlerocket as distinct from EKS Standard

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -104,21 +104,23 @@ The system SHALL add `feature.dynatrace.com/oneagent-privileged: "true"` to the 
 - **WHEN** distro is any value other than `"OpenShift"`
 - **THEN** neither DynaKube in the rendered manifest contains `oneagent-privileged`
 
-### Requirement: Bottlerocket manifests carry readonly-volume annotation on both DynaKubes
+### Requirement: Bottlerocket manifests SHALL NOT carry the injection-readonly-volume annotation
 
-The system SHALL add `feature.dynatrace.com/injection-readonly-volume: "true"` to the metadata annotations of both DynaKube objects when the distribution is EKS-Bottlerocket.
+The `feature.dynatrace.com/injection-readonly-volume: "true"` annotation was required for Dynatrace Operator **0.12.0+** and **< 1.7.0** to make the injected CSI volume read-only on Bottlerocket nodes. Starting with Operator **1.7.0**, read-only CSI volumes are injected automatically — no annotation is needed. dtwiz targets Operator ≥ 1.7.0; the annotation MUST NOT be added to any DynaKube manifest regardless of distro.
 
-#### Scenario: Annotation present on both DynaKubes
+Reference: [Dynatrace Docs — injection-readonly-volume](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/guides/networking-security-compliance/advanced-security-configurations/injection-readonly-volume)
+
+#### Scenario: Annotation absent on EKS-Bottlerocket
 
 - **GIVEN** `InstallKubernetes()` is called
 - **WHEN** distro is `"EKS-Bottlerocket"`
-- **THEN** both DynaKube objects in the rendered manifest contain `feature.dynatrace.com/injection-readonly-volume: "true"`
+- **THEN** neither DynaKube in the rendered manifest contains `feature.dynatrace.com/injection-readonly-volume`
 
-#### Scenario: Annotation absent on non-Bottlerocket distros
+#### Scenario: Annotation absent on all other distros
 
 - **GIVEN** `InstallKubernetes()` is called
-- **WHEN** distro is any value other than `"EKS-Bottlerocket"`
-- **THEN** neither DynaKube contains `injection-readonly-volume`
+- **WHEN** distro is any value
+- **THEN** no DynaKube in the rendered manifest contains `feature.dynatrace.com/injection-readonly-volume`
 
 ### Requirement: Non-standard kubelet paths set in manifest for IKS and TKGI
 

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -136,6 +136,28 @@ The system SHALL set the appropriate `kubeletPath` in the rendered DynaKube spec
 - **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE, or generic kubernetes
 - **THEN** rendered manifest does NOT contain `kubeletPath`
 
+### Requirement: Templates block belongs only in DynaKube #2 (agents), not DynaKube #1 (monitoring)
+
+Per the Dynatrace Kubernetes onboarding guidelines for each supported distribution, DynaKube #1 (monitoring) SHALL contain only `activeGate` with the `kubernetes-monitoring` capability and the optional KSPM block. Extension and image templates (EEC, OTel collector, log module) belong exclusively in DynaKube #2 (agents), alongside `telemetryIngest`, `logMonitoring: {}`, and `extensions`. DynaKube #1 SHALL NOT carry these fields. When KSPM is enabled, only `kspmNodeConfigurationCollector` appears under `templates` in DynaKube #1.
+
+#### Scenario: DynaKube #1 templates limited to kspmNodeConfigurationCollector
+
+- **GIVEN** `InstallKubernetes()` is called with a KSPM-enabled distro
+- **WHEN** the manifest is rendered
+- **THEN** DynaKube #1 `templates` contains only `kspmNodeConfigurationCollector`; no EEC, OTel, or logModule entries
+
+#### Scenario: DynaKube #1 has no templates block when KSPM disabled
+
+- **GIVEN** `InstallKubernetes()` is called with a non-KSPM distro
+- **WHEN** the manifest is rendered
+- **THEN** DynaKube #1 has no `templates` block at all
+
+#### Scenario: DynaKube #2 carries all extension templates
+
+- **GIVEN** `InstallKubernetes()` is called for any distro
+- **WHEN** the manifest is rendered
+- **THEN** DynaKube #2 `templates` contains EEC, OTel collector, and log module image refs; `telemetryIngest`, `logMonitoring: {}`, and `extensions.prometheus: {}` are also present in DynaKube #2
+
 ### Requirement: ClusterRoleBinding included in all rendered manifests
 
 The system SHALL include a `ClusterRoleBinding` for `dynatrace-kubernetes-monitoring-sensitive` in every rendered manifest, binding to the `dynatrace-activegate` service account.

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -46,6 +46,12 @@ The system SHALL include the `kspm.mappedHostPaths` block and `kspmNodeConfigura
 - **WHEN** distro is `"kubernetes"` or empty
 - **THEN** rendered manifest contains `mappedHostPaths` block
 
+#### Scenario: KSPM rendered for local dev distros (minikube, kind, k3s)
+
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** distro is `"minikube"`, `"kind"`, or `"k3s"`
+- **THEN** rendered manifest contains `mappedHostPaths` block, no privileged or readonly-volume annotations, and no `kubeletPath` field — identical behavior to generic `"kubernetes"`
+
 #### Scenario: KSPM omitted for GKE
 
 - **GIVEN** `InstallKubernetes()` is called
@@ -133,7 +139,7 @@ The system SHALL set the appropriate `kubeletPath` in the rendered DynaKube spec
 #### Scenario: kubeletPath absent for standard distros
 
 - **GIVEN** `InstallKubernetes()` is called
-- **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE, or generic kubernetes
+- **WHEN** distro is GKE, GKE-Autopilot, EKS, AKS, OpenShift, RKE, generic kubernetes, minikube, kind, or k3s
 - **THEN** rendered manifest does NOT contain `kubeletPath`
 
 ### Requirement: Templates block belongs only in DynaKube #2 (agents), not DynaKube #1 (monitoring)

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -182,6 +182,18 @@ The system SHALL pass `--set csidriver.enabled=false` to the Helm install/upgrad
 - **WHEN** distro is any value other than `"GKE-Autopilot"`
 - **THEN** the Helm command does NOT include `--set csidriver.enabled=false`
 
+### Requirement: ClusterRole aggregation label SHALL NOT appear in rendered manifests
+
+The label `rbac.dynatrace.com/aggregate-to-monitoring: "true"` was used in Dynatrace Operator **≤ 1.8.0** to aggregate ClusterRoles into the `dynatrace-kubernetes-monitoring` aggregated ClusterRole. Starting with Operator **1.9.0**, aggregated ClusterRoles are no longer used — the operator uses standard ClusterRoles exclusively. dtwiz targets Operator ≥ 1.7.0; this label MUST NOT appear in any rendered manifest.
+
+Reference: [Dynatrace Docs — ClusterRole aggregation](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/guides/deployment-and-configuration/cluster-role-aggregation#default-permissions)
+
+#### Scenario: Aggregation label absent
+
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** any distro string is passed
+- **THEN** rendered manifest does NOT contain `rbac.dynatrace.com/aggregate-to-monitoring`
+
 ### Requirement: ClusterRoleBinding included in all rendered manifests
 
 The system SHALL include a `ClusterRoleBinding` for `dynatrace-kubernetes-monitoring-sensitive` in every rendered manifest, binding to the `dynatrace-activegate` service account.

--- a/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
+++ b/openspec/changes/k8s-distro-aware-installer/specs/k8s-distro-aware-manifest/spec.md
@@ -164,6 +164,22 @@ Per the Dynatrace Kubernetes onboarding guidelines for each supported distributi
 - **WHEN** the manifest is rendered
 - **THEN** DynaKube #2 `templates` contains EEC, OTel collector, and log module image refs; `telemetryIngest`, `logMonitoring: {}`, and `extensions.prometheus: {}` are also present in DynaKube #2
 
+### Requirement: Helm CSI driver disabled on GKE Autopilot
+
+The system SHALL pass `--set csidriver.enabled=false` to the Helm install/upgrade command when the distribution is `"GKE-Autopilot"`. GKE Autopilot blocks privileged containers and write-mode hostPath mounts, both of which are required by the Dynatrace CSI driver DaemonSet. The CSI driver is not needed when `applicationMonitoring: {}` is used.
+
+#### Scenario: CSI driver disabled on GKE Autopilot install
+
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** distro is `"GKE-Autopilot"`
+- **THEN** the Helm command includes `--set csidriver.enabled=false`
+
+#### Scenario: CSI driver enabled on all other distros
+
+- **GIVEN** `InstallKubernetes()` is called
+- **WHEN** distro is any value other than `"GKE-Autopilot"`
+- **THEN** the Helm command does NOT include `--set csidriver.enabled=false`
+
 ### Requirement: ClusterRoleBinding included in all rendered manifests
 
 The system SHALL include a `ClusterRoleBinding` for `dynatrace-kubernetes-monitoring-sensitive` in every rendered manifest, binding to the `dynatrace-activegate` service account.

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -13,7 +13,7 @@
 ## 2. Detection Unit Tests
 
 - [x] 2.1 Add table rows to `TestDetectK8sDistribution` in `pkg/analyzer/analyzer_test.go` for IKS (server URL signal) and RKE (gitVersion `+rke2` signal)
-- [x] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when annotation present, GKE→GKE when absent, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
+- [x] 2.2 Add `TestProbeK8sSubVariant` in `pkg/analyzer/analyzer_test.go` using fake kubectl (PATH injection via `t.TempDir`): assert GKE→GKE-Autopilot when node name has `gk3-` prefix, GKE→GKE when no `gk3-` prefix found, EKS→EKS-Bottlerocket when osImage matches, EKS→EKS when not, TKGI probe triggers on unknown distro, all probes return parent on kubectl error
 - [x] 2.3 Run `make test` and `make lint` — all pass
 
 ## 3. Wire Distro into Installer Signature

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.1 Add IKS detection to `DetectK8sDistribution()` in `pkg/analyzer/detect_kubernetes.go` — match server URL containing `.containers.cloud.ibm.com`, return `"IKS"`
 - [x] 1.2 Add RKE detection to `DetectK8sDistribution()` — match gitVersion containing `+rke2` (RKE2, not RKE1), return `"RKE"`; check before generic `"kubernetes"` fallback
 - [x] 1.3 Add `ProbeK8sSubVariant(distro string) string` and `ClassifyK8sSubVariant(distro, output string, err error) string` in `pkg/analyzer/detect_kubernetes.go` — `ProbeK8sSubVariant` runs kubectl and delegates classification to the pure `ClassifyK8sSubVariant`; on error `ClassifyK8sSubVariant` returns parent distro unchanged
-- [x] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get namespace kube-system -o jsonpath={.metadata.annotations}` with 5s timeout; return `"GKE-Autopilot"` if output contains `autopilot.gke.io`, else return `"GKE"`
+- [x] 1.4 Implement GKE Autopilot probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].metadata.name}` with 5s timeout; return `"GKE-Autopilot"` if any node name has prefix `gk3-`, else return `"GKE"`. Note: `autopilot.gke.io` namespace annotation is absent on current Autopilot clusters; `cloud.google.com/gke-provisioning` node label is unreliable — node name prefix is the correct signal per GKE docs
 - [x] 1.5 Implement EKS Bottlerocket probe inside `ProbeK8sSubVariant`: run `kubectl get nodes -o jsonpath={.items[*].status.nodeInfo.osImage}` with 5s timeout; return `"EKS-Bottlerocket"` if output contains "Bottlerocket" (case-insensitive), else return `"EKS"`
 - [x] 1.6 Implement TKGI fallback probe inside `ProbeK8sSubVariant`: when parent is `"kubernetes"`, run `kubectl get namespace pks-system --ignore-not-found -o jsonpath={.status.phase}` with 5s timeout; return `"TKGI"` only if output is `"Active"`
 - [x] 1.7 Call `ProbeK8sSubVariant` from `detectKubernetes()` in `pkg/analyzer/detect_kubernetes.go` — after `DetectK8sDistribution()` returns, pass result through probe, store final value in `info.Distribution`
@@ -40,6 +40,11 @@
 ## 5b. Template Structure Alignment
 
 - [x] 5b.1 Move EEC, OTel collector, and log module `templates` entries from DynaKube #1 to DynaKube #2 in `dynakube.tmpl`; move `telemetryIngest`, `logMonitoring: {}`, and `extensions.prometheus: {}` from DynaKube #1 to DynaKube #2; DynaKube #1 `templates` block kept only for the conditional `kspmNodeConfigurationCollector` (absent entirely when KSPM disabled)
+
+## 5c. GKE Autopilot Helm + Manifest Fixes
+
+- [x] 5c.1 Add `disableCSI bool` parameter to `helmOperatorArgs()` and `helmOperatorUpgradeArgs()`; when true, append `--set csidriver.enabled=false` to the arg slice
+- [x] 5c.2 In `InstallKubernetes()`, set `disableCSI := distro == "GKE-Autopilot"` and pass it to both Helm arg builders and their post-install-helm re-detection paths
 
 ## 6. Manifest Assertion Tests
 

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -48,6 +48,6 @@
 
 ## 6. Manifest Assertion Tests
 
-- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE`, `TKGI`, `kubernetes`, `minikube`, `kind`, `k3s`
-- [ ] 6.2 For each row assert specific substrings present or absent in rendered YAML: `mappedHostPaths` present/absent per KSPM expectation, correct annotation key present/absent, `kubeletPath` value present/absent with correct path, `ClusterRoleBinding` always present
-- [ ] 6.3 Run `make test` and `make lint` — all pass
+- [x] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE`, `TKGI`, `kubernetes`, `minikube`, `kind`, `k3s`
+- [x] 6.2 For each row assert specific substrings present or absent in rendered YAML: `mappedHostPaths` present/absent per KSPM expectation, correct annotation key present/absent, `kubeletPath` value present/absent with correct path, `ClusterRoleBinding` always present
+- [x] 6.3 Run `make test` and `make lint` — all pass

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -25,15 +25,15 @@
 
 ## 4. Distro-to-Template Mapping
 
-- [x] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
-- [x] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/minikube/kind/k3s/empty (minikube, kind, and k3s use the same config as the generic "other" YAML — standard Linux paths, no platform-managed posture scanning); `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE/GKE/GKE-Autopilot/EKS-Bottlerocket/IKS/TKGI/OpenShift map to no KSPM unless noted above
+- [x] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `KubeletPath string`
+- [x] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/minikube/kind/k3s/empty (minikube, kind, and k3s use the same config as the generic "other" YAML — standard Linux paths, no platform-managed posture scanning); `PrivilegedAnnotation` true for OpenShift; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE/GKE/GKE-Autopilot/EKS-Bottlerocket/IKS/TKGI/OpenShift map to no KSPM unless noted above
 - [x] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
 
 ## 5. Update DynaKube Template
 
 - [x] 5.1 Wrap KSPM block in `dynakube.tmpl` with `{{if .EnableKSPM}} ... {{end}}` — covers both `kspm.mappedHostPaths` and `templates.kspmNodeConfigurationCollector` blocks
-- [x] 5.2 Add conditional annotation block to DynaKube #1 (monitoring) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}` and equivalent for `ReadOnlyVolume`
-- [x] 5.3 Add identical conditional annotation block to DynaKube #2 (agents) metadata in `dynakube.tmpl`
+- [x] 5.2 Add conditional annotation block to DynaKube #1 (monitoring) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}`
+- [x] 5.3 Add identical conditional annotation block to DynaKube #2 (agents) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}`
 - [x] 5.4 Add conditional kubelet path field to both DynaKube specs in `dynakube.tmpl`: `{{if .KubeletPath}}  kubeletPath: {{.KubeletPath}}{{end}}`
 - [x] 5.5 Add `ClusterRoleBinding` resource to `dynakube.tmpl` — bind `dynatrace-kubernetes-monitoring-sensitive` ClusterRole to `dynatrace-activegate` ServiceAccount in `dynatrace` namespace
 

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -25,17 +25,21 @@
 
 ## 4. Distro-to-Template Mapping
 
-- [ ] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
-- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/minikube/kind/k3s/empty (minikube, kind, and k3s use the same config as the generic "other" YAML — standard Linux paths, no platform-managed posture scanning); `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE/GKE/GKE-Autopilot/EKS-Bottlerocket/IKS/TKGI/OpenShift map to no KSPM unless noted above
-- [ ] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
+- [x] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
+- [x] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/minikube/kind/k3s/empty (minikube, kind, and k3s use the same config as the generic "other" YAML — standard Linux paths, no platform-managed posture scanning); `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE/GKE/GKE-Autopilot/EKS-Bottlerocket/IKS/TKGI/OpenShift map to no KSPM unless noted above
+- [x] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
 
 ## 5. Update DynaKube Template
 
-- [ ] 5.1 Wrap KSPM block in `dynakube.tmpl` with `{{if .EnableKSPM}} ... {{end}}` — covers both `kspm.mappedHostPaths` and `templates.kspmNodeConfigurationCollector` blocks
-- [ ] 5.2 Add conditional annotation block to DynaKube #1 (monitoring) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}` and equivalent for `ReadOnlyVolume`
-- [ ] 5.3 Add identical conditional annotation block to DynaKube #2 (agents) metadata in `dynakube.tmpl`
-- [ ] 5.4 Add conditional kubelet path field to both DynaKube specs in `dynakube.tmpl`: `{{if .KubeletPath}}  kubeletPath: {{.KubeletPath}}{{end}}`
-- [ ] 5.5 Add `ClusterRoleBinding` resource to `dynakube.tmpl` — bind `dynatrace-kubernetes-monitoring-sensitive` ClusterRole to `dynatrace-activegate` ServiceAccount in `dynatrace` namespace
+- [x] 5.1 Wrap KSPM block in `dynakube.tmpl` with `{{if .EnableKSPM}} ... {{end}}` — covers both `kspm.mappedHostPaths` and `templates.kspmNodeConfigurationCollector` blocks
+- [x] 5.2 Add conditional annotation block to DynaKube #1 (monitoring) metadata in `dynakube.tmpl`: `{{if .PrivilegedAnnotation}}annotations:\n  feature.dynatrace.com/oneagent-privileged: "true"{{end}}` and equivalent for `ReadOnlyVolume`
+- [x] 5.3 Add identical conditional annotation block to DynaKube #2 (agents) metadata in `dynakube.tmpl`
+- [x] 5.4 Add conditional kubelet path field to both DynaKube specs in `dynakube.tmpl`: `{{if .KubeletPath}}  kubeletPath: {{.KubeletPath}}{{end}}`
+- [x] 5.5 Add `ClusterRoleBinding` resource to `dynakube.tmpl` — bind `dynatrace-kubernetes-monitoring-sensitive` ClusterRole to `dynatrace-activegate` ServiceAccount in `dynatrace` namespace
+
+## 5b. Template Structure Alignment
+
+- [x] 5b.1 Move EEC, OTel collector, and log module `templates` entries from DynaKube #1 to DynaKube #2 in `dynakube.tmpl`; move `telemetryIngest`, `logMonitoring: {}`, and `extensions.prometheus: {}` from DynaKube #1 to DynaKube #2; DynaKube #1 `templates` block kept only for the conditional `kspmNodeConfigurationCollector` (absent entirely when KSPM disabled)
 
 ## 6. Manifest Assertion Tests
 

--- a/openspec/changes/k8s-distro-aware-installer/tasks.md
+++ b/openspec/changes/k8s-distro-aware-installer/tasks.md
@@ -26,7 +26,7 @@
 ## 4. Distro-to-Template Mapping
 
 - [ ] 4.1 Add fields to `dynakubeTemplateData` struct in `pkg/installer/kubernetes.go`: `EnableKSPM bool`, `PrivilegedAnnotation bool`, `ReadOnlyVolume bool`, `KubeletPath string`
-- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/empty; `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE maps to no KSPM, no annotations, no kubeletPath
+- [ ] 4.2 Implement `distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData` in `pkg/installer/kubernetes.go` — set fields per distro: KSPM true for EKS/AKS/kubernetes/minikube/kind/k3s/empty (minikube, kind, and k3s use the same config as the generic "other" YAML — standard Linux paths, no platform-managed posture scanning); `PrivilegedAnnotation` true for OpenShift; `ReadOnlyVolume` true for EKS-Bottlerocket; `KubeletPath` `/var/data/kubelet` for IKS, `/var/vcap/data/kubelet` for TKGI; RKE/GKE/GKE-Autopilot/EKS-Bottlerocket/IKS/TKGI/OpenShift map to no KSPM unless noted above
 - [ ] 4.3 Call `distroTemplateData()` in `InstallKubernetes()` before passing data to `renderDynakubeTemplate()`
 
 ## 5. Update DynaKube Template
@@ -39,6 +39,6 @@
 
 ## 6. Manifest Assertion Tests
 
-- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE`, `TKGI`, `kubernetes`
+- [ ] 6.1 Create `pkg/installer/kubernetes_test.go` with `TestRenderDynakubeTemplate_Distros` table test — one row per distro string: `GKE`, `GKE-Autopilot`, `EKS`, `EKS-Bottlerocket`, `AKS`, `IKS`, `OpenShift`, `RKE`, `TKGI`, `kubernetes`, `minikube`, `kind`, `k3s`
 - [ ] 6.2 For each row assert specific substrings present or absent in rendered YAML: `mappedHostPaths` present/absent per KSPM expectation, correct annotation key present/absent, `kubeletPath` value present/absent with correct path, `ClusterRoleBinding` always present
 - [ ] 6.3 Run `make test` and `make lint` — all pass

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -120,8 +120,10 @@ func ProbeK8sSubVariant(distro string) string {
 func probeK8sSubVariant(distro string, run cmdRunner) string {
 	switch distro {
 	case "GKE":
-		output, err := run(5*time.Second, "kubectl", "get", "namespace", "kube-system",
-			"-o", "jsonpath={.metadata.annotations}")
+		// GKE Autopilot nodes always use the "gk3-" name prefix; Standard nodes use "gke-".
+		// This is the officially documented signal per GKE Autopilot node naming conventions.
+		output, err := run(5*time.Second, "kubectl", "get", "nodes",
+			"-o", "jsonpath={.items[*].metadata.name}")
 		if err != nil {
 			display.PrintWarning("GKE Autopilot probe", err)
 		}
@@ -166,8 +168,10 @@ func ClassifyK8sSubVariant(distro, output string, err error) string {
 	}
 	switch distro {
 	case "GKE":
-		if strings.Contains(output, "autopilot.gke.io") {
-			return "GKE-Autopilot"
+		for _, name := range strings.Fields(output) {
+			if strings.HasPrefix(name, "gk3-") {
+				return "GKE-Autopilot"
+			}
 		}
 	case "EKS":
 		if strings.Contains(strings.ToLower(output), "bottlerocket") {

--- a/pkg/analyzer/detect_kubernetes_test.go
+++ b/pkg/analyzer/detect_kubernetes_test.go
@@ -56,13 +56,13 @@ func TestProbeK8sSubVariant(t *testing.T) {
 		{
 			name:   "GKE Autopilot detected",
 			distro: "GKE",
-			calls:  []fakeCall{{"autopilot.gke.io/enabled:true", nil}},
+			calls:  []fakeCall{{"gk3-my-cluster-pool-1-abc123-xyz", nil}},
 			want:   "GKE-Autopilot",
 		},
 		{
 			name:   "GKE Standard unchanged",
 			distro: "GKE",
-			calls:  []fakeCall{{"other-annotation:value", nil}},
+			calls:  []fakeCall{{"gke-my-cluster-pool-1-abc123-xyz", nil}},
 			want:   "GKE",
 		},
 		{
@@ -181,8 +181,8 @@ func TestClassifyK8sSubVariant(t *testing.T) {
 		err    error
 		want   string
 	}{
-		{"GKE", `{"autopilot.gke.io/enabled":"true"}`, nil, "GKE-Autopilot"},
-		{"GKE", `{"other-annotation":"value"}`, nil, "GKE"},
+		{"GKE", "gk3-my-cluster-pool-1-abc123-xyz", nil, "GKE-Autopilot"},
+		{"GKE", "gke-my-cluster-pool-1-abc123-xyz", nil, "GKE"},
 		{"GKE", "", errProbe, "GKE"},
 		{"EKS", "Bottlerocket OS 1.14.0", nil, "EKS-Bottlerocket"},
 		{"EKS", "Amazon Linux 2", nil, "EKS"},

--- a/pkg/installer/dynakube.tmpl
+++ b/pkg/installer/dynakube.tmpl
@@ -17,6 +17,15 @@ metadata:
   namespace: dynatrace
   labels:
     dynatrace.com/created-by: "dynatrace.kubernetes"
+{{- if or .PrivilegedAnnotation .ReadOnlyVolume }}
+  annotations:
+{{- if .PrivilegedAnnotation }}
+    feature.dynatrace.com/oneagent-privileged: "true"
+{{- end }}
+{{- if .ReadOnlyVolume }}
+    feature.dynatrace.com/injection-readonly-volume: "true"
+{{- end }}
+{{- end }}
 spec:
   apiUrl: {{ .APIURL }}
   tokens: {{ .ClusterName }}
@@ -32,23 +41,10 @@ spec:
         cpu: 1000m
         memory: 6Gi
     replicas: 1
-  templates:
-    extensionExecutionController:
-      imageRef:
-        repository: {{ .EECRepository }}
-        tag: {{ .EECTag }}
-    otelCollector:
-      imageRef:
-        repository: public.ecr.aws/dynatrace/dynatrace-otel-collector
-        tag: latest
-    logMonitoring:
-      imageRef:
-        repository: public.ecr.aws/dynatrace/dynatrace-logmodule
-        tag: 1.331.49.20260227-104933
-    kspmNodeConfigurationCollector:
-      imageRef:
-        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
-        tag: 1.5.4
+{{- if .KubeletPath }}
+  kubeletPath: {{ .KubeletPath }}
+{{- end }}
+{{- if .EnableKSPM }}
   kspm:
     mappedHostPaths:
       - /boot
@@ -58,16 +54,12 @@ spec:
       - /sys/kernel/security/apparmor
       - /usr/lib/systemd/system
       - /var/lib
-  telemetryIngest:
-    protocols:
-      - jaeger
-      - otlp
-      - statsd
-      - zipkin
-    serviceName: telemetry-ingest
-  logMonitoring: {}
-  extensions:
-    prometheus: {}
+  templates:
+    kspmNodeConfigurationCollector:
+      imageRef:
+        repository: public.ecr.aws/dynatrace/dynatrace-k8s-node-config-collector
+        tag: 1.5.4
+{{- end }}
 ---
 apiVersion: dynatrace.com/v1beta6
 kind: DynaKube
@@ -76,11 +68,18 @@ metadata:
   namespace: dynatrace
   labels:
     dynatrace.com/created-by: "dynatrace.kubernetes"
+{{- if or .PrivilegedAnnotation .ReadOnlyVolume }}
+  annotations:
+{{- if .PrivilegedAnnotation }}
+    feature.dynatrace.com/oneagent-privileged: "true"
+{{- end }}
+{{- if .ReadOnlyVolume }}
+    feature.dynatrace.com/injection-readonly-volume: "true"
+{{- end }}
+{{- end }}
 spec:
   apiUrl: {{ .APIURL }}
   tokens: {{ .ClusterName }}
-  metadataEnrichment:
-    enabled: true
   oneAgent:
     applicationMonitoring:
       codeModulesImage: {{ .CodeModulesImage }}
@@ -97,6 +96,32 @@ spec:
         cpu: 1000m
         memory: 2Gi
     replicas: 3
+{{- if .KubeletPath }}
+  kubeletPath: {{ .KubeletPath }}
+{{- end }}
+  templates:
+    extensionExecutionController:
+      imageRef:
+        repository: {{ .EECRepository }}
+        tag: {{ .EECTag }}
+    otelCollector:
+      imageRef:
+        repository: public.ecr.aws/dynatrace/dynatrace-otel-collector
+        tag: latest
+    logMonitoring:
+      imageRef:
+        repository: public.ecr.aws/dynatrace/dynatrace-logmodule
+        tag: 1.331.49.20260227-104933
+  logMonitoring: {}
+  telemetryIngest:
+    protocols:
+      - jaeger
+      - otlp
+      - statsd
+      - zipkin
+    serviceName: telemetry-ingest
+  extensions:
+    prometheus: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -115,3 +140,18 @@ rules:
       - list
       - watch
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    dynatrace.com/created-by: "dynatrace.kubernetes"
+  name: dynatrace-kubernetes-monitoring-sensitive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynatrace-kubernetes-monitoring-sensitive
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-activegate
+    namespace: dynatrace

--- a/pkg/installer/dynakube.tmpl
+++ b/pkg/installer/dynakube.tmpl
@@ -17,14 +17,9 @@ metadata:
   namespace: dynatrace
   labels:
     dynatrace.com/created-by: "dynatrace.kubernetes"
-{{- if or .PrivilegedAnnotation .ReadOnlyVolume }}
-  annotations:
 {{- if .PrivilegedAnnotation }}
+  annotations:
     feature.dynatrace.com/oneagent-privileged: "true"
-{{- end }}
-{{- if .ReadOnlyVolume }}
-    feature.dynatrace.com/injection-readonly-volume: "true"
-{{- end }}
 {{- end }}
 spec:
   apiUrl: {{ .APIURL }}
@@ -68,14 +63,9 @@ metadata:
   namespace: dynatrace
   labels:
     dynatrace.com/created-by: "dynatrace.kubernetes"
-{{- if or .PrivilegedAnnotation .ReadOnlyVolume }}
-  annotations:
 {{- if .PrivilegedAnnotation }}
+  annotations:
     feature.dynatrace.com/oneagent-privileged: "true"
-{{- end }}
-{{- if .ReadOnlyVolume }}
-    feature.dynatrace.com/injection-readonly-volume: "true"
-{{- end }}
 {{- end }}
 spec:
   apiUrl: {{ .APIURL }}
@@ -127,7 +117,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.dynatrace.com/aggregate-to-monitoring: "true"
     dynatrace.com/created-by: "dynatrace.kubernetes"
   name: dynatrace-kubernetes-monitoring-sensitive
 rules:

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -25,6 +25,11 @@ const (
 	dynakubeEECRepository    = "public.ecr.aws/dynatrace/dynatrace-eec"
 	dynakubeEECTag           = "1.337.60.20260603-063549"
 	dynakubeCodeModulesImage = "public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.60.20260603-063549"
+
+	// helmOperatorNightlyVersion is used for all non-GKE distros.
+	helmOperatorNightlyVersion = "0.0.0-nightly-chart"
+	// helmChartGHCR is the default chart source for non-GKE distros.
+	helmChartGHCR = "oci://ghcr.io/dynatrace/dynatrace-operator"
 )
 
 // dynakubeTemplateData holds the values substituted into dynakube.tmpl.
@@ -88,9 +93,12 @@ func sanitizeK8sName(name string) string {
 	if name == "" {
 		return "dynakube"
 	}
-	// Kubernetes names must be at most 63 characters.
-	if len(name) > 63 {
-		name = name[:63]
+	// DynaKube names are limited to 32 characters when OTel collectors are enabled.
+	// The operator also generates labels which adds 39 chars to the base name.
+	// Kubernetes labels must be ≤ 63 chars, so base ≤ 24.
+	const maxLen = 23
+	if len(name) > maxLen {
+		name = name[:maxLen]
 		name = strings.TrimRight(name, "-")
 	}
 	return name
@@ -149,35 +157,49 @@ func isOperatorInstalled() bool {
 
 // helmOperatorArgs builds the `helm install` argument slice.
 // Helm v3 uses --atomic; Helm v4+ uses --rollback-on-failure.
-func helmOperatorArgs(helmMajor int) []string {
+// disableCSI adds --set csidriver.enabled=false, required on GKE Autopilot.
+// version selects the chart version (nightly or stable).
+func helmOperatorArgs(helmMajor int, disableCSI bool) []string {
 	rollbackFlag := "--atomic"
 	if helmMajor >= 4 {
 		rollbackFlag = "--rollback-on-failure"
 	}
-	return []string{
+	args := []string{
 		"install", "dynatrace-operator",
-		"oci://ghcr.io/dynatrace/dynatrace-operator",
-		"--version", "0.0.0-nightly-chart",
+		helmChartGHCR,
+		"--version", helmOperatorNightlyVersion,
 		"--create-namespace",
 		"--namespace", "dynatrace",
 		rollbackFlag,
+		"--timeout", "10m",
 	}
+	if disableCSI {
+		args = append(args, "--set", "csidriver.enabled=false")
+	}
+	return args
 }
 
 // helmOperatorUpgradeArgs builds the `helm upgrade` argument slice used when
 // the dynatrace-operator release already exists.
-func helmOperatorUpgradeArgs(helmMajor int) []string {
+// disableCSI adds --set csidriver.enabled=false, required on GKE Autopilot.
+// version selects the chart version (nightly or stable).
+func helmOperatorUpgradeArgs(helmMajor int, disableCSI bool) []string {
 	rollbackFlag := "--atomic"
 	if helmMajor >= 4 {
 		rollbackFlag = "--rollback-on-failure"
 	}
-	return []string{
+	args := []string{
 		"upgrade", "dynatrace-operator",
-		"oci://ghcr.io/dynatrace/dynatrace-operator",
-		"--version", "0.0.0-nightly-chart",
+		helmChartGHCR,
+		"--version", helmOperatorNightlyVersion,
 		"--namespace", "dynatrace",
 		rollbackFlag,
+		"--timeout", "10m",
 	}
+	if disableCSI {
+		args = append(args, "--set", "csidriver.enabled=false")
+	}
+	return args
 }
 
 // applyDynakube writes the DynaKube CR YAML to a temp file and runs
@@ -351,6 +373,7 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 	}
 
 	// --- Determine Helm command ---
+	disableCSI := distro == "GKE-Autopilot"
 	var helmArgs []string
 	helmMajor := 3 // sensible default for display; re-detected before execution
 	if isHelmInstalled() {
@@ -359,9 +382,9 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 		}
 	}
 	if isOperatorInstalled() {
-		helmArgs = helmOperatorUpgradeArgs(helmMajor)
+		helmArgs = helmOperatorUpgradeArgs(helmMajor, disableCSI)
 	} else {
-		helmArgs = helmOperatorArgs(helmMajor)
+		helmArgs = helmOperatorArgs(helmMajor, disableCSI)
 	}
 	helmCmd := "helm " + strings.Join(helmArgs, " ")
 
@@ -420,9 +443,9 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 		if v, err := helmMajorVersion(); err == nil {
 			helmMajor = v
 			if isOperatorInstalled() {
-				helmArgs = helmOperatorUpgradeArgs(helmMajor)
+				helmArgs = helmOperatorUpgradeArgs(helmMajor, disableCSI)
 			} else {
-				helmArgs = helmOperatorArgs(helmMajor)
+				helmArgs = helmOperatorArgs(helmMajor, disableCSI)
 			}
 		}
 	}

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -29,14 +29,37 @@ const (
 
 // dynakubeTemplateData holds the values substituted into dynakube.tmpl.
 type dynakubeTemplateData struct {
-	ClusterName      string // sanitised Kubernetes resource name
-	APIURL           string // full Dynatrace API URL incl. /api suffix
-	APIToken         string // raw API token
-	DataIngestToken  string // raw data-ingest token
-	ActiveGateImage  string // full image reference for ActiveGate pods
-	EECRepository    string // OCI repository for the EEC image
-	EECTag           string // tag for the EEC image
-	CodeModulesImage string // full image reference for OneAgent code modules
+	ClusterName          string // sanitised Kubernetes resource name
+	APIURL               string // full Dynatrace API URL incl. /api suffix
+	APIToken             string // raw API token
+	DataIngestToken      string // raw data-ingest token
+	ActiveGateImage      string // full image reference for ActiveGate pods
+	EECRepository        string // OCI repository for the EEC image
+	EECTag               string // tag for the EEC image
+	CodeModulesImage     string // full image reference for OneAgent code modules
+	EnableKSPM           bool   // inject kspm.mappedHostPaths + kspmNodeConfigurationCollector block
+	PrivilegedAnnotation bool   // add feature.dynatrace.com/oneagent-privileged: "true" (OpenShift)
+	ReadOnlyVolume       bool   // add feature.dynatrace.com/injection-readonly-volume: "true" (Bottlerocket)
+	KubeletPath          string // non-standard kubelet path (IKS: /var/data/kubelet, TKGI: /var/vcap/data/kubelet)
+}
+
+// distroTemplateData applies per-distribution overrides to the base template
+// data. Distributions not listed here use no KSPM, no annotations, and no
+// kubeletPath override (GKE, GKE-Autopilot, RKE).
+func distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTemplateData {
+	switch distro {
+	case "EKS", "AKS", "kubernetes", "minikube", "kind", "k3s", "":
+		base.EnableKSPM = true
+	case "OpenShift":
+		base.PrivilegedAnnotation = true
+	case "EKS-Bottlerocket":
+		base.ReadOnlyVolume = true
+	case "IKS":
+		base.KubeletPath = "/var/data/kubelet"
+	case "TKGI":
+		base.KubeletPath = "/var/vcap/data/kubelet"
+	}
+	return base
 }
 
 // renderDynakubeTemplate fills dynakube.tmpl with the provided data and
@@ -312,7 +335,7 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 	clusterName = resolveClusterName(clusterName, envURL)
 
 	// --- Build manifest ---
-	tmplData := dynakubeTemplateData{
+	tmplData := distroTemplateData(dynakubeTemplateData{
 		ClusterName:      clusterName,
 		APIURL:           apiURL + "/api",
 		APIToken:         token,
@@ -321,7 +344,7 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 		EECRepository:    dynakubeEECRepository,
 		EECTag:           dynakubeEECTag,
 		CodeModulesImage: dynakubeCodeModulesImage,
-	}
+	}, distro)
 	manifest, err := renderDynakubeTemplate(tmplData)
 	if err != nil {
 		return fmt.Errorf("rendering DynaKube manifest: %w", err)

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -27,9 +27,9 @@ const (
 	dynakubeCodeModulesImage = "public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.60.20260603-063549"
 
 	// helmOperatorNightlyVersion is used for all non-GKE distros.
-	helmOperatorNightlyVersion = "0.0.0-nightly-chart"
+	helmOperatorNightlyVersion = "1.10.0-rc.0"
 	// helmChartGHCR is the default chart source for non-GKE distros.
-	helmChartGHCR = "oci://ghcr.io/dynatrace/dynatrace-operator"
+	helmChartGHCR = "oci://public.ecr.aws/dynatrace/dynatrace-operator"
 )
 
 // dynakubeTemplateData holds the values substituted into dynakube.tmpl.

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -26,9 +26,9 @@ const (
 	dynakubeEECTag           = "1.337.60.20260603-063549"
 	dynakubeCodeModulesImage = "public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.60.20260603-063549"
 
-	// helmOperatorNightlyVersion is used for all non-GKE distros.
+	// helmOperatorNightlyVersion is the operator chart version pinned by dtwiz.
 	helmOperatorNightlyVersion = "1.10.0-rc.0"
-	// helmChartGHCR is the default chart source for non-GKE distros.
+	// helmChartGHCR is the operator chart OCI registry reference (currently hosted on public.ecr.aws).
 	helmChartGHCR = "oci://public.ecr.aws/dynatrace/dynatrace-operator"
 )
 
@@ -44,7 +44,6 @@ type dynakubeTemplateData struct {
 	CodeModulesImage     string // full image reference for OneAgent code modules
 	EnableKSPM           bool   // inject kspm.mappedHostPaths + kspmNodeConfigurationCollector block
 	PrivilegedAnnotation bool   // add feature.dynatrace.com/oneagent-privileged: "true" (OpenShift)
-	ReadOnlyVolume       bool   // add feature.dynatrace.com/injection-readonly-volume: "true" (Bottlerocket)
 	KubeletPath          string // non-standard kubelet path (IKS: /var/data/kubelet, TKGI: /var/vcap/data/kubelet)
 }
 
@@ -57,8 +56,6 @@ func distroTemplateData(base dynakubeTemplateData, distro string) dynakubeTempla
 		base.EnableKSPM = true
 	case "OpenShift":
 		base.PrivilegedAnnotation = true
-	case "EKS-Bottlerocket":
-		base.ReadOnlyVolume = true
 	case "IKS":
 		base.KubeletPath = "/var/data/kubelet"
 	case "TKGI":

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -26,10 +26,10 @@ const (
 	dynakubeEECTag           = "1.337.60.20260603-063549"
 	dynakubeCodeModulesImage = "public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.60.20260603-063549"
 
-	// helmOperatorNightlyVersion is the operator chart version pinned by dtwiz.
-	helmOperatorNightlyVersion = "1.10.0-rc.0"
-	// helmChartGHCR is the operator chart OCI registry reference (currently hosted on public.ecr.aws).
-	helmChartGHCR = "oci://public.ecr.aws/dynatrace/dynatrace-operator"
+	// dynatraceOperatorVersion is the operator chart version pinned by dtwiz.
+	dynatraceOperatorVersion = "1.10.0-rc.0"
+	// dynatraceOperatorOCI is the OCI chart reference hosted on public.ecr.aws.
+	dynatraceOperatorOCI = "oci://public.ecr.aws/dynatrace/dynatrace-operator"
 )
 
 // dynakubeTemplateData holds the values substituted into dynakube.tmpl.
@@ -91,8 +91,8 @@ func sanitizeK8sName(name string) string {
 		return "dynakube"
 	}
 	// DynaKube names are limited to 32 characters when OTel collectors are enabled.
-	// The operator also generates labels which adds 39 chars to the base name.
-	// Kubernetes labels must be ≤ 63 chars, so base ≤ 24.
+	// Kubernetes labels must be ≤ 63 chars; the operator appends suffixes to the
+	// DynaKube name in generated labels, so base names are capped at 23 chars.
 	const maxLen = 23
 	if len(name) > maxLen {
 		name = name[:maxLen]
@@ -155,7 +155,6 @@ func isOperatorInstalled() bool {
 // helmOperatorArgs builds the `helm install` argument slice.
 // Helm v3 uses --atomic; Helm v4+ uses --rollback-on-failure.
 // disableCSI adds --set csidriver.enabled=false, required on GKE Autopilot.
-// version selects the chart version (nightly or stable).
 func helmOperatorArgs(helmMajor int, disableCSI bool) []string {
 	rollbackFlag := "--atomic"
 	if helmMajor >= 4 {
@@ -163,8 +162,8 @@ func helmOperatorArgs(helmMajor int, disableCSI bool) []string {
 	}
 	args := []string{
 		"install", "dynatrace-operator",
-		helmChartGHCR,
-		"--version", helmOperatorNightlyVersion,
+		dynatraceOperatorOCI,
+		"--version", dynatraceOperatorVersion,
 		"--create-namespace",
 		"--namespace", "dynatrace",
 		rollbackFlag,
@@ -179,7 +178,6 @@ func helmOperatorArgs(helmMajor int, disableCSI bool) []string {
 // helmOperatorUpgradeArgs builds the `helm upgrade` argument slice used when
 // the dynatrace-operator release already exists.
 // disableCSI adds --set csidriver.enabled=false, required on GKE Autopilot.
-// version selects the chart version (nightly or stable).
 func helmOperatorUpgradeArgs(helmMajor int, disableCSI bool) []string {
 	rollbackFlag := "--atomic"
 	if helmMajor >= 4 {
@@ -187,8 +185,8 @@ func helmOperatorUpgradeArgs(helmMajor int, disableCSI bool) []string {
 	}
 	args := []string{
 		"upgrade", "dynatrace-operator",
-		helmChartGHCR,
-		"--version", helmOperatorNightlyVersion,
+		dynatraceOperatorOCI,
+		"--version", dynatraceOperatorVersion,
 		"--namespace", "dynatrace",
 		rollbackFlag,
 		"--timeout", "10m",

--- a/pkg/installer/kubernetes_test.go
+++ b/pkg/installer/kubernetes_test.go
@@ -52,44 +52,15 @@ func TestRenderDynakubeTemplate_NoPlaceholders(t *testing.T) {
 	}
 }
 
-func TestDistroTemplateData_UseEphemeralVolume(t *testing.T) {
-	ephemeralDistros := []string{"EKS", "EKS-Bottlerocket"}
-	for _, distro := range ephemeralDistros {
-		d := distroTemplateData(baseTemplateData(), distro)
-		if !d.UseEphemeralVolume {
-			t.Errorf("distro %q: expected UseEphemeralVolume=true", distro)
-		}
-	}
-
-	nonEphemeralDistros := []string{"GKE", "GKE-Autopilot", "AKS", "OpenShift", "IKS", "TKGI", "RKE", "kubernetes", "minikube", "kind", "k3s", ""}
-	for _, distro := range nonEphemeralDistros {
-		d := distroTemplateData(baseTemplateData(), distro)
-		if d.UseEphemeralVolume {
-			t.Errorf("distro %q: expected UseEphemeralVolume=false", distro)
-		}
-	}
-}
-
-func TestRenderDynakubeTemplate_EphemeralVolume_EKS(t *testing.T) {
-	for _, distro := range []string{"EKS", "EKS-Bottlerocket"} {
+func TestRenderDynakubeTemplate_NoAggregationLabel(t *testing.T) {
+	// aggregate-to-monitoring label deprecated since Operator 1.9.0; must never appear.
+	for _, distro := range []string{"EKS", "EKS-Bottlerocket", "GKE", "OpenShift", "AKS", "kubernetes", ""} {
 		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
 		if err != nil {
 			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
 		}
-		if !strings.Contains(out, "useEphemeralVolume: true") {
-			t.Errorf("distro %q: expected useEphemeralVolume: true in manifest", distro)
-		}
-	}
-}
-
-func TestRenderDynakubeTemplate_EphemeralVolume_NonEKS(t *testing.T) {
-	for _, distro := range []string{"GKE", "GKE-Autopilot", "AKS", "OpenShift", "kubernetes", ""} {
-		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
-		if err != nil {
-			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
-		}
-		if strings.Contains(out, "useEphemeralVolume") {
-			t.Errorf("distro %q: unexpected useEphemeralVolume in manifest", distro)
+		if strings.Contains(out, "aggregate-to-monitoring") {
+			t.Errorf("distro %q: manifest must not contain rbac.dynatrace.com/aggregate-to-monitoring label", distro)
 		}
 	}
 }

--- a/pkg/installer/kubernetes_test.go
+++ b/pkg/installer/kubernetes_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestRenderDynakubeTemplate_PinnedImages(t *testing.T) {
-	data := dynakubeTemplateData{
+func baseTemplateData() dynakubeTemplateData {
+	return dynakubeTemplateData{
 		ClusterName:      "test-cluster",
 		APIURL:           "https://abc123.live.dynatracelabs.com/api",
 		APIToken:         "dt0c01.token",
@@ -16,8 +16,10 @@ func TestRenderDynakubeTemplate_PinnedImages(t *testing.T) {
 		EECTag:           dynakubeEECTag,
 		CodeModulesImage: dynakubeCodeModulesImage,
 	}
+}
 
-	out, err := renderDynakubeTemplate(data)
+func TestRenderDynakubeTemplate_PinnedImages(t *testing.T) {
+	out, err := renderDynakubeTemplate(baseTemplateData())
 	if err != nil {
 		t.Fatalf("renderDynakubeTemplate: %v", err)
 	}
@@ -40,23 +42,265 @@ func TestRenderDynakubeTemplate_PinnedImages(t *testing.T) {
 }
 
 func TestRenderDynakubeTemplate_NoPlaceholders(t *testing.T) {
-	data := dynakubeTemplateData{
-		ClusterName:      "test-cluster",
-		APIURL:           "https://abc123.live.dynatracelabs.com/api",
-		APIToken:         "dt0c01.token",
-		DataIngestToken:  "dt0c01.token",
-		ActiveGateImage:  dynakubeActiveGateImage,
-		EECRepository:    dynakubeEECRepository,
-		EECTag:           dynakubeEECTag,
-		CodeModulesImage: dynakubeCodeModulesImage,
-	}
-
-	out, err := renderDynakubeTemplate(data)
+	out, err := renderDynakubeTemplate(baseTemplateData())
 	if err != nil {
 		t.Fatalf("renderDynakubeTemplate: %v", err)
 	}
 
 	if strings.Contains(out, "{{") || strings.Contains(out, "}}") {
 		t.Error("rendered manifest still contains unresolved template placeholders")
+	}
+}
+
+func TestDistroTemplateData_UseEphemeralVolume(t *testing.T) {
+	ephemeralDistros := []string{"EKS", "EKS-Bottlerocket"}
+	for _, distro := range ephemeralDistros {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if !d.UseEphemeralVolume {
+			t.Errorf("distro %q: expected UseEphemeralVolume=true", distro)
+		}
+	}
+
+	nonEphemeralDistros := []string{"GKE", "GKE-Autopilot", "AKS", "OpenShift", "IKS", "TKGI", "RKE", "kubernetes", "minikube", "kind", "k3s", ""}
+	for _, distro := range nonEphemeralDistros {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if d.UseEphemeralVolume {
+			t.Errorf("distro %q: expected UseEphemeralVolume=false", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_EphemeralVolume_EKS(t *testing.T) {
+	for _, distro := range []string{"EKS", "EKS-Bottlerocket"} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if !strings.Contains(out, "useEphemeralVolume: true") {
+			t.Errorf("distro %q: expected useEphemeralVolume: true in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_EphemeralVolume_NonEKS(t *testing.T) {
+	for _, distro := range []string{"GKE", "GKE-Autopilot", "AKS", "OpenShift", "kubernetes", ""} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if strings.Contains(out, "useEphemeralVolume") {
+			t.Errorf("distro %q: unexpected useEphemeralVolume in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_NoReadonlyVolumeAnnotation(t *testing.T) {
+	// injection-readonly-volume must never appear — it was only needed for
+	// Operator 0.12.0+ and < 1.7.0; dtwiz targets Operator >= 1.7.0.
+	for _, distro := range []string{"EKS-Bottlerocket", "EKS", "GKE", "OpenShift", "kubernetes", ""} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if strings.Contains(out, "injection-readonly-volume") {
+			t.Errorf("distro %q: manifest must not contain injection-readonly-volume annotation", distro)
+		}
+	}
+}
+
+func TestDistroTemplateData_KSPM(t *testing.T) {
+	kspmDistros := []string{"EKS", "AKS", "kubernetes", "minikube", "kind", "k3s", ""}
+	for _, distro := range kspmDistros {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if !d.EnableKSPM {
+			t.Errorf("distro %q: expected EnableKSPM=true", distro)
+		}
+	}
+
+	noKSPMDistros := []string{"GKE", "GKE-Autopilot", "OpenShift", "EKS-Bottlerocket", "RKE", "IKS", "TKGI"}
+	for _, distro := range noKSPMDistros {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if d.EnableKSPM {
+			t.Errorf("distro %q: expected EnableKSPM=false", distro)
+		}
+	}
+}
+
+func TestDistroTemplateData_PrivilegedAnnotation(t *testing.T) {
+	d := distroTemplateData(baseTemplateData(), "OpenShift")
+	if !d.PrivilegedAnnotation {
+		t.Error("OpenShift: expected PrivilegedAnnotation=true")
+	}
+
+	for _, distro := range []string{"EKS", "AKS", "GKE", "EKS-Bottlerocket", "kubernetes", ""} {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if d.PrivilegedAnnotation {
+			t.Errorf("distro %q: expected PrivilegedAnnotation=false", distro)
+		}
+	}
+}
+
+func TestDistroTemplateData_KubeletPath(t *testing.T) {
+	cases := []struct {
+		distro string
+		want   string
+	}{
+		{"IKS", "/var/data/kubelet"},
+		{"TKGI", "/var/vcap/data/kubelet"},
+	}
+	for _, c := range cases {
+		d := distroTemplateData(baseTemplateData(), c.distro)
+		if d.KubeletPath != c.want {
+			t.Errorf("distro %q: KubeletPath = %q, want %q", c.distro, d.KubeletPath, c.want)
+		}
+	}
+
+	for _, distro := range []string{"EKS", "AKS", "GKE", "OpenShift", "kubernetes", ""} {
+		d := distroTemplateData(baseTemplateData(), distro)
+		if d.KubeletPath != "" {
+			t.Errorf("distro %q: expected empty KubeletPath, got %q", distro, d.KubeletPath)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_KSPM_Present(t *testing.T) {
+	for _, distro := range []string{"EKS", "AKS", "kubernetes", ""} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if !strings.Contains(out, "mappedHostPaths") {
+			t.Errorf("distro %q: expected mappedHostPaths in manifest", distro)
+		}
+		if !strings.Contains(out, "kspmNodeConfigurationCollector") {
+			t.Errorf("distro %q: expected kspmNodeConfigurationCollector in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_KSPM_Absent(t *testing.T) {
+	for _, distro := range []string{"GKE", "GKE-Autopilot", "OpenShift", "EKS-Bottlerocket", "RKE", "IKS", "TKGI"} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if strings.Contains(out, "mappedHostPaths") {
+			t.Errorf("distro %q: unexpected mappedHostPaths in manifest", distro)
+		}
+		if strings.Contains(out, "kspmNodeConfigurationCollector") {
+			t.Errorf("distro %q: unexpected kspmNodeConfigurationCollector in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_OpenShiftAnnotation(t *testing.T) {
+	out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), "OpenShift"))
+	if err != nil {
+		t.Fatalf("renderDynakubeTemplate: %v", err)
+	}
+	count := strings.Count(out, "feature.dynatrace.com/oneagent-privileged: \"true\"")
+	if count != 2 {
+		t.Errorf("OpenShift: expected privileged annotation on both DynaKubes, found %d occurrence(s)", count)
+	}
+}
+
+func TestRenderDynakubeTemplate_OpenShiftAnnotation_Absent(t *testing.T) {
+	for _, distro := range []string{"EKS", "AKS", "GKE", "EKS-Bottlerocket", "kubernetes", ""} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if strings.Contains(out, "oneagent-privileged") {
+			t.Errorf("distro %q: unexpected oneagent-privileged annotation in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_KubeletPath(t *testing.T) {
+	cases := []struct {
+		distro string
+		want   string
+	}{
+		{"IKS", "kubeletPath: /var/data/kubelet"},
+		{"TKGI", "kubeletPath: /var/vcap/data/kubelet"},
+	}
+	for _, c := range cases {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), c.distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", c.distro, err)
+		}
+		if !strings.Contains(out, c.want) {
+			t.Errorf("distro %q: expected %q in manifest", c.distro, c.want)
+		}
+	}
+
+	for _, distro := range []string{"EKS", "AKS", "GKE", "OpenShift", "kubernetes", ""} {
+		out, err := renderDynakubeTemplate(distroTemplateData(baseTemplateData(), distro))
+		if err != nil {
+			t.Fatalf("distro %q: renderDynakubeTemplate: %v", distro, err)
+		}
+		if strings.Contains(out, "kubeletPath") {
+			t.Errorf("distro %q: unexpected kubeletPath in manifest", distro)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_SecretAndRBAC(t *testing.T) {
+	out, err := renderDynakubeTemplate(baseTemplateData())
+	if err != nil {
+		t.Fatalf("renderDynakubeTemplate: %v", err)
+	}
+
+	for _, want := range []string{
+		"kind: Secret",
+		"kind: ClusterRole",
+		"kind: ClusterRoleBinding",
+		"name: dynatrace-kubernetes-monitoring-sensitive",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in manifest", want)
+		}
+	}
+}
+
+func TestRenderDynakubeTemplate_TwoDynaKubes(t *testing.T) {
+	out, err := renderDynakubeTemplate(baseTemplateData())
+	if err != nil {
+		t.Fatalf("renderDynakubeTemplate: %v", err)
+	}
+
+	if count := strings.Count(out, "kind: DynaKube"); count != 2 {
+		t.Errorf("expected 2 DynaKube objects, found %d", count)
+	}
+	if !strings.Contains(out, "- kubernetes-monitoring") {
+		t.Error("expected kubernetes-monitoring capability in DynaKube #1")
+	}
+	if !strings.Contains(out, "- routing") {
+		t.Error("expected routing capability in DynaKube #2")
+	}
+}
+
+func TestRenderDynakubeTemplate_AgentsDynaKubeStructure(t *testing.T) {
+	out, err := renderDynakubeTemplate(baseTemplateData())
+	if err != nil {
+		t.Fatalf("renderDynakubeTemplate: %v", err)
+	}
+
+	for _, want := range []string{
+		"applicationMonitoring",
+		"extensionExecutionController",
+		"otelCollector",
+		"logMonitoring",
+		"telemetryIngest",
+		"- otlp",
+		"- jaeger",
+		"- statsd",
+		"- zipkin",
+		"extensions:",
+		"prometheus: {}",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DynaKube #2: expected %q in manifest", want)
+		}
 	}
 }

--- a/pkg/installer/kubernetes_test.go
+++ b/pkg/installer/kubernetes_test.go
@@ -234,6 +234,63 @@ func TestRenderDynakubeTemplate_SecretAndRBAC(t *testing.T) {
 	}
 }
 
+func TestHelmOperatorArgs_RollbackFlag(t *testing.T) {
+	for _, tc := range []struct {
+		helmMajor int
+		wantFlag  string
+	}{
+		{3, "--atomic"},
+		{4, "--rollback-on-failure"},
+	} {
+		args := helmOperatorArgs(tc.helmMajor, false)
+		found := false
+		for _, a := range args {
+			if a == tc.wantFlag {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("helmMajor=%d: expected %q in install args", tc.helmMajor, tc.wantFlag)
+		}
+
+		args = helmOperatorUpgradeArgs(tc.helmMajor, false)
+		found = false
+		for _, a := range args {
+			if a == tc.wantFlag {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("helmMajor=%d: expected %q in upgrade args", tc.helmMajor, tc.wantFlag)
+		}
+	}
+}
+
+func TestHelmOperatorArgs_DisableCSI(t *testing.T) {
+	for _, disableCSI := range []bool{true, false} {
+		for _, fn := range []struct {
+			name string
+			args []string
+		}{
+			{"install", helmOperatorArgs(3, disableCSI)},
+			{"upgrade", helmOperatorUpgradeArgs(3, disableCSI)},
+		} {
+			hasCSIFlag := false
+			for i, a := range fn.args {
+				if a == "--set" && i+1 < len(fn.args) && fn.args[i+1] == "csidriver.enabled=false" {
+					hasCSIFlag = true
+				}
+			}
+			if disableCSI && !hasCSIFlag {
+				t.Errorf("%s: disableCSI=true but --set csidriver.enabled=false not found", fn.name)
+			}
+			if !disableCSI && hasCSIFlag {
+				t.Errorf("%s: disableCSI=false but --set csidriver.enabled=false present", fn.name)
+			}
+		}
+	}
+}
+
 func TestRenderDynakubeTemplate_TwoDynaKubes(t *testing.T) {
 	out, err := renderDynakubeTemplate(baseTemplateData())
 	if err != nil {


### PR DESCRIPTION
## Feature Description

### Distribution Detection
- Detect IKS clusters from server URL (`.containers.cloud.ibm.com`) and RKE2 from `gitVersion` containing `+rke2`
- Add GKE Autopilot sub-variant probe via node name prefix (`gk3-`); EKS Bottlerocket probe via `osImage` field
- Add TKGI fallback probe via `pks-system` namespace presence

### Installer
- Pass detected distro and cluster name through to `InstallKubernetes()` to avoid redundant kubectl calls
- Disable CSI driver (`--set csidriver.enabled=false`) for GKE Autopilot Helm installs
- Remove unused `gcrMarketplace` Helm flag and hardcoded `helmVersion` parameter

### DynaKube Manifest
- Map each distro to template fields: KSPM enabled for EKS/AKS/generic; privileged annotation for OpenShift; non-standard kubelet path for IKS and TKGI
- Split manifest into two CRs: monitoring DynaKube (KSPM + ActiveGate kubernetes-monitoring) and agents DynaKube (OTel, EEC, log module, telemetryIngest, extensions)
- Conditionally render KSPM block, privileged annotation, and `kubeletPath` based on distro
- Add `ClusterRoleBinding` for `dynatrace-kubernetes-monitoring-sensitive`
- Drop deprecated `injection-readonly-volume` annotation (only needed for Operator < 1.7.0; dtwiz targets ≥ 1.7.0)
- Drop deprecated `rbac.dynatrace.com/aggregate-to-monitoring` label (removed in Operator 1.9.0)

## How to test
1. Set up the clusters as per the existing internal instructions (at least one of GKE / GKE-Autopilot, AKS, EKS).
2. Run `dtwiz install kubernetes`.
3. Trigger requests in the app which you have deployed on every cluster.
4. Perform the same steps with `dtwiz setup`.
5. Make sure that `dtwiz uninstall kubernetes` removes the `dynatrace` namespace from the cluster.
6. Please also make sure this works for at least one major distribution of your choice on both Linux and Windows.

## Which other features are affected?
1. `dtwiz install kubernetes` — distro detection and manifest rendering
7. `dtwiz setup` — cluster name and distro now passed from analyze result

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.