### PR TITLE
feat(k8s-uninstall): refactor the logic & add dry-run mode

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -37,7 +37,7 @@ var uninstallKubernetesCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		k8sInfo := analyzer.DetectKubernetesIdentity()
-		return installer.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution)
+		return installer.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution, uninstallDryRun)
 	},
 }
 

--- a/openspec/changes/k8s-uninstall-dry-run/.openspec.yaml
+++ b/openspec/changes/k8s-uninstall-dry-run/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/k8s-uninstall-dry-run/design.md
+++ b/openspec/changes/k8s-uninstall-dry-run/design.md
@@ -1,28 +1,32 @@
+# Design: K8s Uninstall Dry-Run
+
 ## Context
 
 `dtwiz uninstall kubernetes` executes four destructive steps against a live cluster: deleting CRs, waiting for pods, helm uninstall, and namespace deletion. All other uninstall subcommands already support `--dry-run` via the shared `uninstallDryRun` flag on the parent command — this subcommand was the only exception.
 
 ## Goals / Non-Goals
 
-**Goals:**
+Goals:
+
 - Make `dtwiz uninstall kubernetes --dry-run` print the uninstall plan (cluster context + steps) without executing any kubectl or helm commands
 - Keep the dry-run path consistent with how other uninstall subcommands behave
 
-**Non-Goals:**
+Non-Goals:
+
 - Simulating or validating what the commands would return (e.g. checking if the namespace exists)
 - Adding dry-run to the install kubernetes path (separate concern)
 
 ## Decisions
 
-**Pass `dryRun bool` as a parameter to `UninstallKubernetes`**
+### Pass `dryRun bool` as a parameter to `UninstallKubernetes`
 
 The function already receives `kubeCtx` and `distro` as parameters; adding `dryRun` keeps the same style. The alternative — reading a package-level variable — would make the function harder to test in isolation. The cmd layer already holds `uninstallDryRun` and passes it to all other uninstall functions, so this is consistent.
 
-**Extract `printK8sUninstallSteps()` helper**
+### Extract `printK8sUninstallSteps()` helper
 
 The four steps are printed in both the dry-run preview and the live confirmation prompt. Extracting them avoids duplication and ensures dry-run always reflects the real execution plan.
 
-**Early return on dry-run before confirmation prompt**
+### Early return on dry-run before confirmation prompt
 
 The confirmation prompt (`confirmProceed`) is only meaningful when commands will actually run. Dry-run exits after printing the plan, so the prompt is never shown — consistent with how other dry-run implementations work.
 

--- a/openspec/changes/k8s-uninstall-dry-run/design.md
+++ b/openspec/changes/k8s-uninstall-dry-run/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`dtwiz uninstall kubernetes` executes four destructive steps against a live cluster: deleting CRs, waiting for pods, helm uninstall, and namespace deletion. All other uninstall subcommands already support `--dry-run` via the shared `uninstallDryRun` flag on the parent command — this subcommand was the only exception.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `dtwiz uninstall kubernetes --dry-run` print the uninstall plan (cluster context + steps) without executing any kubectl or helm commands
+- Keep the dry-run path consistent with how other uninstall subcommands behave
+
+**Non-Goals:**
+- Simulating or validating what the commands would return (e.g. checking if the namespace exists)
+- Adding dry-run to the install kubernetes path (separate concern)
+
+## Decisions
+
+**Pass `dryRun bool` as a parameter to `UninstallKubernetes`**
+
+The function already receives `kubeCtx` and `distro` as parameters; adding `dryRun` keeps the same style. The alternative — reading a package-level variable — would make the function harder to test in isolation. The cmd layer already holds `uninstallDryRun` and passes it to all other uninstall functions, so this is consistent.
+
+**Extract `printK8sUninstallSteps()` helper**
+
+The four steps are printed in both the dry-run preview and the live confirmation prompt. Extracting them avoids duplication and ensures dry-run always reflects the real execution plan.
+
+**Early return on dry-run before confirmation prompt**
+
+The confirmation prompt (`confirmProceed`) is only meaningful when commands will actually run. Dry-run exits after printing the plan, so the prompt is never shown — consistent with how other dry-run implementations work.
+
+## Risks / Trade-offs
+
+- The dry-run output does not verify whether the cluster is reachable or the namespace exists. Users may see a clean dry-run output but encounter failures on the real run. → Acceptable: this is the standard dry-run contract across the CLI.

--- a/openspec/changes/k8s-uninstall-dry-run/proposal.md
+++ b/openspec/changes/k8s-uninstall-dry-run/proposal.md
@@ -1,3 +1,5 @@
+# Proposal: K8s Uninstall Dry-Run
+
 ## Why
 
 `dtwiz uninstall kubernetes` was the only uninstall subcommand missing `--dry-run` support, making it inconsistent with `oneagent`, `otel`, `aws`, `aws-lambda`, and `azure`. Users had no safe way to preview what the command would do before running it against a live cluster.
@@ -15,7 +17,7 @@
 
 ### Modified Capabilities
 
-*(none — no existing spec-level behavior changes)*
+none — no existing spec-level behavior changes
 
 ## Impact
 

--- a/openspec/changes/k8s-uninstall-dry-run/proposal.md
+++ b/openspec/changes/k8s-uninstall-dry-run/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`dtwiz uninstall kubernetes` was the only uninstall subcommand missing `--dry-run` support, making it inconsistent with `oneagent`, `otel`, `aws`, `aws-lambda`, and `azure`. Users had no safe way to preview what the command would do before running it against a live cluster.
+
+## What Changes
+
+- `UninstallKubernetes` accepts a `dryRun bool` parameter
+- When `--dry-run` is set, the command prints the cluster context and the four uninstall steps, then exits without running any `kubectl` or `helm` commands
+
+## Capabilities
+
+### New Capabilities
+
+- `k8s-uninstall-dry-run`: Dry-run mode for `dtwiz uninstall kubernetes` — prints the uninstall plan (cluster info + steps) without executing anything
+
+### Modified Capabilities
+
+*(none — no existing spec-level behavior changes)*
+
+## Impact
+
+- `pkg/installer/kubernetes_uninstall.go` — `UninstallKubernetes` signature change (added `dryRun bool`)
+- `cmd/uninstall.go` — passes `uninstallDryRun` to `UninstallKubernetes`
+- `pkg/installer/kubernetes_uninstall_test.go` — all existing call sites updated; new dry-run test added

--- a/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
+++ b/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
@@ -9,7 +9,7 @@ When `--dry-run` is passed, `dtwiz uninstall kubernetes` SHALL print the cluster
 #### Scenario: Dry-run with cluster context
 
 - **WHEN** `UninstallKubernetes` is called with a non-empty `kubeCtx` and `dryRun=true`
-- **THEN** the output contains the cluster info line and all four step descriptions
+- **THEN** the output contains the cluster info line and all four-step descriptions
 - **THEN** no kubectl or helm commands are invoked
 - **THEN** the function returns nil
 
@@ -17,6 +17,6 @@ When `--dry-run` is passed, `dtwiz uninstall kubernetes` SHALL print the cluster
 
 - **WHEN** `UninstallKubernetes` is called with an empty `kubeCtx` and `dryRun=true`
 - **THEN** no cluster info line appears in output
-- **THEN** the four step descriptions are still printed
+- **THEN** the four-step descriptions are still printed
 - **THEN** no kubectl or helm commands are invoked
 - **THEN** the function returns nil

--- a/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
+++ b/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Dry-run mode prints uninstall plan without executing
+When `--dry-run` is passed, `dtwiz uninstall kubernetes` SHALL print the cluster context (if available) and the four uninstall steps, then exit with a zero return value. It SHALL NOT execute any `kubectl` or `helm` commands.
+
+#### Scenario: Dry-run with cluster context
+- **WHEN** `UninstallKubernetes` is called with a non-empty `kubeCtx` and `dryRun=true`
+- **THEN** the output contains the cluster info line and all four step descriptions
+- **THEN** no kubectl or helm commands are invoked
+- **THEN** the function returns nil
+
+#### Scenario: Dry-run with empty cluster context
+- **WHEN** `UninstallKubernetes` is called with an empty `kubeCtx` and `dryRun=true`
+- **THEN** no cluster info line appears in output
+- **THEN** the four step descriptions are still printed
+- **THEN** no kubectl or helm commands are invoked
+- **THEN** the function returns nil

--- a/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
+++ b/openspec/changes/k8s-uninstall-dry-run/specs/k8s-uninstall-dry-run/spec.md
@@ -1,15 +1,20 @@
+# Spec: K8s Uninstall Dry-Run
+
 ## ADDED Requirements
 
 ### Requirement: Dry-run mode prints uninstall plan without executing
+
 When `--dry-run` is passed, `dtwiz uninstall kubernetes` SHALL print the cluster context (if available) and the four uninstall steps, then exit with a zero return value. It SHALL NOT execute any `kubectl` or `helm` commands.
 
 #### Scenario: Dry-run with cluster context
+
 - **WHEN** `UninstallKubernetes` is called with a non-empty `kubeCtx` and `dryRun=true`
 - **THEN** the output contains the cluster info line and all four step descriptions
 - **THEN** no kubectl or helm commands are invoked
 - **THEN** the function returns nil
 
 #### Scenario: Dry-run with empty cluster context
+
 - **WHEN** `UninstallKubernetes` is called with an empty `kubeCtx` and `dryRun=true`
 - **THEN** no cluster info line appears in output
 - **THEN** the four step descriptions are still printed

--- a/openspec/changes/k8s-uninstall-dry-run/tasks.md
+++ b/openspec/changes/k8s-uninstall-dry-run/tasks.md
@@ -13,4 +13,4 @@
 ## 3. Tests
 
 - [x] 3.1 Update all existing `UninstallKubernetes` call sites in `pkg/installer/kubernetes_uninstall_test.go` to pass `false`
-- [ ] 3.2 Add `TestUninstallKubernetes_DryRun` — verify no kubectl/helm commands run, output contains step descriptions, function returns nil
+- [x] 3.2 Add `TestUninstallKubernetes_DryRun` — verify no kubectl/helm commands run, output contains step descriptions, function returns nil

--- a/openspec/changes/k8s-uninstall-dry-run/tasks.md
+++ b/openspec/changes/k8s-uninstall-dry-run/tasks.md
@@ -1,3 +1,5 @@
+# Tasks: K8s Uninstall Dry-Run
+
 ## 1. Installer
 
 - [x] 1.1 Extract `printK8sUninstallSteps()` helper in `pkg/installer/kubernetes_uninstall.go`

--- a/openspec/changes/k8s-uninstall-dry-run/tasks.md
+++ b/openspec/changes/k8s-uninstall-dry-run/tasks.md
@@ -1,0 +1,14 @@
+## 1. Installer
+
+- [x] 1.1 Extract `printK8sUninstallSteps()` helper in `pkg/installer/kubernetes_uninstall.go`
+- [x] 1.2 Add `handleK8sUninstallDryRun()` that prints the plan and returns without executing
+- [x] 1.3 Add `dryRun bool` parameter to `UninstallKubernetes` and branch on it before the confirmation prompt
+
+## 2. Command Wiring
+
+- [x] 2.1 Pass `uninstallDryRun` to `UninstallKubernetes` in `cmd/uninstall.go`
+
+## 3. Tests
+
+- [x] 3.1 Update all existing `UninstallKubernetes` call sites in `pkg/installer/kubernetes_uninstall_test.go` to pass `false`
+- [ ] 3.2 Add `TestUninstallKubernetes_DryRun` — verify no kubectl/helm commands run, output contains step descriptions, function returns nil

--- a/pkg/display/print.go
+++ b/pkg/display/print.go
@@ -132,18 +132,24 @@ func PrintlnColored(colorFunc *color.Color, format string, args ...any) {
 	colorFunc.Println("  " + fmt.Sprintf(format, args...))
 }
 
-// PrintSteps prints a "Steps:" header followed by auto-numbered steps,
-// each indented by four spaces.
-func PrintSteps(steps ...string) {
-	fmt.Println("  Steps:")
+// PrintSteps prints a title header followed by auto-numbered steps,
+// each indented by four spaces. If title is empty, "Steps:" is used.
+func PrintSteps(title string, steps ...string) {
+	if title == "" {
+		title = "Steps:"
+	}
+	fmt.Println("  " + title)
 	for i, step := range steps {
 		fmt.Printf("    %d. %s\n", i+1, step)
 	}
 }
 
 // PrintStepsColored is like PrintSteps but renders in the given color.
-func PrintStepsColored(colorFunc *color.Color, steps ...string) {
-	colorFunc.Println("  Steps:")
+func PrintStepsColored(colorFunc *color.Color, title string, steps ...string) {
+	if title == "" {
+		title = "Steps:"
+	}
+	colorFunc.Println("  " + title)
 	for i, step := range steps {
 		colorFunc.Printf("    %d. %s\n", i+1, step)
 	}

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -207,7 +207,7 @@ func TestPrintlnColored_IndentsMessage(t *testing.T) {
 
 func TestPrintSteps_NumbersAndIndents(t *testing.T) {
 	got := testutil.CaptureStdout(t, func() {
-		PrintSteps("Ensure Helm is installed", "kubectl apply -f dynakube.yaml")
+		PrintSteps("", "Ensure Helm is installed", "kubectl apply -f dynakube.yaml")
 	})
 	want := "  Steps:\n    1. Ensure Helm is installed\n    2. kubectl apply -f dynakube.yaml\n"
 	if got != want {
@@ -217,7 +217,7 @@ func TestPrintSteps_NumbersAndIndents(t *testing.T) {
 
 func TestPrintStepsColored_NumbersAndIndents(t *testing.T) {
 	got := testutil.CaptureOutput(t, func() {
-		PrintStepsColored(ColorDefault, "step one", "step two")
+		PrintStepsColored(ColorDefault, "", "step one", "step two")
 	})
 	want := "  Steps:\n    1. step one\n    2. step two\n"
 	if got != want {

--- a/pkg/installer/kubernetes.go
+++ b/pkg/installer/kubernetes.go
@@ -311,7 +311,7 @@ func handleK8sDryRun(apiURL, clusterName, distroDisplay, helmArgsStr string) {
 		"DynaKube", clusterName,
 		"Distribution", distroDisplay,
 	)
-	display.PrintSteps(
+	display.PrintSteps("",
 		"Ensure Helm is installed",
 		"helm "+helmArgsStr,
 		fmt.Sprintf("kubectl apply Secret + DynaKube CRs (cluster: %s)", clusterName),
@@ -342,7 +342,7 @@ func printK8sPreview(clusterName, distroDisplay, apiURL, manifest, helmCmd strin
 	display.PrintSectionDivider()
 	display.PrintlnColored(display.ColorMessage, "Commands to be executed:")
 	display.PrintSectionDivider()
-	display.PrintStepsColored(display.ColorMessage,
+	display.PrintStepsColored(display.ColorMessage, "",
 		helmCmd,
 		"kubectl apply -f dynakube.yaml  # manifest shown above",
 	)

--- a/pkg/installer/kubernetes_uninstall.go
+++ b/pkg/installer/kubernetes_uninstall.go
@@ -9,15 +9,31 @@ import (
 
 var runCmdQuietFunc = RunCommandQuiet
 
+func printK8sUninstallSteps() {
+	display.PrintSteps("This will perform the following steps:",
+		"Delete all DynaKube and EdgeConnect custom resources",
+		"Wait for managed pods to terminate (up to 5 min)",
+		"Helm uninstall dynatrace-operator",
+		"Delete the dynatrace namespace",
+	)
+}
+
+// handleK8sUninstallDryRun prints what the uninstallation would do without executing anything.
+func handleK8sUninstallDryRun() {
+	display.Println("[dry-run] Would remove Dynatrace Operator from Kubernetes")
+	fmt.Println()
+	printK8sUninstallSteps()
+}
+
 // UninstallKubernetes removes the Dynatrace Operator and all managed resources
 // from the cluster following the official uninstallation sequence:
 //  1. Delete all DynaKube and EdgeConnect CRs
 //  2. Wait for managed pods to terminate (up to 5 min)
 //  3. Helm uninstall dynatrace-operator
 //  4. Delete the dynatrace namespace
-func UninstallKubernetes(kubeCtx, distro string) error {
+func UninstallKubernetes(kubeCtx, distro string, dryRun bool) error {
 	if err := refreshWindowsPath(); err != nil {
-		fmt.Printf("  Warning: could not refresh PATH: %v\n", err)
+		display.Println("Warning: could not refresh PATH: %v", err)
 	}
 
 	fmt.Println()
@@ -29,12 +45,12 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 		fmt.Println()
 	}
 
-	display.PrintSteps("This will perform the following steps:",
-		"Delete all DynaKube and EdgeConnect custom resources",
-		"Wait for managed pods to terminate (up to 5 min)",
-		"Helm uninstall dynatrace-operator",
-		"Delete the dynatrace namespace",
-	)
+	if dryRun {
+		handleK8sUninstallDryRun()
+		return nil
+	}
+
+	printK8sUninstallSteps()
 	fmt.Println()
 
 	ok, err := confirmProceed("  Proceed with uninstall?")
@@ -53,7 +69,7 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 	// 1. Delete DynaKube and EdgeConnect CRs.
 	display.Println("Step 1: Deleting DynaKube and EdgeConnect custom resources...")
 	if err := runCmdQuietFunc("kubectl", "delete", "dynakube", "-n", dtNamespace, "--all"); err != nil {
-		fmt.Printf("  Error: %v\n", err)
+		display.Println("Error: %v", err)
 		errs = append(errs, fmt.Errorf("deleting DynaKube resources: %w", err))
 	}
 	// EdgeConnect may not exist — ignore failure. Always attempt regardless of DynaKube result.
@@ -72,7 +88,7 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 	)
 	if waitErr != nil {
 		// Non-fatal: pods may already be gone or label may not match.
-		fmt.Printf("  Warning: %v\n", waitErr)
+		display.Println("Warning: %v", waitErr)
 	} else {
 		display.Println("Managed pods terminated.")
 	}
@@ -80,7 +96,7 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 	// 3. Helm uninstall.
 	display.Println("Step 3: Helm uninstall dynatrace-operator...")
 	if err := runCmdQuietFunc("helm", "uninstall", "dynatrace-operator", "-n", dtNamespace); err != nil {
-		fmt.Printf("  Error: %v\n", err)
+		display.Println("Error: %v", err)
 		errs = append(errs, fmt.Errorf("helm uninstall failed: %w", err))
 	} else {
 		display.Println("Dynatrace Operator uninstalled.")
@@ -89,7 +105,7 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 	// 4. Delete namespace.
 	display.Println("Step 4: Deleting dynatrace namespace...")
 	if err := runCmdQuietFunc("kubectl", "delete", "namespace", dtNamespace); err != nil {
-		fmt.Printf("  Error: %v\n", err)
+		display.Println("Error: %v", err)
 		errs = append(errs, fmt.Errorf("deleting namespace: %w", err))
 	} else {
 		display.Println("Namespace deleted.")

--- a/pkg/installer/kubernetes_uninstall.go
+++ b/pkg/installer/kubernetes_uninstall.go
@@ -21,19 +21,20 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 	}
 
 	fmt.Println()
-	display.ColorMessage.Println("  Dynatrace Kubernetes Uninstall")
+	display.PrintlnColored(display.ColorMessage, "Dynatrace Kubernetes Uninstall")
 	fmt.Println()
 
 	if kubeCtx != "" {
-		fmt.Printf("  The affected cluster is: %s context=%s\n", distro, kubeCtx)
+		display.Println("The affected cluster is: %s context=%s", distro, kubeCtx)
 		fmt.Println()
 	}
 
-	fmt.Println("  This will perform the following steps:")
-	fmt.Println("    1. Delete all DynaKube and EdgeConnect custom resources")
-	fmt.Println("    2. Wait for managed pods to terminate (up to 5 min)")
-	fmt.Println("    3. Helm uninstall dynatrace-operator")
-	fmt.Println("    4. Delete the dynatrace namespace")
+	display.PrintSteps("This will perform the following steps:",
+		"Delete all DynaKube and EdgeConnect custom resources",
+		"Wait for managed pods to terminate (up to 5 min)",
+		"Helm uninstall dynatrace-operator",
+		"Delete the dynatrace namespace",
+	)
 	fmt.Println()
 
 	ok, err := confirmProceed("  Proceed with uninstall?")
@@ -41,29 +42,30 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 		return fmt.Errorf("reading confirmation: %w", err)
 	}
 	if !ok {
-		fmt.Println("  Uninstall cancelled.")
+		display.Println("Uninstall cancelled.")
 		return nil
 	}
 	fmt.Println()
 
+	const dtNamespace = "dynatrace"
 	var errs []error
 
 	// 1. Delete DynaKube and EdgeConnect CRs.
-	fmt.Println("  Step 1: Deleting DynaKube and EdgeConnect custom resources...")
-	if err := runCmdQuietFunc("kubectl", "delete", "dynakube", "-n", "dynatrace", "--all"); err != nil {
+	display.Println("Step 1: Deleting DynaKube and EdgeConnect custom resources...")
+	if err := runCmdQuietFunc("kubectl", "delete", "dynakube", "-n", dtNamespace, "--all"); err != nil {
 		fmt.Printf("  Error: %v\n", err)
 		errs = append(errs, fmt.Errorf("deleting DynaKube resources: %w", err))
 	}
 	// EdgeConnect may not exist — ignore failure. Always attempt regardless of DynaKube result.
-	_ = runCmdQuietFunc("kubectl", "delete", "edgeconnect", "-n", "dynatrace", "--all")
+	_ = runCmdQuietFunc("kubectl", "delete", "edgeconnect", "-n", dtNamespace, "--all")
 	if len(errs) == 0 {
-		fmt.Println("  Custom resources deleted.")
+		display.Println("Custom resources deleted.")
 	}
 
 	// 2. Wait for managed pods to terminate.
-	fmt.Println("  Step 2: Waiting for managed pods to terminate (up to 5 min)...")
+	display.Println("Step 2: Waiting for managed pods to terminate (up to 5 min)...")
 	waitErr := runCmdQuietFunc(
-		"kubectl", "-n", "dynatrace", "wait", "pod",
+		"kubectl", "-n", dtNamespace, "wait", "pod",
 		"--for=delete",
 		"-l", "app.kubernetes.io/managed-by=dynatrace-operator",
 		"--timeout=300s",
@@ -72,32 +74,32 @@ func UninstallKubernetes(kubeCtx, distro string) error {
 		// Non-fatal: pods may already be gone or label may not match.
 		fmt.Printf("  Warning: %v\n", waitErr)
 	} else {
-		fmt.Println("  Managed pods terminated.")
+		display.Println("Managed pods terminated.")
 	}
 
 	// 3. Helm uninstall.
-	fmt.Println("  Step 3: Helm uninstall dynatrace-operator...")
-	if err := runCmdQuietFunc("helm", "uninstall", "dynatrace-operator", "-n", "dynatrace"); err != nil {
+	display.Println("Step 3: Helm uninstall dynatrace-operator...")
+	if err := runCmdQuietFunc("helm", "uninstall", "dynatrace-operator", "-n", dtNamespace); err != nil {
 		fmt.Printf("  Error: %v\n", err)
 		errs = append(errs, fmt.Errorf("helm uninstall failed: %w", err))
 	} else {
-		fmt.Println("  Dynatrace Operator uninstalled.")
+		display.Println("Dynatrace Operator uninstalled.")
 	}
 
 	// 4. Delete namespace.
-	fmt.Println("  Step 4: Deleting dynatrace namespace...")
-	if err := runCmdQuietFunc("kubectl", "delete", "namespace", "dynatrace"); err != nil {
+	display.Println("Step 4: Deleting dynatrace namespace...")
+	if err := runCmdQuietFunc("kubectl", "delete", "namespace", dtNamespace); err != nil {
 		fmt.Printf("  Error: %v\n", err)
 		errs = append(errs, fmt.Errorf("deleting namespace: %w", err))
 	} else {
-		fmt.Println("  Namespace deleted.")
+		display.Println("Namespace deleted.")
 	}
 
 	fmt.Println()
 	if len(errs) > 0 {
-		fmt.Println("  Uninstall completed with errors.")
+		display.Println("Uninstall completed with errors.")
 		return errors.New("uninstall: one or more steps failed (see above)")
 	}
-	fmt.Println("  Dynatrace Operator uninstalled successfully.")
+	display.Println("Dynatrace Operator uninstalled successfully.")
 	return nil
 }

--- a/pkg/installer/kubernetes_uninstall.go
+++ b/pkg/installer/kubernetes_uninstall.go
@@ -32,22 +32,21 @@ func handleK8sUninstallDryRun() {
 //  3. Helm uninstall dynatrace-operator
 //  4. Delete the dynatrace namespace
 func UninstallKubernetes(kubeCtx, distro string, dryRun bool) error {
-	if err := refreshWindowsPath(); err != nil {
-		display.Println("Warning: could not refresh PATH: %v", err)
-	}
-
 	fmt.Println()
 	display.PrintlnColored(display.ColorMessage, "Dynatrace Kubernetes Uninstall")
 	fmt.Println()
 
 	if kubeCtx != "" {
-		display.Println("The affected cluster is: %s context=%s", distro, kubeCtx)
-		fmt.Println()
+		display.Println("The affected cluster is: %s context=%s\n", distro, kubeCtx)
 	}
 
 	if dryRun {
 		handleK8sUninstallDryRun()
 		return nil
+	}
+
+	if err := refreshWindowsPath(); err != nil {
+		display.Println("Warning: could not refresh PATH: %v", err)
 	}
 
 	printK8sUninstallSteps()

--- a/pkg/installer/kubernetes_uninstall_test.go
+++ b/pkg/installer/kubernetes_uninstall_test.go
@@ -18,7 +18,7 @@ func withFakeRunCmdQuiet(t *testing.T, fn func(name string, args ...string) erro
 func TestUninstallKubernetes_Cancelled(t *testing.T) {
 	withStdin(t, "n\n", func() {
 		out := testutil.CaptureStdout(t, func() {
-			err := UninstallKubernetes("my-ctx", "AKS")
+			err := UninstallKubernetes("my-ctx", "AKS", false)
 			if err != nil {
 				t.Fatalf("expected nil on cancel, got: %v", err)
 			}
@@ -37,7 +37,7 @@ func TestUninstallKubernetes_ShowsClusterInfo(t *testing.T) {
 	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
 
 	out := testutil.CaptureStdout(t, func() {
-		_ = UninstallKubernetes("FreeTrialKubernetesTest", "AKS")
+		_ = UninstallKubernetes("FreeTrialKubernetesTest", "AKS", false)
 	})
 	if !strings.Contains(out, "The affected cluster is: AKS context=FreeTrialKubernetesTest") {
 		t.Errorf("expected cluster info line in output, got: %q", out)
@@ -52,7 +52,7 @@ func TestUninstallKubernetes_NoClusterInfoWhenContextEmpty(t *testing.T) {
 	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
 
 	out := testutil.CaptureStdout(t, func() {
-		_ = UninstallKubernetes("", "")
+		_ = UninstallKubernetes("", "", false)
 	})
 	if strings.Contains(out, "The affected cluster is") {
 		t.Errorf("expected no cluster info line when context is empty, got: %q", out)
@@ -71,7 +71,7 @@ func TestUninstallKubernetes_Success(t *testing.T) {
 	})
 
 	out := testutil.CaptureStdout(t, func() {
-		if err := UninstallKubernetes("my-ctx", "GKE"); err != nil {
+		if err := UninstallKubernetes("my-ctx", "GKE", false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -98,7 +98,7 @@ func TestUninstallKubernetes_EdgeConnectDeletedEvenWhenDynaKubeFails(t *testing.
 		return nil
 	})
 
-	testutil.CaptureStdout(t, func() { _ = UninstallKubernetes("my-ctx", "EKS") })
+	testutil.CaptureStdout(t, func() { _ = UninstallKubernetes("my-ctx", "EKS", false) })
 
 	ranEdgeConnect := false
 	for _, c := range calls {
@@ -124,7 +124,7 @@ func TestUninstallKubernetes_KubectlDeleteFails(t *testing.T) {
 	})
 
 	testutil.CaptureStdout(t, func() {
-		err := UninstallKubernetes("my-ctx", "EKS")
+		err := UninstallKubernetes("my-ctx", "EKS", false)
 		if err == nil {
 			t.Fatal("expected error when kubectl delete dynakube fails")
 		}
@@ -144,7 +144,7 @@ func TestUninstallKubernetes_HelmUninstallFails(t *testing.T) {
 	})
 
 	testutil.CaptureStdout(t, func() {
-		err := UninstallKubernetes("my-ctx", "EKS")
+		err := UninstallKubernetes("my-ctx", "EKS", false)
 		if err == nil {
 			t.Fatal("expected error when helm uninstall fails")
 		}
@@ -169,7 +169,7 @@ func TestUninstallKubernetes_HelmFailContinuesToNamespaceDeletion(t *testing.T) 
 	})
 
 	out := testutil.CaptureStdout(t, func() {
-		err := UninstallKubernetes("my-ctx", "EKS")
+		err := UninstallKubernetes("my-ctx", "EKS", false)
 		if err == nil {
 			t.Fatal("expected error when helm uninstall fails")
 		}
@@ -204,7 +204,7 @@ func TestUninstallKubernetes_KubectlDeleteFailContinuesToEnd(t *testing.T) {
 	})
 
 	testutil.CaptureStdout(t, func() {
-		err := UninstallKubernetes("my-ctx", "EKS")
+		err := UninstallKubernetes("my-ctx", "EKS", false)
 		if err == nil {
 			t.Fatal("expected error when kubectl delete dynakube fails")
 		}
@@ -243,7 +243,7 @@ func TestUninstallKubernetes_MultipleStepsFail(t *testing.T) {
 	})
 
 	out := testutil.CaptureStdout(t, func() {
-		err := UninstallKubernetes("my-ctx", "EKS")
+		err := UninstallKubernetes("my-ctx", "EKS", false)
 		if err == nil {
 			t.Fatal("expected error when multiple steps fail")
 		}

--- a/pkg/installer/kubernetes_uninstall_test.go
+++ b/pkg/installer/kubernetes_uninstall_test.go
@@ -227,6 +227,34 @@ func TestUninstallKubernetes_KubectlDeleteFailContinuesToEnd(t *testing.T) {
 	}
 }
 
+func TestUninstallKubernetes_DryRun(t *testing.T) {
+	var calls []string
+	withFakeRunCmdQuiet(t, func(name string, args ...string) error {
+		calls = append(calls, name)
+		return nil
+	})
+
+	out := testutil.CaptureStdout(t, func() {
+		if err := UninstallKubernetes("my-ctx", "GKE", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if len(calls) > 0 {
+		t.Errorf("expected no commands to run in dry-run mode, got: %v", calls)
+	}
+	for _, step := range []string{
+		"Delete all DynaKube and EdgeConnect custom resources",
+		"Wait for managed pods to terminate",
+		"Helm uninstall dynatrace-operator",
+		"Delete the dynatrace namespace",
+	} {
+		if !strings.Contains(out, step) {
+			t.Errorf("expected step %q in dry-run output, got: %q", step, out)
+		}
+	}
+}
+
 func TestUninstallKubernetes_MultipleStepsFail(t *testing.T) {
 	orig := AutoConfirm
 	AutoConfirm = true

--- a/pkg/installer/kubernetes_uninstall_test.go
+++ b/pkg/installer/kubernetes_uninstall_test.go
@@ -255,6 +255,37 @@ func TestUninstallKubernetes_DryRun(t *testing.T) {
 	}
 }
 
+func TestUninstallKubernetes_DryRun_NoClusterInfoWhenContextEmpty(t *testing.T) {
+	var calls []string
+	withFakeRunCmdQuiet(t, func(name string, args ...string) error {
+		calls = append(calls, name)
+		return nil
+	})
+
+	out := testutil.CaptureStdout(t, func() {
+		if err := UninstallKubernetes("", "", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if len(calls) > 0 {
+		t.Errorf("expected no commands to run in dry-run mode, got: %v", calls)
+	}
+	if strings.Contains(out, "The affected cluster is") {
+		t.Errorf("expected no cluster info line when context is empty, got: %q", out)
+	}
+	for _, step := range []string{
+		"Delete all DynaKube and EdgeConnect custom resources",
+		"Wait for managed pods to terminate",
+		"Helm uninstall dynatrace-operator",
+		"Delete the dynatrace namespace",
+	} {
+		if !strings.Contains(out, step) {
+			t.Errorf("expected step %q in dry-run output, got: %q", step, out)
+		}
+	}
+}
+
 func TestUninstallKubernetes_MultipleStepsFail(t *testing.T) {
 	orig := AutoConfirm
 	AutoConfirm = true


### PR DESCRIPTION
## Feature Description

Refactors `UninstallKubernetes` for consistency with the rest of the CLI and adds `--dry-run` support.

**Refactoring:**
- Replace raw `fmt.Println` calls with `display.Println` / `display.PrintlnColored` throughout `kubernetes_uninstall.go`
- Extract step list into `printK8sUninstallSteps()` — shared by both the live flow and dry-run preview
- Harden `PrintSteps` / `PrintStepsColored` with an optional title parameter (empty → defaults to `Steps:`)
- Consolidate hardcoded `"dynatrace"` namespace string into a single `dtNamespace` constant

**Dry-run:**
- `dtwiz uninstall kubernetes --dry-run` now prints the cluster context and uninstall plan without executing any `kubectl` or `helm` commands
- `refreshWindowsPath()` (shells out to PowerShell on Windows) is skipped in dry-run mode
- Wires `uninstallDryRun` through to `UninstallKubernetes`, consistent with all other uninstall subcommands

## How to test

**K8s uninstall (live):**
1. Point `kubectl` at a test cluster with Dynatrace Operator installed
2. Run `dtwiz uninstall kubernetes` and confirm the four-step plan is printed
3. Confirm at the prompt — verify DynaKube/EdgeConnect CRs are deleted, operator is helm-uninstalled, and the `dynatrace` namespace is removed

**Dry-run mode:**
1. Run `dtwiz uninstall kubernetes --dry-run`
2. Verify the cluster context line and all four step descriptions are printed
3. Verify no `kubectl` or `helm` commands were executed (namespace and operator should be unchanged)
4. Run with `--dry-run` on a machine with no cluster configured — confirm it exits cleanly with no errors

## Which other features are affected?
1. `dtwiz uninstall` — `--dry-run` flag now applies to the `kubernetes` subcommand

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.