### PR TITLE
feat(k8s): print kubectl context and distro on uninstallation

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
@@ -33,7 +34,8 @@ var uninstallKubernetesCmd = &cobra.Command{
 	Short: "Remove Dynatrace Operator and DynaKube resources from Kubernetes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return installer.UninstallKubernetes()
+		k8sInfo := analyzer.DetectKubernetes()
+		return installer.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution)
 	},
 }
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -34,7 +34,7 @@ var uninstallKubernetesCmd = &cobra.Command{
 	Short: "Remove Dynatrace Operator and DynaKube resources from Kubernetes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		k8sInfo := analyzer.DetectKubernetes()
+		k8sInfo := analyzer.DetectKubernetesIdentity()
 		return installer.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution)
 	},
 }

--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -12,6 +12,30 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
+// fetchKubeContext returns the current kubectl context name, or empty string on failure.
+func fetchKubeContext() string {
+	_, ctx := runCmd("kubectl", "config", "current-context")
+	return ctx
+}
+
+// fetchKubeCluster returns the cluster name from the active kubeconfig context.
+func fetchKubeCluster() string {
+	_, cluster := runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].name}")
+	return cluster
+}
+
+// fetchKubeServerURL returns the API server URL from the active kubeconfig context.
+func fetchKubeServerURL() string {
+	_, serverURL := runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}")
+	return serverURL
+}
+
+// resolveDistro identifies the K8s distribution by running heuristic detection
+// followed by sub-variant probing.
+func resolveDistro(kubeCtx, cluster, serverURL, serverVersion string) string {
+	return ProbeK8sSubVariant(DetectK8sDistribution(kubeCtx, cluster, serverURL, serverVersion))
+}
+
 // DetectKubernetes checks for a reachable Kubernetes cluster.
 func DetectKubernetes() *KubernetesInfo {
 	info := &KubernetesInfo{}
@@ -28,15 +52,9 @@ func DetectKubernetes() *KubernetesInfo {
 		wg                                     sync.WaitGroup
 	)
 	wg.Add(5)
-	go func() { defer wg.Done(); _, ctx = runCmd("kubectl", "config", "current-context") }()
-	go func() {
-		defer wg.Done()
-		_, cluster = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].name}")
-	}()
-	go func() {
-		defer wg.Done()
-		_, serverURL = runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}")
-	}()
+	go func() { defer wg.Done(); ctx = fetchKubeContext() }()
+	go func() { defer wg.Done(); cluster = fetchKubeCluster() }()
+	go func() { defer wg.Done(); serverURL = fetchKubeServerURL() }()
 	go func() { defer wg.Done(); _, ver = runCmd("kubectl", "version", "-o", "json") }()
 	go func() { defer wg.Done(); _, nodesOut = runCmd("kubectl", "get", "nodes", "--no-headers", "-o", "name") }()
 	wg.Wait()
@@ -48,8 +66,25 @@ func DetectKubernetes() *KubernetesInfo {
 		info.NodeCount = len(strings.Split(strings.TrimSpace(nodesOut), "\n"))
 	}
 
-	parent := DetectK8sDistribution(ctx, cluster, serverURL, info.ServerVersion)
-	info.Distribution = ProbeK8sSubVariant(parent)
+	info.Distribution = resolveDistro(ctx, cluster, serverURL, info.ServerVersion)
+	return info
+}
+
+// DetectKubernetesIdentity returns only the kubectl context and K8s distribution.
+// It skips the availability check, version lookup, node count, and sub-variant probes
+// that require a live cluster connection — suitable for use before user confirmation.
+func DetectKubernetesIdentity() *KubernetesInfo {
+	info := &KubernetesInfo{}
+
+	var cluster, serverURL string
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() { defer wg.Done(); info.Context = fetchKubeContext() }()
+	go func() { defer wg.Done(); cluster = fetchKubeCluster() }()
+	go func() { defer wg.Done(); serverURL = fetchKubeServerURL() }()
+	wg.Wait()
+
+	info.Distribution = resolveDistro(info.Context, cluster, serverURL, "")
 	return info
 }
 

--- a/pkg/installer/kubernetes_uninstall.go
+++ b/pkg/installer/kubernetes_uninstall.go
@@ -6,16 +6,24 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 )
 
+var runCmdQuietFunc = RunCommandQuiet
+
 // UninstallKubernetes removes the Dynatrace Operator and all managed resources
-// from the cluster following the official uninstall sequence:
+// from the cluster following the official uninstallation sequence:
 //  1. Delete all DynaKube and EdgeConnect CRs
 //  2. Wait for managed pods to terminate (up to 5 min)
 //  3. Helm uninstall dynatrace-operator
 //  4. Delete the dynatrace namespace
-func UninstallKubernetes() error {
+func UninstallKubernetes(kubeCtx, distro string) error {
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace Kubernetes Uninstall")
 	fmt.Println()
+
+	if kubeCtx != "" {
+		fmt.Printf("  The affected cluster is: %s context=%s\n", distro, kubeCtx)
+		fmt.Println()
+	}
+
 	fmt.Println("  This will perform the following steps:")
 	fmt.Println("    1. Delete all DynaKube and EdgeConnect custom resources")
 	fmt.Println("    2. Wait for managed pods to terminate (up to 5 min)")
@@ -35,16 +43,16 @@ func UninstallKubernetes() error {
 
 	// 1. Delete DynaKube and EdgeConnect CRs.
 	fmt.Println("  Step 1: Deleting DynaKube and EdgeConnect custom resources...")
-	if err := RunCommandQuiet("kubectl", "delete", "dynakube", "-n", "dynatrace", "--all"); err != nil {
+	if err := runCmdQuietFunc("kubectl", "delete", "dynakube", "-n", "dynatrace", "--all"); err != nil {
 		return fmt.Errorf("deleting DynaKube resources: %w", err)
 	}
 	// EdgeConnect may not exist — ignore failure.
-	_ = RunCommandQuiet("kubectl", "delete", "edgeconnect", "-n", "dynatrace", "--all")
+	_ = runCmdQuietFunc("kubectl", "delete", "edgeconnect", "-n", "dynatrace", "--all")
 	fmt.Println("  Custom resources deleted.")
 
 	// 2. Wait for managed pods to terminate.
 	fmt.Println("  Step 2: Waiting for managed pods to terminate (up to 5 min)...")
-	waitErr := RunCommandQuiet(
+	waitErr := runCmdQuietFunc(
 		"kubectl", "-n", "dynatrace", "wait", "pod",
 		"--for=delete",
 		"-l", "app.kubernetes.io/managed-by=dynatrace-operator",
@@ -59,14 +67,14 @@ func UninstallKubernetes() error {
 
 	// 3. Helm uninstall.
 	fmt.Println("  Step 3: Helm uninstall dynatrace-operator...")
-	if err := RunCommandQuiet("helm", "uninstall", "dynatrace-operator", "-n", "dynatrace"); err != nil {
+	if err := runCmdQuietFunc("helm", "uninstall", "dynatrace-operator", "-n", "dynatrace"); err != nil {
 		return fmt.Errorf("helm uninstall failed: %w", err)
 	}
 	fmt.Println("  Dynatrace Operator uninstalled.")
 
 	// 4. Delete namespace.
 	fmt.Println("  Step 4: Deleting dynatrace namespace...")
-	if err := RunCommandQuiet("kubectl", "delete", "namespace", "dynatrace"); err != nil {
+	if err := runCmdQuietFunc("kubectl", "delete", "namespace", "dynatrace"); err != nil {
 		return fmt.Errorf("deleting namespace: %w", err)
 	}
 	fmt.Println("  Namespace deleted.")

--- a/pkg/installer/kubernetes_uninstall_test.go
+++ b/pkg/installer/kubernetes_uninstall_test.go
@@ -1,0 +1,126 @@
+package installer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func withFakeRunCmdQuiet(t *testing.T, fn func(name string, args ...string) error) {
+	t.Helper()
+	orig := runCmdQuietFunc
+	runCmdQuietFunc = fn
+	t.Cleanup(func() { runCmdQuietFunc = orig })
+}
+
+func TestUninstallKubernetes_Cancelled(t *testing.T) {
+	withStdin(t, "n\n", func() {
+		out := captureStdout(t, func() {
+			err := UninstallKubernetes("my-ctx", "AKS")
+			if err != nil {
+				t.Fatalf("expected nil on cancel, got: %v", err)
+			}
+		})
+		if !strings.Contains(out, "Uninstall cancelled") {
+			t.Errorf("expected cancellation message, got: %q", out)
+		}
+	})
+}
+
+func TestUninstallKubernetes_ShowsClusterInfo(t *testing.T) {
+	orig := AutoConfirm
+	AutoConfirm = true
+	t.Cleanup(func() { AutoConfirm = orig })
+
+	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
+
+	out := captureStdout(t, func() {
+		_ = UninstallKubernetes("FreeTrialKubernetesTest", "AKS")
+	})
+	if !strings.Contains(out, "The affected cluster is: AKS context=FreeTrialKubernetesTest") {
+		t.Errorf("expected cluster info line in output, got: %q", out)
+	}
+}
+
+func TestUninstallKubernetes_NoClusterInfoWhenContextEmpty(t *testing.T) {
+	orig := AutoConfirm
+	AutoConfirm = true
+	t.Cleanup(func() { AutoConfirm = orig })
+
+	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
+
+	out := captureStdout(t, func() {
+		_ = UninstallKubernetes("", "")
+	})
+	if strings.Contains(out, "The affected cluster is") {
+		t.Errorf("expected no cluster info line when context is empty, got: %q", out)
+	}
+}
+
+func TestUninstallKubernetes_Success(t *testing.T) {
+	orig := AutoConfirm
+	AutoConfirm = true
+	t.Cleanup(func() { AutoConfirm = orig })
+
+	var calls []string
+	withFakeRunCmdQuiet(t, func(name string, args ...string) error {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return nil
+	})
+
+	out := captureStdout(t, func() {
+		if err := UninstallKubernetes("my-ctx", "GKE"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "uninstalled successfully") {
+		t.Errorf("expected success message, got: %q", out)
+	}
+	if len(calls) == 0 {
+		t.Error("expected kubectl/helm commands to be called")
+	}
+}
+
+func TestUninstallKubernetes_KubectlDeleteFails(t *testing.T) {
+	orig := AutoConfirm
+	AutoConfirm = true
+	t.Cleanup(func() { AutoConfirm = orig })
+
+	withFakeRunCmdQuiet(t, func(_ string, args ...string) error {
+		if len(args) > 0 && args[0] == "delete" && args[1] == "dynakube" {
+			return errors.New("kubectl: not found")
+		}
+		return nil
+	})
+
+	captureStdout(t, func() {
+		err := UninstallKubernetes("my-ctx", "EKS")
+		if err == nil {
+			t.Fatal("expected error when kubectl delete dynakube fails")
+		}
+	})
+}
+
+func TestUninstallKubernetes_HelmUninstallFails(t *testing.T) {
+	orig := AutoConfirm
+	AutoConfirm = true
+	t.Cleanup(func() { AutoConfirm = orig })
+
+	withFakeRunCmdQuiet(t, func(name string, _ ...string) error {
+		if name == "helm" {
+			return errors.New("helm: release not found")
+		}
+		return nil
+	})
+
+	captureStdout(t, func() {
+		err := UninstallKubernetes("my-ctx", "EKS")
+		if err == nil {
+			t.Fatal("expected error when helm uninstall fails")
+		}
+		if !strings.Contains(err.Error(), "helm uninstall failed") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Feature Description
Before listing the uninstall steps, `dtwiz uninstall kubernetes` now prints the affected cluster:
```
The affected cluster is: AKS context=FreeTrialKubernetesTest
```
The kubectl context and K8s distribution are detected via `analyzer.DetectKubernetes()`, consistent with how `dtwiz install kubernetes` works.

## How to test
1. Ensure a Kubernetes cluster is reachable (`kubectl cluster-info`)
2. Run `dtwiz uninstall kubernetes --dry-run` (or decline the prompt)
3. Verify the cluster info line appears above "This will perform the following steps"
4. Please also test this on Windows and Linux.

## Which other features are affected?
None.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.