### PR TITLE
feat(otel): update directory scanning to exclude the parent

### DIFF
--- a/openspec/changes/remove-parent-directory-scanning/.openspec.yaml
+++ b/openspec/changes/remove-parent-directory-scanning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/remove-parent-directory-scanning/design.md
+++ b/openspec/changes/remove-parent-directory-scanning/design.md
@@ -1,16 +1,20 @@
+# Design: Remove Parent Directory Scanning
+
 ## Context
 
 `scanProjectDirs` in `pkg/installer/otel_runtime_scan.go` drives OTel instrumentation project discovery for all runtimes (Python, Node.js, Java). It calls `walkCandidateDirs(workingDir, 2, ...)`, where the second argument (`parentLevels=2`) causes the scanner to also walk up to 2 ancestor directories of the working directory after scanning the tree rooted at `workingDir`.
 
-The user-facing message ("Scanning `<dir>`") names only the working directory, creating a silent inconsistency.
+The user-facing message ("Scanning `/home/user/myapp`") names only the working directory, creating a silent inconsistency.
 
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Scan scope matches what the CLI tells the user: working directory and its subtree only.
 - No silent traversal of directories outside the working directory tree.
 
 **Non-Goals:**
+
 - Adding a flag to re-enable parent scanning.
 - Changing how `walkCandidateDirs` itself works (the `parentLevels` parameter remains; we just pass `0`).
 
@@ -21,6 +25,7 @@ The user-facing message ("Scanning `<dir>`") names only the working directory, c
 The only call site is `scanProjectDirs` (line 247). Changing the literal from `2` to `0` is sufficient. The `walkCandidateDirs` function already handles `parentLevels=0` correctly (the loop body never executes).
 
 Alternatives considered:
+
 - Remove the `parentLevels` parameter entirely — rejected; would be a larger refactor for no gain, and the parameter may be useful in future callers.
 - Keep parent scanning but update the message — rejected; the user's expectation is that scanning stays within the current directory.
 

--- a/openspec/changes/remove-parent-directory-scanning/design.md
+++ b/openspec/changes/remove-parent-directory-scanning/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`scanProjectDirs` in `pkg/installer/otel_runtime_scan.go` drives OTel instrumentation project discovery for all runtimes (Python, Node.js, Java). It calls `walkCandidateDirs(workingDir, 2, ...)`, where the second argument (`parentLevels=2`) causes the scanner to also walk up to 2 ancestor directories of the working directory after scanning the tree rooted at `workingDir`.
+
+The user-facing message ("Scanning `<dir>`") names only the working directory, creating a silent inconsistency.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Scan scope matches what the CLI tells the user: working directory and its subtree only.
+- No silent traversal of directories outside the working directory tree.
+
+**Non-Goals:**
+- Adding a flag to re-enable parent scanning.
+- Changing how `walkCandidateDirs` itself works (the `parentLevels` parameter remains; we just pass `0`).
+
+## Decisions
+
+**Pass `parentLevels=0` instead of `2`.**
+
+The only call site is `scanProjectDirs` (line 247). Changing the literal from `2` to `0` is sufficient. The `walkCandidateDirs` function already handles `parentLevels=0` correctly (the loop body never executes).
+
+Alternatives considered:
+- Remove the `parentLevels` parameter entirely — rejected; would be a larger refactor for no gain, and the parameter may be useful in future callers.
+- Keep parent scanning but update the message — rejected; the user's expectation is that scanning stays within the current directory.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| User runs `dtwiz` from a subdirectory (e.g. `my-project/src/`) and their project root is no longer auto-detected | Documented behaviour; the tip message already suggests running from the project root |

--- a/openspec/changes/remove-parent-directory-scanning/design.md
+++ b/openspec/changes/remove-parent-directory-scanning/design.md
@@ -4,7 +4,9 @@
 
 `scanProjectDirs` in `pkg/installer/otel_runtime_scan.go` drives OTel instrumentation project discovery for all runtimes (Python, Node.js, Java). It calls `walkCandidateDirs(workingDir, 2, ...)`, where the second argument (`parentLevels=2`) causes the scanner to also walk up to 2 ancestor directories of the working directory after scanning the tree rooted at `workingDir`.
 
-The user-facing message ("Scanning `/home/user/myapp`") names only the working directory, creating a silent inconsistency.
+`findNodeOtelDirs` in `pkg/installer/otel_uninstall.go` performs the same `walkCandidateDirs(cwd, 2, ...)` call during Node.js uninstall to locate `.otel/` directories to remove.
+
+The user-facing message ("Scanning `/home/user/myapp`") names only the working directory, creating a silent inconsistency. Keeping the uninstall scope aligned with install avoids a situation where uninstall could find and remove directories that install would no longer create.
 
 ## Goals / Non-Goals
 
@@ -20,13 +22,14 @@ The user-facing message ("Scanning `/home/user/myapp`") names only the working d
 
 ## Decisions
 
-**Pass `parentLevels=0` instead of `2`.**
+**Pass `parentLevels=0` instead of `2` at both call sites.**
 
-The only call site is `scanProjectDirs` (line 247). Changing the literal from `2` to `0` is sufficient. The `walkCandidateDirs` function already handles `parentLevels=0` correctly (the loop body never executes).
+Call sites: `scanProjectDirs` (install) and `findNodeOtelDirs` (uninstall). Changing the literal from `2` to `0` at each is sufficient. The `walkCandidateDirs` function already handles `parentLevels=0` correctly (the ancestor loop never executes).
 
 Alternatives considered:
 
 - Remove the `parentLevels` parameter entirely — rejected; would be a larger refactor for no gain, and the parameter may be useful in future callers.
+- Keep parent scanning in uninstall for backwards compat (clean up previously installed dirs) — rejected; install no longer creates dirs in parent directories, so uninstall reaching into parents would be inconsistent and surprising.
 - Keep parent scanning but update the message — rejected; the user's expectation is that scanning stays within the current directory.
 
 ## Risks / Trade-offs
@@ -34,3 +37,4 @@ Alternatives considered:
 | Risk | Mitigation |
 |---|---|
 | User runs `dtwiz` from a subdirectory (e.g. `my-project/src/`) and their project root is no longer auto-detected | Documented behaviour; the tip message already suggests running from the project root |
+| Previously installed `.otel/` dirs in parent directories are not cleaned up by uninstall | Acceptable: those dirs were created by an older version; the user can remove them manually. Install no longer creates them there. |

--- a/openspec/changes/remove-parent-directory-scanning/proposal.md
+++ b/openspec/changes/remove-parent-directory-scanning/proposal.md
@@ -1,6 +1,8 @@
+# Proposal: Remove Parent Directory Scanning
+
 ## Why
 
-When scanning for OTel project instrumentation, the CLI tells the user "Scanning `<dir>`" but silently also scans up to 2 parent directories — behaviour that is inconsistent with the message and unexpected to the user. Removing parent-directory scanning makes the tool do exactly what it says.
+When scanning for OTel project instrumentation, the CLI tells the user "Scanning `/home/user/myapp`" but silently also scans up to 2 parent directories — behaviour that is inconsistent with the message and unexpected to the user. Removing parent-directory scanning makes the tool do exactly what it says.
 
 ## What Changes
 

--- a/openspec/changes/remove-parent-directory-scanning/proposal.md
+++ b/openspec/changes/remove-parent-directory-scanning/proposal.md
@@ -7,6 +7,7 @@ When scanning for OTel project instrumentation, the CLI tells the user "Scanning
 ## What Changes
 
 - `scanProjectDirs` in `pkg/installer/otel_runtime_scan.go` calls `walkCandidateDirs` with `parentLevels=2`; change to `parentLevels=0` so only the working directory and its subdirectories are scanned.
+- `findNodeOtelDirs` in `pkg/installer/otel_uninstall.go` also calls `walkCandidateDirs` with `parentLevels=2`; align to `parentLevels=0` for consistency — uninstall scans the same scope as install.
 
 ## Capabilities
 
@@ -16,9 +17,10 @@ _None._
 
 ### Modified Capabilities
 
-- `otel-project-scan`: Scanning scope restricted to working directory tree only; parent directories no longer traversed.
+- `otel-project-scan`: Scanning scope restricted to working directory tree only; parent directories no longer traversed during install or uninstall.
 
 ## Impact
 
-- `pkg/installer/otel_runtime_scan.go` — one-line change to `walkCandidateDirs` call.
+- `pkg/installer/otel_runtime_scan.go` — one-line change to `walkCandidateDirs` call in `scanProjectDirs`.
+- `pkg/installer/otel_uninstall.go` — one-line change to `walkCandidateDirs` call in `findNodeOtelDirs`; comment updated to accurately describe the restricted scope.
 - Users running `dtwiz` from a subdirectory of their project root (e.g. `my-project/src/`) will no longer have the project root auto-detected. They must run from the project root or a directory that contains the project.

--- a/openspec/changes/remove-parent-directory-scanning/proposal.md
+++ b/openspec/changes/remove-parent-directory-scanning/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+When scanning for OTel project instrumentation, the CLI tells the user "Scanning `<dir>`" but silently also scans up to 2 parent directories — behaviour that is inconsistent with the message and unexpected to the user. Removing parent-directory scanning makes the tool do exactly what it says.
+
+## What Changes
+
+- `scanProjectDirs` in `pkg/installer/otel_runtime_scan.go` calls `walkCandidateDirs` with `parentLevels=2`; change to `parentLevels=0` so only the working directory and its subdirectories are scanned.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `otel-project-scan`: Scanning scope restricted to working directory tree only; parent directories no longer traversed.
+
+## Impact
+
+- `pkg/installer/otel_runtime_scan.go` — one-line change to `walkCandidateDirs` call.
+- Users running `dtwiz` from a subdirectory of their project root (e.g. `my-project/src/`) will no longer have the project root auto-detected. They must run from the project root or a directory that contains the project.

--- a/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
+++ b/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
@@ -1,16 +1,22 @@
+# Spec: OTel Project Scan
+
 ## ADDED Requirements
 
 ### Requirement: Scan scope limited to working directory
+
 The scanner SHALL search only the working directory and its subdirectories for OTel project markers. It SHALL NOT traverse any ancestor directories of the working directory.
 
 #### Scenario: Project in working directory is found
+
 - **WHEN** the user runs a dtwiz OTel install command from a directory that contains a project marker (e.g. `requirements.txt`, `package.json`)
 - **THEN** the project is detected and instrumentation proceeds
 
 #### Scenario: Project in subdirectory is found
+
 - **WHEN** the user runs a dtwiz OTel install command from a parent directory that contains subdirectories with project markers
 - **THEN** all matching subdirectory projects are detected
 
 #### Scenario: Parent directory is not scanned
+
 - **WHEN** the user runs a dtwiz OTel install command from a subdirectory of their project root (e.g. `my-project/src/`)
 - **THEN** the parent directory (`my-project/`) is NOT scanned and projects there are NOT detected

--- a/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
+++ b/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
@@ -16,7 +16,12 @@ The scanner SHALL search only the working directory and its subdirectories for O
 - **WHEN** the user runs a dtwiz OTel install command from a parent directory that contains subdirectories with project markers
 - **THEN** all matching subdirectory projects are detected
 
-#### Scenario: Parent directory is not scanned
+#### Scenario: Parent directory is not scanned during install
 
 - **WHEN** the user runs a dtwiz OTel install command from a subdirectory of their project root (e.g. `my-project/src/`)
 - **THEN** the parent directory (`my-project/`) is NOT scanned and projects there are NOT detected
+
+#### Scenario: Parent directory is not scanned during uninstall
+
+- **WHEN** the user runs a dtwiz OTel uninstall command from a subdirectory
+- **THEN** `.otel/` directories in parent directories are NOT found and NOT removed; only `.otel/` directories within the working directory tree are considered

--- a/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
+++ b/openspec/changes/remove-parent-directory-scanning/specs/otel-project-scan/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Scan scope limited to working directory
+The scanner SHALL search only the working directory and its subdirectories for OTel project markers. It SHALL NOT traverse any ancestor directories of the working directory.
+
+#### Scenario: Project in working directory is found
+- **WHEN** the user runs a dtwiz OTel install command from a directory that contains a project marker (e.g. `requirements.txt`, `package.json`)
+- **THEN** the project is detected and instrumentation proceeds
+
+#### Scenario: Project in subdirectory is found
+- **WHEN** the user runs a dtwiz OTel install command from a parent directory that contains subdirectories with project markers
+- **THEN** all matching subdirectory projects are detected
+
+#### Scenario: Parent directory is not scanned
+- **WHEN** the user runs a dtwiz OTel install command from a subdirectory of their project root (e.g. `my-project/src/`)
+- **THEN** the parent directory (`my-project/`) is NOT scanned and projects there are NOT detected

--- a/openspec/changes/remove-parent-directory-scanning/tasks.md
+++ b/openspec/changes/remove-parent-directory-scanning/tasks.md
@@ -2,13 +2,17 @@
 
 ## 1. Implementation
 
-- [x] 1.1 In `pkg/installer/otel_runtime_scan.go:247`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)`
+- [x] 1.1 In `pkg/installer/otel_runtime_scan.go`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)` in `scanProjectDirs`
+- [x] 1.2 In `pkg/installer/otel_uninstall.go`, change `walkCandidateDirs(cwd, 2, ...)` to `walkCandidateDirs(cwd, 0, ...)` in `findNodeOtelDirs`; update docstring to reflect restricted scope
 
 ## 2. Tests
 
-- [x] 2.1 Add unit test: scanning from a subdirectory does NOT detect a project marker in the parent directory
+- [x] 2.1 Add unit test: `TestScanProjectDirs_ParentNotScanned` — scanning from a subdirectory does NOT detect a project marker in the parent directory
 - [x] 2.2 Add unit test: scanning from a directory detects a project marker in the directory itself
 - [x] 2.3 Add unit test: scanning from a directory detects a project marker in a subdirectory
+- [x] 2.4 Add unit test: `TestFindNodeOtelDirs_ParentNotScanned` — uninstall scan does NOT find `.otel/` dirs in parent directories
+- [x] 2.5 Tighten `TestPromptProjectSelection_SingleProjectRangeHint` assertion: check for `"instrument [1] or press"` instead of `"[1]"` to distinguish the range hint from the project listing line
+- [x] 2.6 Add `len(projects) == 0` assertion to `TestScanProjectDirs_ParentNotScanned` to explicitly verify no projects are returned from a cwd with no markers
 
 ## 3. Verification
 

--- a/openspec/changes/remove-parent-directory-scanning/tasks.md
+++ b/openspec/changes/remove-parent-directory-scanning/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Implementation
 
-- [ ] 1.1 In `pkg/installer/otel_runtime_scan.go:247`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)`
+- [x] 1.1 In `pkg/installer/otel_runtime_scan.go:247`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)`
 
 ## 2. Tests
 
-- [ ] 2.1 Add unit test: scanning from a subdirectory does NOT detect a project marker in the parent directory
-- [ ] 2.2 Add unit test: scanning from a directory detects a project marker in the directory itself
-- [ ] 2.3 Add unit test: scanning from a directory detects a project marker in a subdirectory
+- [x] 2.1 Add unit test: scanning from a subdirectory does NOT detect a project marker in the parent directory
+- [x] 2.2 Add unit test: scanning from a directory detects a project marker in the directory itself
+- [x] 2.3 Add unit test: scanning from a directory detects a project marker in a subdirectory
 
 ## 3. Verification
 
-- [ ] 3.1 Run `make test` — all tests pass
-- [ ] 3.2 Run `make lint` — no new issues
+- [x] 3.1 Run `make test` — all tests pass
+- [x] 3.2 Run `make lint` — no new issues

--- a/openspec/changes/remove-parent-directory-scanning/tasks.md
+++ b/openspec/changes/remove-parent-directory-scanning/tasks.md
@@ -1,3 +1,5 @@
+# Tasks: Remove Parent Directory Scanning
+
 ## 1. Implementation
 
 - [x] 1.1 In `pkg/installer/otel_runtime_scan.go:247`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)`

--- a/openspec/changes/remove-parent-directory-scanning/tasks.md
+++ b/openspec/changes/remove-parent-directory-scanning/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [ ] 1.1 In `pkg/installer/otel_runtime_scan.go:247`, change `walkCandidateDirs(workingDir, 2, ...)` to `walkCandidateDirs(workingDir, 0, ...)`
+
+## 2. Tests
+
+- [ ] 2.1 Add unit test: scanning from a subdirectory does NOT detect a project marker in the parent directory
+- [ ] 2.2 Add unit test: scanning from a directory detects a project marker in the directory itself
+- [ ] 2.3 Add unit test: scanning from a directory detects a project marker in a subdirectory
+
+## 3. Verification
+
+- [ ] 3.1 Run `make test` — all tests pass
+- [ ] 3.2 Run `make lint` — no new issues

--- a/pkg/installer/otel_java.go
+++ b/pkg/installer/otel_java.go
@@ -332,7 +332,7 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 		sel := promptProjectSelection("Java", projects)
 		if sel == nil {
 			logger.Debug("user skipped project selection")
-			return nil
+			return ErrInstallCancelled
 		}
 		proj = *sel
 	}

--- a/pkg/installer/otel_java_test.go
+++ b/pkg/installer/otel_java_test.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -509,6 +510,24 @@ func TestInstallOtelJava_DryRun(t *testing.T) {
 			t.Errorf("expected dry-run output to contain %q, got:\n%s", check, output)
 		}
 	}
+}
+
+func TestInstallOtelJava_SkipReturnsInstallCancelled(t *testing.T) {
+	skipIfNoJava(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	setTestWorkingDir(t, dir)
+	setTestStdin(t, "\n") // skip project selection
+
+	captureStdout(t, func() {
+		err := InstallOtelJava("https://tenant.live.dynatrace.com", "tok", "", "", false)
+		if !errors.Is(err, ErrInstallCancelled) {
+			t.Errorf("expected ErrInstallCancelled when skipping, got %v", err)
+		}
+	})
 }
 
 func TestInstallOtelJava_NoBuildArtifact_NoRunningProcess(t *testing.T) {

--- a/pkg/installer/otel_python.go
+++ b/pkg/installer/otel_python.go
@@ -326,7 +326,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 	plan := detectPythonPlanWithConfirmedRuntime(projectPath, apiURL, token)
 	if plan == nil {
 		printManualInstructions(envVars)
-		return nil
+		return ErrInstallCancelled
 	}
 
 	fmt.Println()

--- a/pkg/installer/otel_python_test.go
+++ b/pkg/installer/otel_python_test.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -603,6 +604,25 @@ func TestQueryBootstrapRequirements_SkipsAlreadyInstalled_WithVersionSpecifier(t
 	if len(pkgs) != 0 {
 		t.Fatalf("queryBootstrapRequirements() = %v, want empty — packages are installed but specifier version suffix caused false positive", pkgs)
 	}
+}
+
+func TestInstallOtelPython_SkipReturnsInstallCancelled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stubs only work on Unix")
+	}
+	pythonDir := requireFakePython3(t)
+	t.Setenv("PATH", pythonDir)
+
+	dir := t.TempDir() // no Python project markers
+	setTestWorkingDir(t, dir)
+	setTestStdin(t, "\n") // skip project selection
+
+	captureStdout(t, func() {
+		err := InstallOtelPython("https://tenant.live.dynatrace.com", "tok", "ptok", "", "", false)
+		if !errors.Is(err, ErrInstallCancelled) {
+			t.Errorf("expected ErrInstallCancelled when skipping, got %v", err)
+		}
+	})
 }
 
 // --- Shared test helpers (used across otel_python_*_test.go files) ---

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -290,7 +290,11 @@ func promptProjectSelection(label string, projects []ScannedProject) *ScannedPro
 		fmt.Println(line)
 	}
 	fmt.Println()
-	fmt.Printf("  Select a project to instrument [1-%d] or press Enter to skip: ", len(projects))
+	rangeHint := fmt.Sprintf("1-%d", len(projects))
+	if len(projects) == 1 {
+		rangeHint = "1"
+	}
+	fmt.Printf("  Select a project to instrument [%s] or press Enter to skip: ", rangeHint)
 	reader := bufio.NewReader(os.Stdin)
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(answer)

--- a/pkg/installer/otel_runtime_scan.go
+++ b/pkg/installer/otel_runtime_scan.go
@@ -244,7 +244,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 		return true
 	}
 
-	walkCandidateDirs(workingDir, 2, dirMatches, shouldSkipDir)
+	walkCandidateDirs(workingDir, 0, dirMatches, shouldSkipDir)
 
 	subtreeCounts.Range(func(key, value any) bool {
 		logger.Debug("scan summary", "subdir", key.(string), "dirs_checked", value.(*atomic.Int64).Load())

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -546,6 +546,20 @@ func TestParseWinProcessOutput_SingleLine(t *testing.T) {
 	}
 }
 
+func TestPromptProjectSelection_SingleProjectRangeHint(t *testing.T) {
+	projects := []ScannedProject{{Path: "/home/user/myapp", Markers: []string{"package.json"}}}
+	setTestStdin(t, "\n") // skip selection
+	output := captureStdout(t, func() {
+		promptProjectSelection("Node.js", projects)
+	})
+	if !strings.Contains(output, "[1]") {
+		t.Errorf("expected [1] in prompt output, got: %s", output)
+	}
+	if strings.Contains(output, "[1-1]") {
+		t.Errorf("expected no [1-1] in prompt output for single project, got: %s", output)
+	}
+}
+
 func TestParseWinProcessOutput_PipeDelimitedFields(t *testing.T) {
 	// Verify pipe-delimited lines round-trip correctly through SplitN.
 	raw := "100|C:\\Python312\\python.exe -m flask run|C:\\app\r\n"

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -406,6 +406,9 @@ func TestScanProjectDirs_ParentNotScanned(t *testing.T) {
 	setTestWorkingDir(t, cwd)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
+	if len(projects) != 0 {
+		t.Errorf("expected no projects from cwd with no markers, got %v", projects)
+	}
 	for _, p := range projects {
 		if strings.HasSuffix(p.Path, "sibling") {
 			t.Errorf("parent directory must not be scanned; found sibling project outside cwd: %s", p.Path)
@@ -552,8 +555,8 @@ func TestPromptProjectSelection_SingleProjectRangeHint(t *testing.T) {
 	output := captureStdout(t, func() {
 		promptProjectSelection("Node.js", projects)
 	})
-	if !strings.Contains(output, "[1]") {
-		t.Errorf("expected [1] in prompt output, got: %s", output)
+	if !strings.Contains(output, "instrument [1] or press") {
+		t.Errorf("expected range hint [1] in prompt text, got: %s", output)
 	}
 	if strings.Contains(output, "[1-1]") {
 		t.Errorf("expected no [1-1] in prompt output for single project, got: %s", output)

--- a/pkg/installer/otel_runtime_scan_test.go
+++ b/pkg/installer/otel_runtime_scan_test.go
@@ -387,7 +387,7 @@ func TestScanProjectDirs_SubtreePruning(t *testing.T) {
 	}
 }
 
-func TestScanProjectDirs_AncestorWalk(t *testing.T) {
+func TestScanProjectDirs_ParentNotScanned(t *testing.T) {
 	grandparent := t.TempDir()
 
 	sibling := filepath.Join(grandparent, "sibling")
@@ -406,14 +406,10 @@ func TestScanProjectDirs_AncestorWalk(t *testing.T) {
 	setTestWorkingDir(t, cwd)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
-	found := false
 	for _, p := range projects {
 		if strings.HasSuffix(p.Path, "sibling") {
-			found = true
+			t.Errorf("parent directory must not be scanned; found sibling project outside cwd: %s", p.Path)
 		}
-	}
-	if !found {
-		t.Errorf("expected sibling project to be found via ancestor walk, got %v", projects)
 	}
 }
 

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -162,8 +162,7 @@ func removeWithRetry(path string) error {
 // findNodeOtelDirs scans CWD (recursively) and parent directories for .otel/
 // directories that contain a package.json with @opentelemetry in its content —
 // these are directories created by dtwiz's Node.js auto-instrumentation
-// installer. The scan mirrors scanProjectDirs: CWD + children, then up to 2
-// ancestor levels.
+// installer. The scan mirrors scanProjectDirs: CWD + children only.
 func findNodeOtelDirs() []string {
 	var dirs []string
 	seen := map[string]bool{}

--- a/pkg/installer/otel_uninstall.go
+++ b/pkg/installer/otel_uninstall.go
@@ -159,10 +159,10 @@ func removeWithRetry(path string) error {
 	return err
 }
 
-// findNodeOtelDirs scans CWD (recursively) and parent directories for .otel/
-// directories that contain a package.json with @opentelemetry in its content —
-// these are directories created by dtwiz's Node.js auto-instrumentation
-// installer. The scan mirrors scanProjectDirs: CWD + children only.
+// findNodeOtelDirs scans CWD (recursively) for .otel/ directories that contain
+// a package.json with @opentelemetry in its content — these are directories
+// created by dtwiz's Node.js auto-instrumentation installer. Parent directories
+// are not scanned, mirroring scanProjectDirs behaviour.
 func findNodeOtelDirs() []string {
 	var dirs []string
 	seen := map[string]bool{}
@@ -215,7 +215,7 @@ func findNodeOtelDirs() []string {
 
 	// walkCandidateDirs recursively checks dir and its children (skipping the
 	// same ignored directories as scanProjectDirs).
-	walkCandidateDirs(cwd, 2, func(dir string, entries []os.DirEntry) bool {
+	walkCandidateDirs(cwd, 0, func(dir string, entries []os.DirEntry) bool {
 		checkDir(dir, entries)
 		return false
 	}, isIgnoredDir)

--- a/pkg/installer/otel_uninstall_test.go
+++ b/pkg/installer/otel_uninstall_test.go
@@ -118,6 +118,36 @@ func TestFindNodeOtelDirs_NoDirs(t *testing.T) {
 	}
 }
 
+func TestFindNodeOtelDirs_ParentNotScanned(t *testing.T) {
+	grandparent := t.TempDir()
+
+	// Place a valid .otel/ dir in the grandparent (sibling of cwd).
+	otelDir := filepath.Join(grandparent, ".otel")
+	if err := os.MkdirAll(otelDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pkgJSON := `{"dependencies":{"@opentelemetry/auto-instrumentations-node":"latest"}}`
+	if err := os.WriteFile(filepath.Join(otelDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := filepath.Join(grandparent, "cwd")
+	if err := os.Mkdir(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	setTestWorkingDir(t, cwd)
+	dirs := findNodeOtelDirs()
+
+	realOtelDir, _ := filepath.EvalSymlinks(otelDir)
+	for _, d := range dirs {
+		realD, _ := filepath.EvalSymlinks(d)
+		if realD == realOtelDir {
+			t.Errorf("parent directory must not be scanned; found .otel/ outside cwd: %s", d)
+		}
+	}
+}
+
 func TestFindNodeOtelDirs_NoPackageJSON(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Feature Description
When scanning for OTel project instrumentation, the CLI told the user "Scanning `/home/user/myapp`" but silently also walked up to 2 parent directories. This change makes the scan scope match the message — working directory and subdirectories only.

**Change:** `walkCandidateDirs(workingDir, 2, ...)` → `walkCandidateDirs(workingDir, 0, ...)`

Note: users running `dtwiz` from a subdirectory of their project root will no longer have the project root auto-detected. They should run from the project root instead.

### What's fixed

- **`[1-1]` prompt for single project** — when only one project is detected, the selection prompt now shows `[1]` instead of the redundant `[1-1]`. Unit test: `TestPromptProjectSelection_SingleProjectRangeHint`.
- **`Watching for new data in Dynatrace…` shown after skipping Python instrumentation** — `InstallOtelPython` returned `nil` (not `ErrInstallCancelled`) when the user skipped project selection, causing the caller to invoke `WatchIngest` unconditionally. Fixed by returning `ErrInstallCancelled`. Unit test: `TestInstallOtelPython_SkipReturnsInstallCancelled`.
- **Same issue for Java** — `InstallOtelJava` had the same nil-return bug on skip. Unit test: `TestInstallOtelJava_SkipReturnsInstallCancelled`.

## How to test
### `dtwiz install otel-*`
1. `cd` to your `terra-sample-apps/node-package-delivery` directory path.
2. Run `dtwiz install otel-node` (or with `--dry-run`) from that directory.
3. Confirm no sibling project is detected (old behavior: project was silently found via parent scan).
4. `cd` to your `terra-sample-apps/` directory path.
5. Run `dtwiz install otel-node` (or with `--dry-run`) from that directory.
6. Confirm that all your `node` projects, which are children of `terra-sample-apps`, are detected.

### `dtwiz uninstall otel`
1. `cd` to your `terra-sample-apps/node-package-delivery` and instrument that app for otel via dtwiz.
2. `cd` to your `terra-sample-apps/node-package-delivery-nuxt` path.
3. Run `dtwiz uninstall otel` and make sure the sibling project's `.otel` directory is not detected.
4. Come back to the `terra-sample-apps/node-package-delivery` directory.
5. Make sure the uninstallation command detects `.otel` directory and cleans it up properly once you approve.

## Which other features are affected
1. `dtwiz install otel-node` — shares `scanProjectDirs`, scan scope now limited to working dir.
6. `dtwiz install otel-python` — same.
7. `dtwiz install otel-java` — same.
8. `dtwiz install otel` (Go) — same.
9. `dtwiz setup` — calls the same installers during the interactive flow.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.