### PR TITLE
feat: gate dtwiz update otel behind experimental feature flag

### DIFF
--- a/cmd/cancel_test.go
+++ b/cmd/cancel_test.go
@@ -52,6 +52,7 @@ func TestUpdateCmd_OtelRegistered(t *testing.T) {
 func TestUpdateOtelCmd_HiddenByDefault(t *testing.T) {
 	t.Setenv("DTWIZ_EXPERIMENTAL", "")
 	featureflags.ClearCLIOverrideForTest(t, featureflags.Experimental)
+	if !updateOtelCmd.Hidden {
 		t.Error("expected update otel subcommand to be hidden when experimental is not enabled")
 	}
 }

--- a/cmd/cancel_test.go
+++ b/cmd/cancel_test.go
@@ -50,8 +50,8 @@ func TestUpdateCmd_OtelRegistered(t *testing.T) {
 }
 
 func TestUpdateOtelCmd_HiddenByDefault(t *testing.T) {
+	t.Setenv("DTWIZ_EXPERIMENTAL", "")
 	featureflags.ClearCLIOverrideForTest(t, featureflags.Experimental)
-	if !updateOtelCmd.Hidden {
 		t.Error("expected update otel subcommand to be hidden when experimental is not enabled")
 	}
 }
@@ -68,6 +68,7 @@ func TestUpdateOtelCmd_VisibleWhenExperimental(t *testing.T) {
 }
 
 func TestUpdateOtelCmd_RunE_BlockedWithoutExperimental(t *testing.T) {
+	t.Setenv("DTWIZ_EXPERIMENTAL", "")
 	featureflags.ClearCLIOverrideForTest(t, featureflags.Experimental)
 	err := updateOtelCmd.RunE(updateOtelCmd, nil)
 	if err == nil {

--- a/cmd/cancel_test.go
+++ b/cmd/cancel_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 )
 
 // TestInstallCmd_CancelledSubcommands verifies each install subcommand that
@@ -33,9 +35,8 @@ func TestInstallCmd_CancelledSubcommands(t *testing.T) {
 	}
 }
 
-// TestUpdateCmd_OtelCancelledSubcommand verifies the update otel subcommand is
-// registered and its RunE will not propagate ErrInstallCancelled.
-func TestUpdateCmd_OtelCancelledSubcommand(t *testing.T) {
+// TestUpdateCmd_OtelRegistered verifies the update otel subcommand is registered.
+func TestUpdateCmd_OtelRegistered(t *testing.T) {
 	found := false
 	for _, c := range updateCmd.Commands() {
 		if c.Use == "otel" {
@@ -45,6 +46,36 @@ func TestUpdateCmd_OtelCancelledSubcommand(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected update otel subcommand to be registered")
+	}
+}
+
+func TestUpdateOtelCmd_HiddenByDefault(t *testing.T) {
+	featureflags.ClearCLIOverrideForTest(t, featureflags.Experimental)
+	if !updateOtelCmd.Hidden {
+		t.Error("expected update otel subcommand to be hidden when experimental is not enabled")
+	}
+}
+
+func TestUpdateOtelCmd_VisibleWhenExperimental(t *testing.T) {
+	featureflags.SetCLIOverrideForTest(t, featureflags.Experimental, true)
+	// Simulate what the HelpFunc does: update Hidden based on the flag.
+	updateOtelCmd.Hidden = !featureflags.IsEnabled(featureflags.Experimental)
+	t.Cleanup(func() { updateOtelCmd.Hidden = true })
+
+	if updateOtelCmd.Hidden {
+		t.Error("expected update otel subcommand to be visible when experimental is enabled")
+	}
+}
+
+func TestUpdateOtelCmd_RunE_BlockedWithoutExperimental(t *testing.T) {
+	featureflags.ClearCLIOverrideForTest(t, featureflags.Experimental)
+	err := updateOtelCmd.RunE(updateOtelCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when running update otel without experimental flag")
+	}
+	want := "otel update is an experimental feature; enable it with --experimental or DTWIZ_EXPERIMENTAL=true"
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\n got:  %s\n want: %s", err.Error(), want)
 	}
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -54,7 +54,8 @@ var setupCmd = &cobra.Command{
 		var actionable []recommender.Recommendation
 		for _, r := range recs {
 			if !r.Done && r.Method != recommender.MethodNotSupported && !r.ComingSoon {
-				if r.Method == recommender.MethodDocker && !featureflags.IsEnabled(featureflags.Experimental) {
+				if !featureflags.IsEnabled(featureflags.Experimental) &&
+					(r.Method == recommender.MethodDocker || r.Method == recommender.MethodOtelUpdate) {
 					continue
 				}
 				actionable = append(actionable, r)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 var updateDryRun bool
@@ -16,16 +19,25 @@ var updateCmd = &cobra.Command{
 	Short: "Update an existing ingestion method configuration",
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// updateCmd.PersistentPreRun overrides root's, so reproduce its behaviour here.
+		logger.Init(debugFlag, verbosityFlag)
+		logger.Verbose("logging: verbose")
+		logger.Debug("logging: debug")
+		featureflags.ApplyCLIOverrides(cmd.Flags())
 		installer.AutoConfirm = updateAutoConfirm
 	},
 }
 
 var updateOtelConfigPath string
 var updateOtelCmd = &cobra.Command{
-	Use:   "otel",
-	Short: "Patch an existing OTel Collector config with the Dynatrace exporter",
-	Args:  cobra.NoArgs,
+	Use:    "otel",
+	Short:  "Patch an existing OTel Collector config with the Dynatrace exporter",
+	Args:   cobra.NoArgs,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !featureflags.IsEnabled(featureflags.Experimental) {
+			return fmt.Errorf("otel update is an experimental feature; enable it with --experimental or DTWIZ_EXPERIMENTAL=true")
+		}
 		envURL, accessTok, platformTok, err := getDtEnvironment()
 		if err != nil {
 			return err
@@ -55,4 +67,13 @@ func init() {
 	updateCmd.PersistentFlags().BoolVarP(&updateAutoConfirm, "yes", "y", false, "skip confirmation prompts")
 	updateOtelCmd.Flags().StringVar(&updateOtelConfigPath, "config", "", "path to the existing OTel Collector config file to patch (prompts with running collector list when omitted)")
 	updateCmd.AddCommand(updateOtelCmd)
+
+	// PersistentPreRun doesn't run for --help, so resolve the experimental flag here
+	// to conditionally show the otel subcommand in help output.
+	defaultUpdateHelp := updateCmd.HelpFunc()
+	updateCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		featureflags.ApplyCLIOverrides(cmd.Flags())
+		updateOtelCmd.Hidden = !featureflags.IsEnabled(featureflags.Experimental)
+		defaultUpdateHelp(cmd, args)
+	})
 }

--- a/openspec/changes/feature-flags-package/specs/feature-flag-registry/spec.md
+++ b/openspec/changes/feature-flags-package/specs/feature-flag-registry/spec.md
@@ -81,29 +81,74 @@ The package SHALL expose `RegisterFlags(flags *pflag.FlagSet)` that registers a 
 
 Subcommands that are experimental SHALL be registered with `Hidden: true` by default and unhidden only when `featureflags.IsEnabled(featureflags.Experimental)` returns `true`. Because `PersistentPreRun` is not called when `--help` is requested, commands that conditionally show hidden subcommands SHALL override their `HelpFunc` to call `ApplyCLIOverrides` before delegating to the default help renderer. Execution of an experimental command without the flag enabled SHALL return an error directing the user to `--experimental` or `DTWIZ_EXPERIMENTAL=true`.
 
-#### Scenario: Experimental command hidden from help by default
+Any command that defines its own `PersistentPreRun` (which overrides root's) SHALL call `featureflags.ApplyCLIOverrides` within that `PersistentPreRun` so that `--experimental` and other feature flags take effect for its subcommands.
+
+The following commands and setup flows are gated behind the `Experimental` flag:
+
+- `dtwiz install docker`
+- `dtwiz install demo`
+- `dtwiz update otel`
+- The `MethodOtelUpdate` recommendation in `dtwiz setup` (patch existing OTel Collector)
+
+#### Scenario: Experimental install command hidden from help by default
 
 - **GIVEN** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set
 - **WHEN** a user runs `dtwiz install --help`
 - **THEN** the `docker` subcommand does NOT appear in the available commands list
 
-#### Scenario: Experimental command visible with env var
+#### Scenario: Experimental install command visible with env var
 
 - **GIVEN** `DTWIZ_EXPERIMENTAL=true` is set in the environment
 - **WHEN** a user runs `dtwiz install --help`
 - **THEN** the `docker` subcommand appears in the available commands list
 
-#### Scenario: Experimental command visible with CLI flag
+#### Scenario: Experimental install command visible with CLI flag
 
 - **GIVEN** `--experimental` is passed on the command line
 - **WHEN** a user runs `dtwiz install --experimental --help`
 - **THEN** the `docker` subcommand appears in the available commands list
 
-#### Scenario: Experimental command blocked at execution without flag
+#### Scenario: Experimental install command blocked at execution without flag
 
 - **GIVEN** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set
 - **WHEN** a user runs `dtwiz install docker`
 - **THEN** the command exits with an error: `docker installation is an experimental feature; enable it with --experimental or DTWIZ_EXPERIMENTAL=true`
+
+#### Scenario: `update otel` hidden from help by default
+
+- **GIVEN** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set
+- **WHEN** a user runs `dtwiz update --help`
+- **THEN** the `otel` subcommand does NOT appear in the available commands list
+
+#### Scenario: `update otel` visible with experimental flag
+
+- **GIVEN** `--experimental` or `DTWIZ_EXPERIMENTAL=true` is set
+- **WHEN** a user runs `dtwiz update --help`
+- **THEN** the `otel` subcommand appears in the available commands list
+
+#### Scenario: `update otel` blocked at execution without flag
+
+- **GIVEN** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set
+- **WHEN** a user runs `dtwiz update otel`
+- **THEN** the command exits with an error: `otel update is an experimental feature; enable it with --experimental or DTWIZ_EXPERIMENTAL=true`
+
+### Requirement: `Experimental` flag gates `setup` recommendations
+
+The `dtwiz setup` interactive flow SHALL exclude experimental recommendations from the selectable list when `Experimental` is not enabled. Specifically, `MethodOtelUpdate` (patch existing OTel Collector) and `MethodDocker` SHALL NOT appear as options unless `featureflags.IsEnabled(featureflags.Experimental)` returns `true`.
+
+#### Scenario: OTel update option absent from setup without experimental
+
+- **GIVEN** an OTel Collector is running on the host
+- **AND** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set
+- **WHEN** a user runs `dtwiz setup`
+- **THEN** the "patch existing OpenTelemetry Collector" option does NOT appear in the recommendation list
+
+#### Scenario: OTel update option present in setup with experimental
+
+- **GIVEN** an OTel Collector is running on the host
+- **AND** `--experimental` or `DTWIZ_EXPERIMENTAL=true` is set
+- **WHEN** a user runs `dtwiz setup`
+- **THEN** the "patch existing OpenTelemetry Collector" option appears in the recommendation list
 
 ### Requirement: Test helper `SetCLIOverrideForTest`
 

--- a/openspec/changes/feature-flags-package/specs/feature-flag-registry/spec.md
+++ b/openspec/changes/feature-flags-package/specs/feature-flag-registry/spec.md
@@ -90,6 +90,8 @@ The following commands and setup flows are gated behind the `Experimental` flag:
 - `dtwiz update otel`
 - The `MethodOtelUpdate` recommendation in `dtwiz setup` (patch existing OTel Collector)
 
+The cobra flag description for `--experimental` in the registry entry SHALL enumerate all gated features so that `dtwiz --help` remains accurate. When a new experimental feature is added, its description SHALL be updated.
+
 #### Scenario: Experimental install command hidden from help by default
 
 - **GIVEN** neither `--experimental` nor `DTWIZ_EXPERIMENTAL` is set

--- a/openspec/changes/feature-flags-package/tasks.md
+++ b/openspec/changes/feature-flags-package/tasks.md
@@ -67,3 +67,4 @@ Gate the `dtwiz update otel` command and the corresponding `setup` recommendatio
 - [x] 7.3 Add `updateCmd.HelpFunc` override to call `ApplyCLIOverrides` and toggle `updateOtelCmd.Hidden` before rendering help, so `--experimental --help` reveals the subcommand
 - [x] 7.4 In `cmd/setup.go`, extend the experimental filter to also skip `MethodOtelUpdate` recommendations when `Experimental` is not enabled
 - [x] 7.5 Add tests in `cmd/cancel_test.go`: `TestUpdateOtelCmd_HiddenByDefault`, `TestUpdateOtelCmd_VisibleWhenExperimental`, `TestUpdateOtelCmd_RunE_BlockedWithoutExperimental`
+- [x] 7.6 Update the `--experimental` cobra flag description in `pkg/featureflags/featureflags.go` to mention OTel update alongside demo and Docker, so `dtwiz --help` reflects all gated features

--- a/openspec/changes/feature-flags-package/tasks.md
+++ b/openspec/changes/feature-flags-package/tasks.md
@@ -54,4 +54,16 @@ End-to-end verification of all flows.
 Manually evaluate whether Docker, Kubernetes, OneAgent, AWS, Azure, and GCP analysis/recommendations should be gated behind feature flags (Platform, OTel, and Services are already GA and excluded from this evaluation).
 
 - [x] 6.1 Review each analyzer in `pkg/analyzer/` and each recommendation method in `pkg/recommender/` — determine if any non-GA capability would benefit from a feature flag
-- [x] 6.2 Document findings: Docker recommendation and demo app installation are gated behind `Experimental` (`--experimental` / `DTWIZ_EXPERIMENTAL`). Kubernetes, OneAgent, AWS, Azure, and GCP are GA and remain ungated.
+- [x] 6.2 Document findings: Docker recommendation, demo app installation, and OTel Collector update are gated behind `Experimental` (`--experimental` / `DTWIZ_EXPERIMENTAL`). Kubernetes, OneAgent, AWS, Azure, and GCP are GA and remain ungated.
+
+## 7. Gate `dtwiz update otel` behind `Experimental`
+
+Gate the `dtwiz update otel` command and the corresponding `setup` recommendation behind the `Experimental` feature flag.
+
+**Files:** `cmd/update.go` (modify), `cmd/setup.go` (modify), `cmd/cancel_test.go` (modify)
+
+- [x] 7.1 Set `Hidden: true` on `updateOtelCmd` and add feature flag guard at the top of its `RunE` returning an error when `Experimental` is not enabled
+- [x] 7.2 Fix `updateCmd.PersistentPreRun` to call `logger.Init`, `logger.Verbose`, `logger.Debug`, and `featureflags.ApplyCLIOverrides` — it overrides root's `PersistentPreRun`, so `--experimental` was not being applied for `update` subcommands
+- [x] 7.3 Add `updateCmd.HelpFunc` override to call `ApplyCLIOverrides` and toggle `updateOtelCmd.Hidden` before rendering help, so `--experimental --help` reveals the subcommand
+- [x] 7.4 In `cmd/setup.go`, extend the experimental filter to also skip `MethodOtelUpdate` recommendations when `Experimental` is not enabled
+- [x] 7.5 Add tests in `cmd/cancel_test.go`: `TestUpdateOtelCmd_HiddenByDefault`, `TestUpdateOtelCmd_VisibleWhenExperimental`, `TestUpdateOtelCmd_RunE_BlockedWithoutExperimental`

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -49,7 +49,7 @@ var registry = []CLIFeatureFlag{
 		"experimental",
 		"DTWIZ_EXPERIMENTAL",
 		false,
-		"enable experimental features (demo installation, Docker in recommendations)",
+		"enable experimental features (demo installation, Docker and OTel update in recommendations)",
 		false,
 	},
 }


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe):
Hide dtwiz update otel behind experimental feature flag

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. run `dtwiz setup`, install otel collector on your machine
2. run `dtwiz setup`, make sure ` [1]  This machine's services (patch existing OpenTelemetry Collector)` option **is not** present in recommendations
3. run `dtwiz setup` --experimental,  `[1]  This machine's services (patch existing OpenTelemetry Collector)` option **is**  present in recommendations
4. run `dtwiz update otel`, make sure there is a warning
5. run `dtwiz update otel --experimental`, make sure it's possible
6. set up `FF DTWIZ_EXPERIMENTAL=true`, run `dtwiz setup`, `[1]  This machine's services (patch existing OpenTelemetry Collector)` option **is**  present in recommendations
7. run `dtwiz update otel`, make sure update is possible

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
