### PR TITLE
chore: small improvements

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/azure"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/gcp"
 	k8s "github.com/dynatrace-oss/dtwiz/pkg/installer/kubernetes"
@@ -50,6 +51,32 @@ var setupCmd = &cobra.Command{
 			return fmt.Errorf("analysis failed: %w", err)
 		}
 		fmt.Println(info.Summary())
+
+		// Pre-check Azure/GCP connection status so the recommender can emit the
+		// right method (install vs update) for each cloud integration.
+		if envURL, _, platformTok, credErr := getDtEnvironment(); credErr == nil {
+			var checks []func() error
+			if info.AzureDetected() {
+				checks = append(checks, func() error {
+					exists, err := azure.ConnectionExists(envURL, platformTok)
+					info.AzureConfigured = exists
+					return err
+				})
+			}
+			if info.GCPDetected() {
+				checks = append(checks, func() error {
+					exists, err := gcp.ConnectionExists(envURL, platformTok)
+					info.GCPConfigured = exists
+					return err
+				})
+			}
+			if len(checks) > 0 {
+				if err := installer.RunConcurrently(checks...); err != nil {
+					logger.Debug("connection existence check failed, assuming not configured", "err", err)
+				}
+			}
+		}
+
 
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -17,7 +17,6 @@ import (
 	k8s "github.com/dynatrace-oss/dtwiz/pkg/installer/kubernetes"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel"
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
 )
 
@@ -51,31 +50,6 @@ var setupCmd = &cobra.Command{
 			return fmt.Errorf("analysis failed: %w", err)
 		}
 		fmt.Println(info.Summary())
-
-		// Pre-check Azure/GCP connection status so the recommender can emit the
-		// right method (install vs update) for each cloud integration.
-		if envURL, _, platformTok, credErr := getDtEnvironment(); credErr == nil {
-			var checks []func() error
-			if info.AzureDetected() {
-				checks = append(checks, func() error {
-					exists, err := azure.ConnectionExists(envURL, platformTok)
-					info.AzureConfigured = exists
-					return err
-				})
-			}
-			if info.GCPDetected() {
-				checks = append(checks, func() error {
-					exists, err := gcp.ConnectionExists(envURL, platformTok)
-					info.GCPConfigured = exists
-					return err
-				})
-			}
-			if len(checks) > 0 {
-				if err := installer.RunConcurrently(checks...); err != nil {
-					logger.Debug("connection existence check failed, assuming not configured", "err", err)
-				}
-			}
-		}
 
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -77,7 +77,6 @@ var setupCmd = &cobra.Command{
 			}
 		}
 
-
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")
 		recs := recommender.GenerateRecommendations(info)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -12,12 +12,12 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/azure"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/gcp"
 	k8s "github.com/dynatrace-oss/dtwiz/pkg/installer/kubernetes"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel"
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"github.com/dynatrace-oss/dtwiz/pkg/recommender"
 )
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -123,6 +123,7 @@ type GCPService struct {
 // GCPInfo holds details about a detected GCP environment.
 type GCPInfo struct {
 	Available         bool         `json:"available"`
+	Authenticated     bool         `json:"authenticated,omitempty"`
 	ProjectID         string       `json:"project_id,omitempty"`
 	Account           string       `json:"account,omitempty"`
 	Services          []GCPService `json:"services,omitempty"`
@@ -271,9 +272,13 @@ func (s *SystemInfo) Summary() string {
 		}
 		sb.WriteString(gcpLine + "\n")
 	} else {
+		gcpNoneMsg := "<none> — sign in with 'gcloud auth login' to detect your project"
+		if s.GCP != nil && s.GCP.Authenticated {
+			gcpNoneMsg = "<none> — set a project with 'gcloud config set project PROJECT_ID'"
+		}
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("GCP"),
-			display.ColorMuted.Sprint("<none> — sign in with 'gcloud auth login' to detect your project")))
+			display.ColorMuted.Sprint(gcpNoneMsg)))
 	}
 
 	switch {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -150,6 +150,9 @@ type SystemInfo struct {
 	Services         []string         `json:"services"`
 }
 
+func (s *SystemInfo) AzureDetected() bool { return s.Azure != nil && s.Azure.Available }
+func (s *SystemInfo) GCPDetected() bool   { return s.GCP != nil && s.GCP.Available }
+
 const (
 	labelWidth = 18
 )
@@ -233,7 +236,7 @@ func (s *SystemInfo) Summary() string {
 			display.ColorMuted.Sprint("<none> — sign in with 'aws configure' to detect your account")))
 	}
 
-	if s.Azure != nil && s.Azure.Available {
+	if s.AzureDetected() {
 		azureLine := fmt.Sprintf("  %s subscription=%s",
 			label("Azure"),
 			s.Azure.SubscriptionID)
@@ -253,7 +256,7 @@ func (s *SystemInfo) Summary() string {
 			display.ColorMuted.Sprint("<none> — sign in with 'az login' to detect your subscription")))
 	}
 
-	if s.GCP != nil && s.GCP.Available {
+	if s.GCPDetected() {
 		gcpLine := fmt.Sprintf("  %s project=%s",
 			label("GCP"),
 			s.GCP.ProjectID)

--- a/pkg/analyzer/detect_gcp.go
+++ b/pkg/analyzer/detect_gcp.go
@@ -15,10 +15,12 @@ func detectGCP() *GCPInfo {
 	if !ok || projectID == "" || strings.Contains(projectID, "(unset)") {
 		if ok {
 			// gcloud is available but no project is set — check if the user is authenticated.
-			_, acctOut := runCmd("gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)")
-			if acct := strings.TrimSpace(acctOut); acct != "" {
-				info.Authenticated = true
-				info.Account = acct
+			authOK, acctOut := runCmd("gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)")
+			if authOK {
+				if acct := strings.TrimSpace(acctOut); acct != "" {
+					info.Authenticated = true
+					info.Account = acct
+				}
 			}
 		}
 		return info

--- a/pkg/analyzer/detect_gcp.go
+++ b/pkg/analyzer/detect_gcp.go
@@ -13,6 +13,14 @@ func detectGCP() *GCPInfo {
 	ok, out := runCmd("gcloud", "config", "get-value", "project")
 	projectID := CleanGCloudConfigValue(out)
 	if !ok || projectID == "" || strings.Contains(projectID, "(unset)") {
+		if ok {
+			// gcloud is available but no project is set — check if the user is authenticated.
+			_, acctOut := runCmd("gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)")
+			if acct := strings.TrimSpace(acctOut); acct != "" {
+				info.Authenticated = true
+				info.Account = acct
+			}
+		}
 		return info
 	}
 	info.Available = true

--- a/pkg/installer/otel/java.go
+++ b/pkg/installer/otel/java.go
@@ -258,7 +258,7 @@ func (p *JavaInstrumentationPlan) Execute() {
 		entrypoints := detectJavaEntrypoints(p.Project.Path)
 		if len(entrypoints) == 0 {
 			logger.Debug("no entrypoints found at execute time", "project", p.Project.Path)
-			display.PrintStatusLine("error", "no runnable entrypoint detected — build the project first", display.ColorError)
+			display.PrintStatusLine("error", noEntrypointMessage(p.Project.Path), display.ColorError)
 			return
 		}
 		ep = promptEntrypointSelection(entrypoints)
@@ -394,13 +394,13 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 			return nil
 		}
 		if err := attemptSingleModuleBuild(proj.Path); err != nil {
-			display.PrintStatusLine("error", "no runnable entrypoint detected — build the project first", display.ColorError)
+			display.PrintStatusLine("error", noEntrypointMessage(proj.Path), display.ColorError)
 			return err
 		}
 		entrypoints = detectJavaEntrypoints(proj.Path)
 		logger.Debug("detected java entrypoints after build", "count", len(entrypoints), "project", proj.Path)
 		if len(entrypoints) == 0 {
-			display.PrintStatusLine("error", "no runnable entrypoint detected — build the project first", display.ColorError)
+			display.PrintStatusLine("error", noEntrypointMessage(proj.Path), display.ColorError)
 			return fmt.Errorf("no runnable entrypoint detected")
 		}
 	}

--- a/pkg/installer/otel/java_process.go
+++ b/pkg/installer/otel/java_process.go
@@ -284,23 +284,32 @@ func detectJavaEntrypoints(projectPath string) []JavaEntrypoint {
 	return entrypoints
 }
 
+// buildCommandStr returns the human-readable build command for the project, or ""
+// if no supported build tool is detected.
+func buildCommandStr(projectPath string) string {
+	if mvnCmd, _ := resolveMavenCmd(projectPath); mvnCmd != "" {
+		return mvnCmd + " clean package -DskipTests"
+	}
+	if gradleCmd, _ := resolveGradleCmd(projectPath); gradleCmd != "" {
+		return gradleCmd + " build -x test"
+	}
+	return ""
+}
+
 func attemptSingleModuleBuild(projectPath string) error {
 	mvnCmd, _ := resolveMavenCmd(projectPath)
 	gradleCmd, _ := resolveGradleCmd(projectPath)
 
 	var cmd *exec.Cmd
-	var displayCmd string
 
 	switch {
 	case mvnCmd != "":
-		displayCmd = mvnCmd + " clean package -DskipTests"
 		if strings.HasSuffix(mvnCmd, ".cmd") {
 			cmd = exec.Command("cmd", "/c", mvnCmd, "clean", "package", "-DskipTests")
 		} else {
 			cmd = exec.Command(mvnCmd, "clean", "package", "-DskipTests")
 		}
 	case gradleCmd != "":
-		displayCmd = gradleCmd + " build -x test"
 		if strings.HasSuffix(gradleCmd, ".bat") {
 			cmd = exec.Command("cmd", "/c", gradleCmd, "build", "-x", "test")
 		} else {
@@ -311,7 +320,7 @@ func attemptSingleModuleBuild(projectPath string) error {
 		return fmt.Errorf("no build tool detected")
 	}
 
-	logger.Debug("attempting auto-build", "command", displayCmd, "project", projectPath)
+	logger.Debug("attempting auto-build", "command", buildCommandStr(projectPath), "project", projectPath)
 	cmd.Dir = projectPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -323,6 +332,21 @@ func attemptSingleModuleBuild(projectPath string) error {
 
 	logger.Debug("auto-build succeeded", "project", projectPath)
 	return nil
+}
+
+// noEntrypointMessage returns a targeted message explaining why no runnable JAR
+// was found: missing JDK (javac), project not compiled yet, or unknown.
+func noEntrypointMessage(projectPath string) string {
+	if _, err := exec.LookPath("javac"); err != nil {
+		return "no runnable entrypoint detected — Java compiler (javac) not found.\n" +
+			"  Install a JDK (not just JRE): Maven and Gradle cannot compile without it.\n" +
+			"  Download from https://adoptium.net or use your system package manager."
+	}
+	if cmd := buildCommandStr(projectPath); cmd != "" {
+		return "no runnable entrypoint detected — project not compiled yet.\n" +
+			"  Run:  " + cmd
+	}
+	return "no runnable entrypoint detected — build the project first"
 }
 
 // promptEntrypointSelection presents a selection menu for available entrypoints.

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -102,11 +102,13 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 		// interpreter is installed, so run it to verify it's usable.
 		var available bool
 		var stubOnly bool
+		var binPath string
 		if rt.binName == "python3" || rt.binName == "python" {
 			_, err := DetectPython()
 			available = err == nil
 			if !available {
-				_, lookErr := exec.LookPath(rt.binName)
+				var lookErr error
+				binPath, lookErr = exec.LookPath(rt.binName)
 				stubOnly = lookErr == nil // binary found but not usable
 			}
 		} else {
@@ -115,7 +117,11 @@ func detectAllProjects(runtimes []runtimeInfo) []detectedProject {
 		}
 		if !available {
 			if stubOnly {
-				fmt.Printf("  Skipping %s instrumentation — '%s' found on PATH but not usable.\n", rt.name, rt.binName)
+				if isWindowsStorePythonStub(binPath) {
+					fmt.Printf("  Skipping %s instrumentation — '%s' is a Windows Store stub, not a real interpreter.\n  Install Python 3 from https://python.org or disable it in Settings → Apps → Advanced app settings → App execution aliases.\n", rt.name, rt.binName)
+				} else {
+					fmt.Printf("  Skipping %s instrumentation — '%s' found on PATH but not usable.\n", rt.name, rt.binName)
+				}
 			} else {
 				fmt.Printf("  Skipping %s instrumentation — '%s' not found on PATH.\n", rt.name, rt.binName)
 			}

--- a/pkg/installer/otel/python_venv.go
+++ b/pkg/installer/otel/python_venv.go
@@ -37,6 +37,14 @@ func DetectPython() (string, error) {
 	return "", fmt.Errorf("Python 3 interpreter not found: install Python 3 and ensure either `python3` or `python` is in PATH") //nolint:staticcheck // ST1005: keep brand capitalization
 }
 
+// isWindowsStorePythonStub reports whether the given path is the Windows Store
+// Python stub (located under the WindowsApps directory). The stub exists on
+// PATH by default but only opens the Microsoft Store when invoked — it is not
+// a real interpreter.
+func isWindowsStorePythonStub(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "WindowsApps")
+}
+
 func validatePythonPrerequisites() (string, error) {
 	pythonBin, err := DetectPython()
 	if err != nil {

--- a/pkg/installer/otel/python_venv_test.go
+++ b/pkg/installer/otel/python_venv_test.go
@@ -296,6 +296,26 @@ func TestDetectProjectVenvDir_PrefersFirst(t *testing.T) {
 	}
 }
 
+func TestIsWindowsStorePythonStub(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Users\user\AppData\Local\Microsoft\WindowsApps\python3.exe`, true},
+		{`C:\Users\user\AppData\Local\Microsoft\WindowsApps\python.exe`, true},
+		{`C:\Python312\python.exe`, false},
+		{`C:\Program Files\Python312\python3.exe`, false},
+		{`/usr/bin/python3`, false},
+		{`/usr/local/bin/python3`, false},
+	}
+	for _, tc := range cases {
+		got := isWindowsStorePythonStub(tc.path)
+		if got != tc.want {
+			t.Errorf("isWindowsStorePythonStub(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
 func TestResolveVenvBinary_AlternativeVenvNames(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix-only bin/ layout test")

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -244,9 +244,9 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 			return true // dup via symlink: skip children but don't re-record
 		}
 
-		logger.Debug("project dir matched", "path", dir, "markers", strings.Join(matchedMarkers, ","))
+		logger.Debug("project dir matched", "path", resolvedDir, "markers", strings.Join(matchedMarkers, ","))
 		mu.Lock()
-		discoveredProjects = append(discoveredProjects, ScannedProject{Path: dir, Markers: matchedMarkers})
+		discoveredProjects = append(discoveredProjects, ScannedProject{Path: resolvedDir, Markers: matchedMarkers})
 		mu.Unlock()
 		return true
 	}

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -94,6 +94,9 @@ const (
 // walkCandidateDirs scans root + descendants in parallel and walks up to
 // parentLevels ancestors. visit receives each dir's entries (read once, reused
 // for matching and recursion); returning true means matched — skip children.
+// The scan root itself is exempted from the skip-children rule: it's the
+// user's cwd, not necessarily a project boundary, so a marker match there
+// (e.g. a stray lockfile) must not hide every nested project underneath it.
 func walkCandidateDirs(root string, parentLevels int, visit func(dir string, entries []os.DirEntry) bool, shouldSkip func(name string) bool) {
 	concurrency := max(runtime.NumCPU()*scanConcurrencyPerCPU, minScanConcurrency)
 	// When full, child scans run synchronously instead of spawning more goroutines.
@@ -103,17 +106,20 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 	var queued sync.Map
 	var wg sync.WaitGroup
 
-	var scanDir func(dir string, anyFound *atomic.Bool)
-	scanDir = func(dir string, anyFound *atomic.Bool) {
+	var scanDir func(dir string, anyFound *atomic.Bool, isRoot bool)
+	scanDir = func(dir string, anyFound *atomic.Bool, isRoot bool) {
 		defer wg.Done()
 
 		entries, _ := os.ReadDir(dir)
 
-		if visit(dir, entries) {
+		matched := visit(dir, entries)
+		if matched {
 			if anyFound != nil {
 				anyFound.Store(true)
 			}
-			return // matched: skip children
+			if !isRoot {
+				return // matched: skip children
+			}
 		}
 
 		for _, entry := range entries {
@@ -129,28 +135,28 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 				wg.Add(1)
 				go func(p string) {
 					defer func() { <-sem }()
-					scanDir(p, anyFound)
+					scanDir(p, anyFound, false)
 				}(childPath)
 			default:
 				// Pool saturated — run synchronously.
 				wg.Add(1)
-				scanDir(childPath, anyFound)
+				scanDir(childPath, anyFound, false)
 			}
 		}
 	}
 
-	scanTree := func(dir string) bool {
+	scanTree := func(dir string, isRoot bool) bool {
 		if _, loaded := queued.LoadOrStore(dir, struct{}{}); loaded {
 			return false
 		}
 		var found atomic.Bool
 		wg.Add(1)
-		scanDir(dir, &found)
+		scanDir(dir, &found, isRoot)
 		wg.Wait()
 		return found.Load()
 	}
 
-	scanTree(root)
+	scanTree(root, true)
 
 	currentDir := root
 	for range parentLevels {
@@ -159,7 +165,7 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 			break
 		}
 		logger.Debug("scanning ancestor dir", "path", parentDir)
-		if scanTree(parentDir) {
+		if scanTree(parentDir, false) {
 			break
 		}
 		currentDir = parentDir

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -389,6 +389,47 @@ func TestScanProjectDirs_SubtreePruning(t *testing.T) {
 	}
 }
 
+// TestScanProjectDirs_RootMatchStillDescends guards against a regression where
+// a marker file sitting directly in the scan root (e.g. a stray lockfile in
+// the user's cwd) short-circuited the walk and hid every nested project.
+func TestScanProjectDirs_RootMatchStillDescends(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module root\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	nested := filepath.Join(root, "nested-app")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "go.mod"), []byte("module nested\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	realRoot, _ := filepath.EvalSymlinks(root)
+	realNested, _ := filepath.EvalSymlinks(nested)
+
+	testutil.SetTestWorkingDir(t, root)
+	projects := scanProjectDirs([]string{"go.mod"}, nil)
+
+	foundRoot, foundNested := false, false
+	for _, p := range projects {
+		if p.Path == realRoot {
+			foundRoot = true
+		}
+		if p.Path == realNested {
+			foundNested = true
+		}
+	}
+	if !foundRoot {
+		t.Errorf("expected root dir itself to be reported as a match, got %v", projects)
+	}
+	if !foundNested {
+		t.Errorf("root match must not prevent descending into nested projects, got %v", projects)
+	}
+}
+
 func TestScanProjectDirs_ParentNotScanned(t *testing.T) {
 	grandparent := t.TempDir()
 

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -410,7 +410,7 @@ func TestScanProjectDirs_RootMatchStillDescends(t *testing.T) {
 	realRoot, _ := filepath.EvalSymlinks(root)
 	realNested, _ := filepath.EvalSymlinks(nested)
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	foundRoot, foundNested := false, false

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -162,7 +162,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 	}
 
 	// 8. Azure detected.
-	if system.Azure != nil && system.Azure.Available {
+	if system.AzureDetected() {
 		method := MethodAzure
 		title := "Azure cloud services"
 		if system.AzureConfigured {
@@ -178,7 +178,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 	}
 
 	// 9. GCP detected.
-	if system.GCP != nil && system.GCP.Available {
+	if system.GCPDetected() {
 		method := MethodGCP
 		title := "GCP cloud services"
 		if system.GCPConfigured {


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

Two notable bug fixes:
1. **Scan root no longer hides nested projects**
2. **GCP: smarter "none detected" message**

and some small improvements.

## How to test
1. If you have a `/Projects` folder where you have all your projects, create a package-lock.json there. Run `dtwiz install otel` from the folder and all projects should appear in the list.
2. Authenticate `gcloud` (`gcloud auth login`) but leave the project unset (`gcloud config unset project`). Run `dtwiz analyze` — the GCP line should say *"set a project with 'gcloud config set project PROJECT_ID'"*.
4. (Optional) On Windows with the default Store stub installed, run `dtwiz install otel` — the Python skip message should mention the Windows Store stub and link to python.org.

## Which other features are affected?
1. Project scanning (all OTel runtimes) — the root-exemption change affects how all markers are matched when running from a directory that also contains project indicators.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.