### PR TITLE
refactor(k8s): break down the installation logic

### DIFF
--- a/pkg/analyzer/detect_kubernetes.go
+++ b/pkg/analyzer/detect_kubernetes.go
@@ -18,8 +18,8 @@ func fetchKubeContext() string {
 	return ctx
 }
 
-// fetchKubeCluster returns the cluster name from the active kubeconfig context.
-func fetchKubeCluster() string {
+// FetchKubeCluster returns the cluster name from the active kubeconfig context.
+func FetchKubeCluster() string {
 	_, cluster := runCmd("kubectl", "config", "view", "--minify", "-o", "jsonpath={.clusters[0].name}")
 	return cluster
 }
@@ -53,7 +53,7 @@ func DetectKubernetes() *KubernetesInfo {
 	)
 	wg.Add(5)
 	go func() { defer wg.Done(); ctx = fetchKubeContext() }()
-	go func() { defer wg.Done(); cluster = fetchKubeCluster() }()
+	go func() { defer wg.Done(); cluster = FetchKubeCluster() }()
 	go func() { defer wg.Done(); serverURL = fetchKubeServerURL() }()
 	go func() { defer wg.Done(); _, ver = runCmd("kubectl", "version", "-o", "json") }()
 	go func() { defer wg.Done(); _, nodesOut = runCmd("kubectl", "get", "nodes", "--no-headers", "-o", "name") }()
@@ -80,7 +80,7 @@ func DetectKubernetesIdentity() *KubernetesInfo {
 	var wg sync.WaitGroup
 	wg.Add(3)
 	go func() { defer wg.Done(); info.Context = fetchKubeContext() }()
-	go func() { defer wg.Done(); cluster = fetchKubeCluster() }()
+	go func() { defer wg.Done(); cluster = FetchKubeCluster() }()
 	go func() { defer wg.Done(); serverURL = fetchKubeServerURL() }()
 	wg.Wait()
 

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -36,6 +36,32 @@ func PrintStatusLine(label, message string, colorFunc *color.Color) {
 	}
 }
 
+// PrintAlignedStatusLine is like PrintStatusLine but pads label: to labelWidth
+// characters so values align across a group of lines with different label lengths.
+func PrintAlignedStatusLine(label, message string, labelWidth int, colorFunc *color.Color) {
+	padded := fmt.Sprintf("%-*s", labelWidth, label+":")
+	_, err := fmt.Fprintf(color.Output, "  %s  %s\n", padded, colorFunc.Sprint(message))
+	if err != nil {
+		PrintError(label, err)
+	}
+}
+
+// PrintAlignedStatusLines prints label/value pairs with auto-computed alignment:
+// the label column width is derived from the longest label so all values line up.
+// pairs must be an even-length sequence of label, value, label, value, ...
+func PrintAlignedStatusLines(colorFunc *color.Color, pairs ...string) {
+	labelWidth := 0
+	numOfPairs := len(pairs)
+	for i := 0; i < numOfPairs-1; i += 2 {
+		if w := len(pairs[i]) + 1; w > labelWidth { // +1 for colon
+			labelWidth = w
+		}
+	}
+	for i := 0; i < numOfPairs-1; i += 2 {
+		PrintAlignedStatusLine(pairs[i], pairs[i+1], labelWidth, colorFunc)
+	}
+}
+
 // PrintFlagLine prints a feature flag line without a colon after the label,
 // producing output like:  DTWIZ_ALL_RUNTIMES  ✓ enabled (env)
 func PrintFlagLine(label, message string, colorFunc *color.Color) {
@@ -94,6 +120,33 @@ func PrintInfoBox(lines ...string) {
 		fmt.Println("  │ " + line + strings.Repeat(" ", spaces) + " │")
 	}
 	fmt.Println("  " + bot)
+}
+
+// Println prints a formatted message with a two-space indent.
+func Println(format string, args ...any) {
+	fmt.Println("  " + fmt.Sprintf(format, args...))
+}
+
+// PrintlnColored prints a formatted message with a two-space indent in the given color.
+func PrintlnColored(colorFunc *color.Color, format string, args ...any) {
+	colorFunc.Println("  " + fmt.Sprintf(format, args...))
+}
+
+// PrintSteps prints a "Steps:" header followed by auto-numbered steps,
+// each indented by four spaces.
+func PrintSteps(steps ...string) {
+	fmt.Println("  Steps:")
+	for i, step := range steps {
+		fmt.Printf("    %d. %s\n", i+1, step)
+	}
+}
+
+// PrintStepsColored is like PrintSteps but renders in the given color.
+func PrintStepsColored(colorFunc *color.Color, steps ...string) {
+	colorFunc.Println("  Steps:")
+	for i, step := range steps {
+		colorFunc.Printf("    %d. %s\n", i+1, step)
+	}
 }
 
 func PrintError(label string, err error) {

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -1,39 +1,15 @@
 package display
 
 import (
-	"bytes"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
-
-	"github.com/fatih/color"
 )
 
-// captureOutput redirects color.Output (used by fatih/color Printf/Println)
-// to a buffer for the duration of fn. Colors are disabled,
-// so assertions are not fragile against terminal capability detection.
-func captureOutput(t *testing.T, fn func()) string {
-	t.Helper()
-
-	var buf bytes.Buffer
-
-	origOutput := color.Output
-	color.Output = &buf
-	t.Cleanup(func() { color.Output = origOutput })
-
-	origNoColor := color.NoColor
-	color.NoColor = true
-	t.Cleanup(func() { color.NoColor = origNoColor })
-
-	fn()
-
-	return buf.String()
-}
-
 func TestHeader_PrintsIndentedTitle(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		Header("Connection Status")
 	})
 	if !strings.Contains(got, "  Connection Status\n") {
@@ -45,7 +21,7 @@ func TestHeader_PrintsIndentedTitle(t *testing.T) {
 }
 
 func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintSectionDivider()
 	})
 	if !strings.HasPrefix(got, "  ") {
@@ -60,7 +36,7 @@ func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
 }
 
 func TestPrintStatusLine_FormatsLabelAndMessage(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintStatusLine("Environment", "✓ https://abc.live.com", ColorOK)
 	})
 	want := "  Environment:  ✓ https://abc.live.com\n"
@@ -70,7 +46,7 @@ func TestPrintStatusLine_FormatsLabelAndMessage(t *testing.T) {
 }
 
 func TestPrintStatusLine_ErrorMessage(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintStatusLine("Access Token", "✗ not set (use --access-token)", ColorError)
 	})
 	want := "  Access Token:  ✗ not set (use --access-token)\n"
@@ -80,7 +56,7 @@ func TestPrintStatusLine_ErrorMessage(t *testing.T) {
 }
 
 func TestPrintStatusLine_EmptyMessage(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintStatusLine("Label", "", ColorOK)
 	})
 	want := "  Label:  \n"
@@ -90,7 +66,7 @@ func TestPrintStatusLine_EmptyMessage(t *testing.T) {
 }
 
 func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintFlagLine("DTWIZ_ALL_RUNTIMES", "✓ enabled (env)", ColorOK)
 	})
 	want := "  DTWIZ_ALL_RUNTIMES  ✓ enabled (env)\n"
@@ -100,7 +76,7 @@ func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
 }
 
 func TestPrintError_FormatsLabelAndError(t *testing.T) {
-	got := captureOutput(t, func() {
+	got := testutil.CaptureOutput(t, func() {
 		PrintError("Setup", errors.New("connection refused"))
 	})
 	want := "  Setup: ✗ connection refused\n"
@@ -109,26 +85,8 @@ func TestPrintError_FormatsLabelAndError(t *testing.T) {
 	}
 }
 
-func captureErrorOutput(t *testing.T, fn func()) string {
-	t.Helper()
-
-	var buf bytes.Buffer
-
-	origError := color.Error
-	color.Error = &buf
-	t.Cleanup(func() { color.Error = origError })
-
-	origNoColor := color.NoColor
-	color.NoColor = true
-	t.Cleanup(func() { color.NoColor = origNoColor })
-
-	fn()
-
-	return buf.String()
-}
-
 func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
-	got := captureErrorOutput(t, func() {
+	got := testutil.CaptureErrorOutput(t, func() {
 		PrintWarning("EKS Bottlerocket probe", errors.New("exit status 1"))
 	})
 	want := "  EKS Bottlerocket probe: ⚠ exit status 1\n"
@@ -139,8 +97,8 @@ func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
 
 func TestPrintWarning_DiffersFromPrintError(t *testing.T) {
 	err := errors.New("kubectl timeout")
-	warning := captureErrorOutput(t, func() { PrintWarning("probe", err) })
-	errOut := captureOutput(t, func() { PrintError("probe", err) })
+	warning := testutil.CaptureErrorOutput(t, func() { PrintWarning("probe", err) })
+	errOut := testutil.CaptureOutput(t, func() { PrintError("probe", err) })
 	if warning == errOut {
 		t.Error("PrintWarning() and PrintError() should produce different output (⚠ vs ✗)")
 	}
@@ -171,7 +129,6 @@ func TestHyperlink_TTY_OSC8Format(t *testing.T) {
 }
 
 func TestHyperlink_NonTTYEnvironment_NoEscapeCodes(t *testing.T) {
-	// In the test environment stdout is not a TTY — Hyperlink must return plain text.
 	got := Hyperlink("Visit docs", "https://example.com")
 	if strings.Contains(got, "\033") {
 		t.Errorf("Hyperlink() in non-TTY = %q, want no escape codes", got)
@@ -218,10 +175,60 @@ func TestPrintInfoBox_BlankLineRendersEmptyRow(t *testing.T) {
 	}
 }
 
+func TestPrintAlignedStatusLine_PadsLabelToWidth(t *testing.T) {
+	got := testutil.CaptureOutput(t, func() {
+		PrintAlignedStatusLine("API URL", "https://foo.com", 13, ColorDefault)
+	})
+	want := "  API URL:       https://foo.com\n"
+	if got != want {
+		t.Errorf("PrintAlignedStatusLine() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintln_IndentsAndFormats(t *testing.T) {
+	got := testutil.CaptureStdout(t, func() {
+		Println("hello %s", "world")
+	})
+	want := "  hello world\n"
+	if got != want {
+		t.Errorf("Println() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintlnColored_IndentsMessage(t *testing.T) {
+	got := testutil.CaptureOutput(t, func() {
+		PrintlnColored(ColorDefault, "Dynatrace Kubernetes Integration")
+	})
+	want := "  Dynatrace Kubernetes Integration\n"
+	if got != want {
+		t.Errorf("PrintlnColored() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintSteps_NumbersAndIndents(t *testing.T) {
+	got := testutil.CaptureStdout(t, func() {
+		PrintSteps("Ensure Helm is installed", "kubectl apply -f dynakube.yaml")
+	})
+	want := "  Steps:\n    1. Ensure Helm is installed\n    2. kubectl apply -f dynakube.yaml\n"
+	if got != want {
+		t.Errorf("PrintSteps() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintStepsColored_NumbersAndIndents(t *testing.T) {
+	got := testutil.CaptureOutput(t, func() {
+		PrintStepsColored(ColorDefault, "step one", "step two")
+	})
+	want := "  Steps:\n    1. step one\n    2. step two\n"
+	if got != want {
+		t.Errorf("PrintStepsColored() = %q, want %q", got, want)
+	}
+}
+
 func TestPrintFlagLine_DiffersFromPrintStatusLine(t *testing.T) {
 	label, message := "DTWIZ_ALL_RUNTIMES", "✓ enabled (cli)"
-	flagLine := captureOutput(t, func() { PrintFlagLine(label, message, ColorOK) })
-	statusLine := captureOutput(t, func() { PrintStatusLine(label, message, ColorOK) })
+	flagLine := testutil.CaptureOutput(t, func() { PrintFlagLine(label, message, ColorOK) })
+	statusLine := testutil.CaptureOutput(t, func() { PrintStatusLine(label, message, ColorOK) })
 	if flagLine == statusLine {
 		t.Error("PrintFlagLine() and PrintStatusLine() should produce different output (colon vs no colon)")
 	}

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -180,7 +180,8 @@ func waitForPods(timeout time.Duration) error {
 	for {
 		pods, err := queryPodStatuses()
 		if err != nil {
-			logger.Debug("querying pod statuses", "error", err)
+			fmt.Print(clearLine)
+			return fmt.Errorf("querying pod statuses: %w", err)
 		}
 
 		readyCount := 0

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -11,7 +11,9 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 //go:embed dynakube.tmpl
@@ -77,13 +79,13 @@ func renderDynakubeTemplate(d dynakubeTemplateData) (string, error) {
 	return buf.String(), nil
 }
 
+var k8sNameRe = regexp.MustCompile(`[^a-z0-9-]+`)
+
 // sanitizeK8sName converts a string to a valid RFC 1123 DNS label suitable
 // for use as a Kubernetes resource name.
 func sanitizeK8sName(name string) string {
 	name = strings.ToLower(name)
-	// Replace any character that is not alphanumeric or hyphen with a hyphen.
-	re := regexp.MustCompile(`[^a-z0-9-]+`)
-	name = re.ReplaceAllString(name, "-")
+	name = k8sNameRe.ReplaceAllString(name, "-")
 	// Trim leading/trailing hyphens.
 	name = strings.Trim(name, "-")
 	if name == "" {
@@ -176,34 +178,42 @@ func waitForPods(timeout time.Duration) error {
 	fmt.Print("  0/0 pods ready  activegate: …  [0:00]")
 
 	for {
-		pods, _ := queryPodStatuses()
+		pods, err := queryPodStatuses()
+		if err != nil {
+			logger.Debug("querying pod statuses", "error", err)
+		}
 
 		readyCount := 0
 		total := len(pods)
 		hasActiveGate := false
 		for _, p := range pods {
-			if p.ready {
-				readyCount++
+			if !p.ready {
+				continue
 			}
-			if strings.Contains(strings.ToLower(p.name), "activegate") && p.ready {
+			readyCount++
+			if strings.Contains(strings.ToLower(p.name), "activegate") {
 				hasActiveGate = true
 			}
 		}
 
-		elapsed := time.Since(start)
+		agGlyph := "…"
+		if hasActiveGate {
+			agGlyph = "✓"
+		}
+
+		now := time.Now()
+		elapsed := now.Sub(start)
 		fmt.Printf("\r  %d/%d pods ready  activegate: %s  [%s]",
-			readyCount, total,
-			map[bool]string{true: "✓", false: "…"}[hasActiveGate],
-			formatElapsed(elapsed),
+			readyCount, total, agGlyph, formatElapsed(elapsed),
 		)
 
 		if total > 0 && readyCount == total && hasActiveGate {
 			fmt.Print(clearLine)
-			fmt.Println("  All Dynatrace pods ready.")
+			display.Println("All Dynatrace pods ready.")
 			return nil
 		}
 
-		if time.Now().After(deadline) {
+		if now.After(deadline) {
 			fmt.Print(clearLine)
 			return fmt.Errorf("timed out after %s: %d/%d pods ready, activegate ready: %v",
 				elapsed.Round(time.Second), readyCount, total, hasActiveGate)
@@ -216,12 +226,8 @@ func waitForPods(timeout time.Duration) error {
 // fetchClusterName returns the current kubectl cluster name, sanitized for use
 // as a Kubernetes resource name. Falls back to fallback if detection fails.
 func fetchClusterName(fallback string) string {
-	out, err := exec.Command("kubectl", "config", "view",
-		"--minify", "-o", "jsonpath={.clusters[0].name}").Output()
-	if err != nil || strings.TrimSpace(string(out)) == "" {
-		return fallback
-	}
-	name := sanitizeK8sName(strings.TrimSpace(string(out)))
+	cluster := analyzer.FetchKubeCluster()
+	name := sanitizeK8sName(cluster)
 	if name == "" {
 		return fallback
 	}
@@ -240,25 +246,9 @@ func resolveClusterName(name, envURL string) string {
 	return "dynakube"
 }
 
-// InstallKubernetes deploys the Dynatrace Operator on a Kubernetes cluster.
-//
-// Parameters:
-// Parameters:
-//   - envURL:      Dynatrace environment URL
-//   - token:       platform token used for both apiToken and dataIngestToken in the DynaKube Secret
-//   - clusterName: DynaKube CR name; when empty, it is derived from the current kubectl context (falling back to a value derived from envURL)
-//   - distro:      detected Kubernetes distribution (e.g. "GKE", "EKS"); empty falls back to defaults
-//   - dryRun:      when true, only print what would be done
-func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) error {
-	if err := refreshWindowsPath(); err != nil {
-		fmt.Printf("  Warning: could not refresh PATH: %v\n", err)
-	}
-
-	apiURL := APIURL(envURL)
-
-	clusterName = resolveClusterName(clusterName, envURL)
-
-	// --- Build manifest ---
+// buildDynakubeManifest constructs the DynaKube template data for the given
+// environment and renders it into a YAML manifest string.
+func buildDynakubeManifest(apiURL, token, clusterName, distro string) (string, error) {
 	tmplData := distroTemplateData(dynakubeTemplateData{
 		ClusterName:      clusterName,
 		APIURL:           apiURL + "/api",
@@ -271,109 +261,150 @@ func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) e
 	}, distro)
 	manifest, err := renderDynakubeTemplate(tmplData)
 	if err != nil {
-		return fmt.Errorf("rendering DynaKube manifest: %w", err)
+		return "", fmt.Errorf("rendering DynaKube manifest: %w", err)
 	}
+	return manifest, nil
+}
 
-	// --- Determine Helm command ---
-	disableCSI := distro == "GKE-Autopilot"
-	var helmArgs []string
-	helmMajor := 3 // sensible default for display; re-detected before execution
+// helmInstallArgs detects the installed Helm version and returns the major
+// version and the appropriate install or upgrade args for the operator chart.
+func helmInstallArgs(disableCSI bool) (helmMajor int, args []string) {
+	helmMajor = 3
 	if isHelmInstalled() {
 		if v, err := helmMajorVersion(); err == nil {
 			helmMajor = v
 		}
 	}
 	if isOperatorInstalled() {
-		helmArgs = helmOperatorUpgradeArgs(helmMajor, disableCSI)
+		return helmMajor, helmOperatorUpgradeArgs(helmMajor, disableCSI)
+	}
+	return helmMajor, helmOperatorArgs(helmMajor, disableCSI)
+}
+
+// ensureHelmOperator installs Helm if absent, then installs or upgrades the
+// dynatrace-operator Helm chart. Helm version detection runs after installation
+// so the correct args are always used.
+func ensureHelmOperator(disableCSI bool) error {
+	if !isHelmInstalled() {
+		if err := installHelm(); err != nil {
+			return fmt.Errorf("helm installation failed: %w", err)
+		}
+	}
+	helmMajor, helmArgs := helmInstallArgs(disableCSI)
+	if isOperatorInstalled() {
+		display.Println("Dynatrace Operator already installed — upgrading (helm v%d)...", helmMajor)
 	} else {
-		helmArgs = helmOperatorArgs(helmMajor, disableCSI)
+		display.Println("Installing Dynatrace Operator via Helm (helm v%d)...", helmMajor)
 	}
-	helmCmd := "helm " + strings.Join(helmArgs, " ")
-
-	if dryRun {
-		fmt.Println("[dry-run] Would deploy Dynatrace Operator on Kubernetes")
-		fmt.Printf("  API URL:      %s\n", apiURL)
-		fmt.Printf("  DynaKube:     %s\n", clusterName)
-		fmt.Printf("  Distribution: %s\n", distro)
-		fmt.Println("  Steps:")
-		fmt.Println("    1. Ensure Helm is installed")
-		fmt.Printf("    2. %s\n", helmCmd)
-		fmt.Printf("    3. kubectl apply Secret + DynaKube CRs (cluster: %s)\n", clusterName)
-		fmt.Println("    4. Wait for pods to become ready")
-		return nil
+	if err := RunCommandQuiet("helm", helmArgs...); err != nil {
+		return fmt.Errorf("Helm operator install failed: %w", err) //nolint:staticcheck // ST1005: keep brand capitalization
 	}
+	display.Println("Helm chart deployed.")
+	return nil
+}
 
-	// --- Preview ---
-	sep := strings.Repeat("─", 60)
+// handleK8sDryRun prints what the Kubernetes installation would do without executing anything.
+func handleK8sDryRun(apiURL, clusterName, distroDisplay, helmArgsStr string) {
+	fmt.Println("[dry-run] Would deploy Dynatrace Operator on Kubernetes")
+	display.PrintAlignedStatusLines(display.ColorDefault,
+		"API URL", apiURL,
+		"DynaKube", clusterName,
+		"Distribution", distroDisplay,
+	)
+	display.PrintSteps(
+		"Ensure Helm is installed",
+		"helm "+helmArgsStr,
+		fmt.Sprintf("kubectl apply Secret + DynaKube CRs (cluster: %s)", clusterName),
+		"Wait for pods to become ready",
+	)
+}
 
+// printK8sPreview prints the full installation preview: cluster metadata,
+// the rendered DynaKube manifest, and the Helm command to be executed.
+func printK8sPreview(clusterName, distroDisplay, apiURL, manifest, helmCmd string) {
 	fmt.Println()
-	display.ColorMessage.Println("  Dynatrace Kubernetes Integration")
+	display.PrintlnColored(display.ColorMessage, "Dynatrace Kubernetes Integration")
+	display.PrintSectionDivider()
 	fmt.Println()
-	fmt.Printf("  Cluster name:  %s\n", clusterName)
-	fmt.Printf("  Distribution:  %s\n", distro)
-	fmt.Printf("  API URL:       %s\n\n", apiURL)
-	fmt.Printf("  %s\n", sep)
-	display.ColorMessage.Println("  dynakube.yaml manifest to be applied:")
-	fmt.Printf("  %s\n", sep)
+	display.PrintAlignedStatusLines(display.ColorDefault,
+		"Cluster name", clusterName,
+		"Distribution", distroDisplay,
+		"API URL", apiURL,
+	)
+	fmt.Println()
+	display.PrintSectionDivider()
+	display.PrintlnColored(display.ColorMessage, "dynakube.yaml manifest to be applied:")
+	display.PrintSectionDivider()
 	for _, line := range strings.Split(strings.TrimRight(manifest, "\n"), "\n") {
 		fmt.Printf("    %s\n", line)
 	}
-	fmt.Printf("\n  %s\n", sep)
-	display.ColorMessage.Printf("  Commands to be executed:\n")
-	fmt.Printf("  %s\n", sep)
-	display.ColorMessage.Printf("    1. %s\n", helmCmd)
-	display.ColorMessage.Printf("    2. kubectl apply -f dynakube.yaml  # manifest shown above\n")
-	fmt.Printf("  %s\n\n", sep)
+	fmt.Println()
+	display.PrintSectionDivider()
+	display.PrintlnColored(display.ColorMessage, "Commands to be executed:")
+	display.PrintSectionDivider()
+	display.PrintStepsColored(display.ColorMessage,
+		helmCmd,
+		"kubectl apply -f dynakube.yaml  # manifest shown above",
+	)
+	display.PrintSectionDivider()
+	fmt.Println()
+}
 
-	// --- Confirm ---
+// InstallKubernetes deploys the Dynatrace Operator on a Kubernetes cluster.
+//
+//   - envURL:      Dynatrace environment URL
+//   - token:       platform token used for both apiToken and dataIngestToken in the DynaKube Secret
+//   - clusterName: DynaKube CR name; when empty, derived from the kubectl context or envURL
+//   - distro:      detected Kubernetes distribution (e.g. "GKE", "EKS"); empty falls back to defaults
+//   - dryRun:      when true, only print what would be done
+func InstallKubernetes(envURL, token, clusterName, distro string, dryRun bool) error {
+	if err := refreshWindowsPath(); err != nil {
+		display.PrintWarning("kubernetes", err)
+	}
+
+	apiURL := APIURL(envURL)
+	clusterName = resolveClusterName(clusterName, envURL)
+
+	manifest, err := buildDynakubeManifest(apiURL, token, clusterName, distro)
+	if err != nil {
+		return err
+	}
+
+	disableCSI := distro == "GKE-Autopilot"
+	_, helmArgs := helmInstallArgs(disableCSI)
+	helmArgsStr := strings.Join(helmArgs, " ")
+	helmCmd := "helm " + helmArgsStr
+
+	if dryRun {
+		handleK8sDryRun(apiURL, clusterName, distro, helmArgsStr)
+		return nil
+	}
+
+	printK8sPreview(clusterName, distro, apiURL, manifest, helmCmd)
+
 	ok, err := confirmProceed("  Proceed with installation?")
 	if err != nil {
 		return fmt.Errorf("reading confirmation: %w", err)
 	}
 	if !ok {
-		fmt.Println("  Installation cancelled.")
+		display.Println("Installation cancelled.")
 		return ErrInstallCancelled
 	}
 	fmt.Println()
 
-	// 1. Ensure Helm is present.
-	if !isHelmInstalled() {
-		if err := installHelm(); err != nil {
-			return fmt.Errorf("helm installation failed: %w", err)
-		}
-		// Re-detect version after installation.
-		if v, err := helmMajorVersion(); err == nil {
-			helmMajor = v
-			if isOperatorInstalled() {
-				helmArgs = helmOperatorUpgradeArgs(helmMajor, disableCSI)
-			} else {
-				helmArgs = helmOperatorArgs(helmMajor, disableCSI)
-			}
-		}
+	if err := ensureHelmOperator(disableCSI); err != nil {
+		return err
 	}
 
-	// 2. Install / upgrade dynatrace-operator via Helm.
-	if isOperatorInstalled() {
-		fmt.Printf("  Dynatrace Operator already installed — upgrading (helm v%d)...\n", helmMajor)
-	} else {
-		fmt.Printf("  Installing Dynatrace Operator via Helm (helm v%d)...\n", helmMajor)
-	}
-	if err := RunCommandQuiet("helm", helmArgs...); err != nil {
-		return fmt.Errorf("Helm operator install failed: %w", err) //nolint:staticcheck // ST1005: keep brand capitalization
-	}
-	fmt.Println("  Helm chart deployed.")
-
-	// 3. Apply manifest (Secret + DynaKube CRs in one pass).
-	fmt.Println("  Applying DynaKube manifests (Secret + DynaKube CRs)...")
+	display.Println("Applying DynaKube manifests (Secret + DynaKube CRs)...")
 	if err := applyDynakube(manifest); err != nil {
 		return fmt.Errorf("applying DynaKube manifests: %w", err)
 	}
 
-	// 4. Wait for pods.
 	if err := waitForPods(10 * time.Minute); err != nil {
 		return err
 	}
 
-	fmt.Println("  Dynatrace Operator installed successfully.")
+	display.Println("Dynatrace Operator installed successfully.")
 	return nil
 }

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 //go:embed dynakube.tmpl

--- a/pkg/testutil/stdout.go
+++ b/pkg/testutil/stdout.go
@@ -1,10 +1,13 @@
 package testutil
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"sync"
 	"testing"
+
+	"github.com/fatih/color"
 )
 
 // stdoutMu serializes tests that temporarily replace os.Stdout.
@@ -36,4 +39,41 @@ func CaptureStdout(t *testing.T, fn func()) string {
 	}
 	r.Close()
 	return string(out)
+}
+
+// CaptureOutput redirects color.Output (used by fatih/color) to a buffer for
+// the duration of fn, with colors disabled so assertions aren't fragile against
+// terminal capability detection.
+func CaptureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	origOutput := color.Output
+	color.Output = &buf
+	t.Cleanup(func() { color.Output = origOutput })
+
+	origNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = origNoColor })
+
+	fn()
+	return buf.String()
+}
+
+// CaptureErrorOutput redirects color.Error (used by fatih/color for stderr) to
+// a buffer for the duration of fn, with colors disabled.
+func CaptureErrorOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	origError := color.Error
+	color.Error = &buf
+	t.Cleanup(func() { color.Error = origError })
+
+	origNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = origNoColor })
+
+	fn()
+	return buf.String()
 }

--- a/pkg/testutil/stdout.go
+++ b/pkg/testutil/stdout.go
@@ -41,20 +41,27 @@ func CaptureStdout(t *testing.T, fn func()) string {
 	return string(out)
 }
 
+// colorMu serializes tests that temporarily replace fatih/color global output.
+// These globals are process-wide; tests using these helpers must not call t.Parallel().
+var colorMu sync.Mutex
+
 // CaptureOutput redirects color.Output (used by fatih/color) to a buffer for
 // the duration of fn, with colors disabled so assertions aren't fragile against
 // terminal capability detection.
 func CaptureOutput(t *testing.T, fn func()) string {
 	t.Helper()
+	colorMu.Lock()
+	defer colorMu.Unlock()
 
 	var buf bytes.Buffer
 	origOutput := color.Output
-	color.Output = &buf
-	t.Cleanup(func() { color.Output = origOutput })
-
 	origNoColor := color.NoColor
+	color.Output = &buf
 	color.NoColor = true
-	t.Cleanup(func() { color.NoColor = origNoColor })
+	defer func() {
+		color.Output = origOutput
+		color.NoColor = origNoColor
+	}()
 
 	fn()
 	return buf.String()
@@ -64,15 +71,18 @@ func CaptureOutput(t *testing.T, fn func()) string {
 // a buffer for the duration of fn, with colors disabled.
 func CaptureErrorOutput(t *testing.T, fn func()) string {
 	t.Helper()
+	colorMu.Lock()
+	defer colorMu.Unlock()
 
 	var buf bytes.Buffer
 	origError := color.Error
-	color.Error = &buf
-	t.Cleanup(func() { color.Error = origError })
-
 	origNoColor := color.NoColor
+	color.Error = &buf
 	color.NoColor = true
-	t.Cleanup(func() { color.NoColor = origNoColor })
+	defer func() {
+		color.Error = origError
+		color.NoColor = origNoColor
+	}()
 
 	fn()
 	return buf.String()


### PR DESCRIPTION
## Chore Description

Refactors `InstallKubernetes` in `pkg/installer/kubernetes.go` to break the monolithic function into focused, testable helpers. Adds aligned display utilities and test capture helpers as supporting infrastructure.

## What changed and why?

**`pkg/installer/kubernetes.go`**
- Extracted `buildDynakubeManifest` — isolates manifest rendering from install orchestration
- Extracted `helmInstallArgs` — isolates Helm version detection and install/upgrade arg selection
- Extracted `ensureHelmOperator` — owns the full Helm install-or-upgrade flow including post-install version re-detection
- Extracted `handleK8sDryRun` and `printK8sPreview` — separate dry-run output from live-run preview
- `InstallKubernetes` is now a thin orchestrator delegating to the above helpers
- `fetchClusterName` now delegates to `analyzer.FetchKubeCluster()` — eliminates duplicated kubectl logic
- Compiled `k8sNameRe` once as a package-level var instead of inside the function on every call
- `waitForPods`: handle error from `queryPodStatuses`, simplify ready-count loop with `continue`, remove inline `map[bool]string` literal, avoid repeated `time.Now()` calls
- Replaced ad-hoc `fmt.Printf("  ...")` calls with `display.Println`, `display.PrintAlignedStatusLines`, `display.PrintSteps`, and `display.PrintWarning`

**`pkg/display/print.go`**
- Added `PrintAlignedStatusLines` / `PrintAlignedStatusLine` — auto-computes label column width so values align across a group
- Added `Println` / `PrintlnColored` — two-space-indented formatted printing
- Added `PrintSteps` / `PrintStepsColored` — numbered step list output

**`pkg/analyzer/detect_kubernetes.go`**
- Exported `FetchKubeCluster` (was `fetchKubeCluster`) so the installer package can reuse it without duplicating the kubectl call

**`pkg/testutil/stdout.go`**
- Added `CaptureOutput` / `CaptureErrorOutput` — redirect `color.Output` / `color.Error` to a buffer with colors disabled, making display assertions stable in tests

> **Out of scope for this PR:** K8s uninstall refactoring and distro detection refactoring — these will be addressed in follow-up subtask PRs.

## How to test
1. Please refer to the testing instructions of the [implementation PR](https://github.com/dynatrace-oss/dtwiz/pull/114).

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] No unintended behavior changes were introduced.
- [x] CHANGELOG and/or documentation was updated where necessary.