### PR TITLE
fix: show otel host monitoring info at different location

### DIFF
--- a/pkg/display/tty.go
+++ b/pkg/display/tty.go
@@ -23,3 +23,8 @@ func stdoutSupportsHyperlinks() bool {
 	// URL detection can make the URL itself right-clickable.
 	return os.Getenv("TERM_PROGRAM") != "Apple_Terminal"
 }
+
+// StdoutSupportsHyperlinks reports whether stdout supports OSC 8 hyperlinks.
+func StdoutSupportsHyperlinks() bool {
+	return stdoutSupportsHyperlinks()
+}

--- a/pkg/installer/otel.go
+++ b/pkg/installer/otel.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -251,6 +252,30 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 
 	fmt.Println()
 	display.ColorMessage.Println("  Dynatrace OpenTelemetry Installation")
+	fmt.Println()
+	const hmURL = "https://docs.dynatrace.com/docs/observe/infrastructure-observability/extensions/opentelemetry-host-monitoring"
+	supportsLinks := display.StdoutSupportsHyperlinks()
+	// ℹ️ (U+2139 + U+FE0F) width is reliable on macOS and Windows (always 2 cols)
+	// but inconsistent across Linux terminals — some render it as 1-wide.
+	// Fall back to ASCII (i) on Linux and non-hyperlink terminals to guarantee
+	// box alignment. Both options pad to 4 visual columns.
+	icon := "(i) " // 3-wide ASCII + 1 space
+	if supportsLinks && runtime.GOOS != "linux" {
+		icon = "ℹ️  " // 2-wide emoji + 2 spaces (macOS/Windows only)
+	}
+	fmt.Println("  ┌────────────────────────────────────────────────────────────────┐")
+	fmt.Printf("  │ %sThis will enable OpenTelemetry service monitoring.         │\n", icon)
+	fmt.Println("  │                                                                │")
+	fmt.Println("  │ If you also want to activate host monitoring, follow the       │")
+	if supportsLinks {
+		fmt.Printf("  │ %s instructions.                    │\n", display.Hyperlink("OpenTelemetry Host Monitoring", hmURL))
+	} else {
+		fmt.Println("  │ OpenTelemetry Host Monitoring instructions.                    │")
+	}
+	fmt.Println("  └────────────────────────────────────────────────────────────────┘")
+	if !supportsLinks {
+		fmt.Printf("    OpenTelemetry Host Monitoring: %s\n", hmURL)
+	}
 	fmt.Println()
 
 	runtimes := detectAvailableRuntimes()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -128,24 +128,6 @@ if ($Tag -eq "snapshot-main") {
 Write-Host "  * Download from github.com/${Repo}"
 Write-Host "  * Install to $InstallDir"
 Write-Host "  * Add $InstallDir to your user PATH (if not already present)"
-$HostMonitoringUrl = "https://docs.dynatrace.com/docs/observe/infrastructure-observability/extensions/opentelemetry-host-monitoring"
-Write-Host ""
-Write-Host "┌────────────────────────────────────────────────────────────────┐"
-Write-Host "│ ℹ️  This will enable OpenTelemetry service monitoring.         │"
-Write-Host "│                                                                │"
-Write-Host "│ If you also want to activate host monitoring, follow the       │"
-if (-not [Console]::IsOutputRedirected) {
-    $Esc    = [char]27
-    $ST     = [char]27 + "\"
-    $HmLink = "${Esc}]8;;${HostMonitoringUrl}${ST}OpenTelemetry Host Monitoring${Esc}]8;;${ST}"
-    Write-Host "│ $HmLink instructions.                    │"
-} else {
-    Write-Host "│ OpenTelemetry Host Monitoring instructions.                    │"
-}
-Write-Host "└────────────────────────────────────────────────────────────────┘"
-if ([Console]::IsOutputRedirected) {
-    Write-Host "  OpenTelemetry Host Monitoring: $HostMonitoringUrl"
-}
 Write-Host ""
 $Confirm = Read-Host "Continue? [Y/n]"
 if ($Confirm -match '^[Nn]') {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,21 +127,6 @@ fi
 echo "  - Download from github.com/${REPO}"
 echo "  - Install to ${INSTALL_DIR}"
 echo "  - Add ${INSTALL_DIR} to your PATH (if not already present)"
-HM_URL="https://docs.dynatrace.com/docs/observe/infrastructure-observability/extensions/opentelemetry-host-monitoring"
-echo ""
-echo "┌────────────────────────────────────────────────────────────────┐"
-echo "│ (i) This will enable OpenTelemetry service monitoring.         │"
-echo "│                                                                │"
-echo "│ If you also want to activate host monitoring, follow the       │"
-if [ -t 1 ] && [ "${TERM_PROGRAM:-}" != "Apple_Terminal" ]; then
-    printf '│ \033]8;;%s\033\\OpenTelemetry Host Monitoring\033]8;;\033\\ instructions.                    │\n' "$HM_URL"
-else
-    echo "│ OpenTelemetry Host Monitoring instructions.                    │"
-fi
-echo "└────────────────────────────────────────────────────────────────┘"
-if [ ! -t 1 ] || [ "${TERM_PROGRAM:-}" = "Apple_Terminal" ]; then
-    echo "  OpenTelemetry Host Monitoring: ${HM_URL}"
-fi
 echo ""
 printf 'Continue? [Y/n] '
 read -r REPLY </dev/tty


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. install dtwiz:
macOS: DTWIZ_TAG="snapshot-fix-show-otel-host-monitoring-into-dif-location" source <(curl -sSL https://raw.githubusercontent.com/dynatrace-oss/dtwiz/fix/show-otel-host-monitoring-into-dif-location/scripts/install.sh)
Windows $env:DTWIZ_TAG="snapshot-fix-show-otel-host-monitoring-into-dif-location"; irm https://raw.githubusercontent.com/dynatrace-oss/dtwiz/fix/show-otel-host-monitoring-into-dif-location/scripts/install.ps1 | iex
2. make sure OpenTelemetry Info Block is not present on installation step
3. run `dtwiz setup`, select Otel instrumentation, make sure OpenTelemetry Info Block is present there

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
