### PR TITLE
chore: integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,8 @@ on:
   workflow_dispatch:
 
 # Minimum test coverage percentage required to pass CI.
-# Target: gradually increase to 30 -> 40 -> 50.
 env:
-  COVERAGE_THRESHOLD: 30
+  COVERAGE_THRESHOLD: 50
 
 jobs:
   test:

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -32,8 +32,11 @@ Integration tests require a live Dynatrace environment and are opt-in:
 # Copy the template and fill in your credentials
 cp .e2e.env.example .e2e.env
 
-# Run integration tests
+# Run integration tests (parallel by default)
 make test-integration
+
+# Run integration tests sequentially
+make test-integration SEQUENTIAL=true
 ```
 
 ## Writing Unit Tests
@@ -101,7 +104,7 @@ Integration tests live in `test/e2e/` and carry the `//go:build integration` bui
 
 Set these in `.e2e.env` (gitignored). `make test-integration` loads the file automatically.
 
-**Test setup:** call `integration.SetupIntegration(t)` at the start of each test. It validates the environment variables, creates a shared `client.Client`, and returns a `TestEnv` with a unique `TestID` and a `t.TempDir()` for scratch files.
+**Test setup:** call `integration.Parallelize(t)` then `integration.SetupIntegration(t)` at the start of each test. `Parallelize` marks the test as parallel (respects `SEQUENTIAL=true`); `SetupIntegration` validates environment variables, creates a shared `client.Client`, and returns a `TestEnv` with a unique `TestID` and a `t.TempDir()` for scratch files.
 
 ```go
 //go:build integration
@@ -111,6 +114,7 @@ package e2e_test
 import "github.com/dynatrace-oss/dtwiz/test/integration"
 
 func TestMyInstaller(t *testing.T) {
+    integration.Parallelize(t)
     env := integration.SetupIntegration(t)
 
     svcName := env.TestID + "-my-svc"
@@ -122,6 +126,15 @@ func TestMyInstaller(t *testing.T) {
 **Fixtures:** sample applications for language-specific OTel tests live in `test/fixtures/`. Each fixture is a minimal runnable app. Use them as the target directory when testing `install otel-*` commands.
 
 **Assertions:** use `test/integration/grail` helpers to query Dynatrace via DQL and verify that telemetry actually arrived. Poll with a timeout rather than sleeping — the `grail.WaitFor*` helpers handle this.
+
+**Tests with extra infrastructure prerequisites:** some lifecycle tests need more than a Dynatrace tenant and skip (or fail with an actionable message) when their prerequisite isn't met:
+
+| Test | Extra prerequisite | Behavior when missing |
+|---|---|---|
+| `TestKubernetesLifecycle` | `kubectl` + `helm` on PATH, and a cluster reachable via the current kubeconfig context (point it at a disposable cluster, e.g. kind/minikube — the test does not provision one) | Skips |
+| `TestAzureLifecycle` | `az` CLI logged in (`az login`) to a subscription where the signed-in account can create App Registrations and role assignments at subscription scope | Skips if `az` isn't installed; fails with instructions if installed but not logged in |
+
+These tests create and tear down real cluster/cloud resources, so point them at disposable environments.
 
 ## Mocking Conventions
 

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ build:
 install:
 	$(GO) install .
 
-COVERAGE_THRESHOLD ?= 30
+COVERAGE_THRESHOLD ?= 50
 
 test:
 	$(GO) test ./pkg/... -coverprofile=coverage.out

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ endif
 TEST_DEBUG ?= $(DEBUG)
 export TEST_DEBUG
 
-test-integration: SHELL := /bin/bash
+test-integration: SHELL := bash
 test-integration:
 ifeq ($(strip $(TEST_DT_ENVIRONMENT)),)
 	$(error TEST_DT_ENVIRONMENT is not set)

--- a/makefile
+++ b/makefile
@@ -45,6 +45,24 @@ fmt:
 lint:
 	golangci-lint run ./...
 
+ifeq ($(OS),Windows_NT)
+RACE_FLAG :=
+else
+RACE_FLAG := -race
+endif
+
+# SEQUENTIAL=true runs integration tests one at a time (default: parallel).
+SEQUENTIAL ?= false
+ifeq ($(SEQUENTIAL),true)
+SEQ_ENV := TEST_SEQUENTIAL=1
+else
+SEQ_ENV :=
+endif
+
+TEST_DEBUG ?= $(DEBUG)
+export TEST_DEBUG
+
+test-integration: SHELL := /bin/bash
 test-integration:
 ifeq ($(strip $(TEST_DT_ENVIRONMENT)),)
 	$(error TEST_DT_ENVIRONMENT is not set)
@@ -52,11 +70,17 @@ endif
 ifeq ($(strip $(TEST_DT_PLATFORM_TOKEN)),)
 	$(error TEST_DT_PLATFORM_TOKEN is not set)
 endif
-ifeq ($(OS),Windows_NT)
-	$(GO) test -v -tags integration -timeout 15m $(if $(RUN),-run $(RUN),) ./test/e2e/...
-else
-	$(GO) test -v -race -tags integration -timeout 15m $(if $(RUN),-run $(RUN),) ./test/e2e/...
-endif
+	@set -o pipefail; \
+	LOG=$$(mktemp); \
+	trap 'rm -f "$$LOG"' EXIT; \
+	$(SEQ_ENV) $(GO) test -v -count=1 $(RACE_FLAG) -tags integration -timeout 30m $(if $(RUN),-run $(RUN),) ./test/e2e/... 2>&1 | tee "$$LOG"; \
+	status=$$?; \
+	echo ""; \
+	echo "=== Integration Test Summary ==="; \
+	grep -E "^--- (PASS|FAIL|SKIP):" "$$LOG" | sed 's/^--- //' | sort; \
+	echo ""; \
+	echo "$$(grep -c '^--- PASS:' "$$LOG") passed, $$(grep -c '^--- FAIL:' "$$LOG") failed, $$(grep -c '^--- SKIP:' "$$LOG") skipped"; \
+	exit $$status
 
 clean:
 	rm -f $(BINARY)

--- a/openspec/changes/integration-test-improvements/.openspec.yaml
+++ b/openspec/changes/integration-test-improvements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/integration-test-improvements/design.md
+++ b/openspec/changes/integration-test-improvements/design.md
@@ -61,7 +61,7 @@ Debugging a failing integration test often requires knowing what DQL queries ran
 
 ### `kubernetesClusterByNameQuery` and `WaitForKubernetesCluster`
 
-The existing `grail` helpers follow the pattern: a `*Query` function builds the DQL string, a `WaitFor*` function polls until records appear, and a `Require*` function wraps the poll and fatals if it fails. The Kubernetes helpers follow the same pattern. The DQL query fetches logs with `k8s.cluster.name` matching the cluster context name (lowercased to match what Dynatrace normalizes it to).
+The existing `grail` helpers follow the pattern: a `*Query` function builds the DQL string, a `WaitFor*` function polls until records appear, and a `Require*` function wraps the poll and fatals if it fails. The Kubernetes helpers follow the same pattern. The DQL query uses `smartscapeNodes "K8S_CLUSTER", from: -30m, to: now() | filter name == <clusterName>`, consistent with the SERVICE and HOST helpers. A `fetch logs` approach was considered but dropped for the same reasons `fetch spans` was dropped for traces — entity-level queries are more reliable than raw ingestion queries.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/integration-test-improvements/design.md
+++ b/openspec/changes/integration-test-improvements/design.md
@@ -1,0 +1,69 @@
+# Design: Integration Test Improvements
+
+## Context
+
+The integration tests live in `test/e2e/` and run against a live Dynatrace environment. Before this change, they ran sequentially, each test set and restored `installer.AutoConfirm` individually, and there were no lifecycle tests for the Kubernetes or Azure installers.
+
+## Goals / Non-Goals
+
+Goals:
+
+- Run integration tests in parallel by default to shorten the total run time.
+- Add lifecycle (install → verify → uninstall → verify) tests for Kubernetes and Azure.
+- Give developers a way to see DQL queries and Kubernetes state when a test fails.
+- Print a pass/fail/skip summary at the end of `make test-integration`.
+
+Non-Goals:
+
+- Provisioning test infrastructure (clusters, Azure subscriptions): tests skip if prerequisites are not available.
+- Adding lifecycle tests for other installers (OneAgent and OTel already have them).
+
+## Decisions
+
+### Set `AutoConfirm = true` once in `TestMain`
+
+Each test previously saved and restored `installer.AutoConfirm` around its own body. That pattern breaks under parallel execution: a test finishing early restores the flag to `false` while other tests are still running mid-install. Moving the assignment to `TestMain` sets it once for the entire binary and removes the race.
+
+### `Parallelize(t)` helper instead of calling `t.Parallel()` directly
+
+Tests opt in to parallelism by calling `integration.Parallelize(t)`. The helper calls `t.Parallel()` unless `TEST_SEQUENTIAL=1` is set, which lets developers run tests one at a time by passing `SEQUENTIAL=true` to make. This is simpler than trying to control parallelism from outside the test binary.
+
+`Parallelize` is called before `SetupIntegration` so that Go's parallel scheduling starts as early as possible (before the test body waits for the parallel semaphore to release).
+
+### Azure pre-flight checks before acquiring any resources
+
+`TestAzureLifecycle` checks `az account show` and `az ad signed-in-user show` before calling the installer. This catches two common failure modes (no active session, expired Graph token) before any Azure or Dynatrace resources are created. Without these checks, a test could create partial state (e.g. a Dynatrace connection) and then fail mid-install, leaving the cleanup to guess what was created.
+
+### `MonitoringConfigExists` exported from `azure/uninstall.go`
+
+The test needs to verify that a monitoring configuration exists after install and is gone after uninstall. `findAllMonitoringConfigs` is already used internally by the uninstaller; wrapping it in an exported function gives the test access to the same check without duplicating logic or changing the uninstall path.
+
+### Safety-net `t.Cleanup` on both lifecycle tests
+
+Both `TestKubernetesLifecycle` and `TestAzureLifecycle` register a cleanup that calls the uninstaller regardless of test outcome. Installers can create real resources (namespaces, App Registrations, Dynatrace connections) and may fail partway through. Without a safety-net cleanup, a partial failure leaves resources behind. The cleanup is skipped only when the explicit uninstall step in the test body already succeeded (tracked by the `uninstalled` flag in the Kubernetes test).
+
+### `TEST_DEBUG` for DQL and cluster diagnostics
+
+Debugging a failing integration test often requires knowing what DQL queries ran and what state the cluster was in at the time of failure. Setting `TEST_DEBUG=1` enables two things:
+- DQL queries are logged as they run (added to `grail/execute.go`).
+- On Kubernetes test failure, `kubectl get pods` and `kubectl get events` output is logged.
+
+`TEST_DEBUG` is passed through from make via `export TEST_DEBUG` so it is available to the test binary without extra steps.
+
+### Test summary in `make test-integration`
+
+`go test -v` output includes pass/fail lines but no totals. The updated make target captures output in a temp file, prints it in real time via `tee`, and then greps the file to print counts. The temp file is deleted via `trap` after the target exits, so it does not accumulate across runs.
+
+### Timeout raised
+
+`TestKubernetesLifecycle` alone can take up to 20 minutes: 10 min waiting for Operator pods to become ready, 5 min polling for cluster topology in Dynatrace, and 5 min waiting for pods to terminate on uninstall. The previous 15-minute timeout was already too short for this single test.
+
+### `kubernetesClusterByNameQuery` and `WaitForKubernetesCluster`
+
+The existing `grail` helpers follow the pattern: a `*Query` function builds the DQL string, a `WaitFor*` function polls until records appear, and a `Require*` function wraps the poll and fatals if it fails. The Kubernetes helpers follow the same pattern. The DQL query fetches logs with `k8s.cluster.name` matching the cluster context name (lowercased to match what Dynatrace normalizes it to).
+
+## Risks / Trade-offs
+
+- Parallel tests share a single Dynatrace tenant, so they all write to the same environment. There is no tenant-level isolation. For the installers under test (OneAgent, OTel Collector, Kubernetes Operator, Azure Monitor) this is acceptable because each installer manages distinct resources.
+- `TestKubernetesLifecycle` and `TestAzureLifecycle` create and destroy real cloud resources. Pointing them at a production environment would be destructive. The tests document this in their comments; skipping when prerequisites are absent helps, but cannot prevent misuse.
+- The Azure test uses `integrationName` (from the installer package) as the resource name. If that constant changes, the test continues to work because it calls the same installer functions. The monitoring-config existence check is also based on the same constant via `MonitoringConfigExists`.

--- a/openspec/changes/integration-test-improvements/design.md
+++ b/openspec/changes/integration-test-improvements/design.md
@@ -45,6 +45,7 @@ Both `TestKubernetesLifecycle` and `TestAzureLifecycle` register a cleanup that 
 ### `TEST_DEBUG` for DQL and cluster diagnostics
 
 Debugging a failing integration test often requires knowing what DQL queries ran and what state the cluster was in at the time of failure. Setting `TEST_DEBUG=1` enables two things:
+
 - DQL queries are logged as they run (added to `grail/execute.go`).
 - On Kubernetes test failure, `kubectl get pods` and `kubectl get events` output is logged.
 

--- a/openspec/changes/integration-test-improvements/proposal.md
+++ b/openspec/changes/integration-test-improvements/proposal.md
@@ -6,8 +6,8 @@ The integration test suite had several gaps that made it harder to use and trust
 
 - Tests ran sequentially, so the full suite took longer than necessary.
 - Setting `AutoConfirm = true` was done per-test, which was unsafe to do in parallel (a finishing test could reset the flag while other tests were still running).
-- The Kubernetes and Azure installers had no lifecycle tests; install and uninstall were never validated end-to-end against a real cluster or cloud account.
-- When `TestAzureLifecycle` wanted to verify that a monitoring configuration was removed after uninstall, there was no exported function to check for it.
+- The Kubernetes, Azure, and GCP installers had no lifecycle tests; install and uninstall were never validated end-to-end against a real cluster or cloud account.
+- When `TestAzureLifecycle` and `TestGCPLifecycle` wanted to verify that a monitoring configuration was removed after uninstall, there was no exported function to check for it.
 - The test output was hard to read: no summary of how many tests passed, failed, or were skipped.
 - When a test failed, there was no easy way to see the DQL queries that ran or the Kubernetes state at the time of failure.
 
@@ -19,6 +19,8 @@ The integration test suite had several gaps that made it harder to use and trust
 - A `TestKubernetesLifecycle` test installs and uninstalls the Dynatrace Operator against a real cluster and checks that topology data appeared in Dynatrace.
 - A `TestAzureLifecycle` test installs and uninstalls the Azure Monitor integration against a real Azure subscription and checks that the Dynatrace connection and monitoring configuration exist and are cleaned up.
 - `azure.MonitoringConfigExists()` is exported so the Azure lifecycle test can check post-uninstall state.
+- A `TestGCPLifecycle` test installs and uninstalls the Google Cloud integration against a real GCP project and checks that the Dynatrace connection and monitoring configuration exist and are cleaned up.
+- `gcp.MonitoringConfigExists()` is exported so the GCP lifecycle test can check post-uninstall state.
 - A DQL debug mode (`TEST_DEBUG=1`) logs DQL queries as they run and dumps Kubernetes pod/event state on test failure.
 - `make test-integration` prints a summary (passed/failed/skipped counts) after the run.
 - The timeout for `make test-integration` is raised from 15 to 30 minutes to accommodate the new lifecycle tests.
@@ -45,5 +47,7 @@ none
 - `test/integration/grail/kubernetes.go`: new file; `WaitForKubernetesCluster` and `RequireKubernetesCluster`
 - `test/integration/grail/execute.go`: adds `TEST_DEBUG` DQL logging
 - `pkg/installer/azure/uninstall.go`: exports `MonitoringConfigExists`
+- `test/e2e/gcp_test.go`: new file; `TestGCPLifecycle`
+- `pkg/installer/gcp/uninstall.go`: exports `MonitoringConfigExists`
 - `makefile`: parallel-safe test runner, `SEQUENTIAL` flag, test summary, 30 min timeout, `TEST_DEBUG` pass-through
 - `docs/contributing/testing.md`: updated to reflect parallel execution, `Parallelize` usage, and new infrastructure-dependent tests

--- a/openspec/changes/integration-test-improvements/proposal.md
+++ b/openspec/changes/integration-test-improvements/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: Integration Test Improvements
+
+## Why
+
+The integration test suite had several gaps that made it harder to use and trust:
+
+- Tests ran sequentially, so the full suite took longer than necessary.
+- Setting `AutoConfirm = true` was done per-test, which was unsafe to do in parallel (a finishing test could reset the flag while other tests were still running).
+- The Kubernetes and Azure installers had no lifecycle tests; install and uninstall were never validated end-to-end against a real cluster or cloud account.
+- When `TestAzureLifecycle` wanted to verify that a monitoring configuration was removed after uninstall, there was no exported function to check for it.
+- The test output was hard to read: no summary of how many tests passed, failed, or were skipped.
+- When a test failed, there was no easy way to see the DQL queries that ran or the Kubernetes state at the time of failure.
+
+## What Changes
+
+- Integration tests run in parallel by default; pass `SEQUENTIAL=true` to run them one at a time.
+- `AutoConfirm = true` is set once in `TestMain` for the whole binary instead of per-test.
+- A `Parallelize(t)` helper marks a test as parallel, and respects `SEQUENTIAL=true`.
+- A `TestKubernetesLifecycle` test installs and uninstalls the Dynatrace Operator against a real cluster and checks that topology data appeared in Dynatrace.
+- A `TestAzureLifecycle` test installs and uninstalls the Azure Monitor integration against a real Azure subscription and checks that the Dynatrace connection and monitoring configuration exist and are cleaned up.
+- `azure.MonitoringConfigExists()` is exported so the Azure lifecycle test can check post-uninstall state.
+- A DQL debug mode (`TEST_DEBUG=1`) logs DQL queries as they run and dumps Kubernetes pod/event state on test failure.
+- `make test-integration` prints a summary (passed/failed/skipped counts) after the run.
+- The timeout for `make test-integration` is raised from 15 to 30 minutes to accommodate the new lifecycle tests.
+
+## Capabilities
+
+### New Capabilities
+
+none
+
+### Modified Capabilities
+
+none
+
+## Impact
+
+- `test/e2e/main_test.go`: new file; sets `AutoConfirm = true` in `TestMain`
+- `test/e2e/kubernetes_test.go`: new file; `TestKubernetesLifecycle`
+- `test/e2e/azure_test.go`: new file; `TestAzureLifecycle`
+- `test/e2e/oneagent_test.go`: removes per-test `AutoConfirm` save/restore; adds `Parallelize` call
+- `test/e2e/otel_test.go`: removes per-test `AutoConfirm` save/restore; adds `Parallelize` call
+- `test/integration/setup.go`: adds `Parallelize(t)` helper
+- `test/integration/grail/helpers.go`: adds `kubernetesClusterByNameQuery`
+- `test/integration/grail/kubernetes.go`: new file; `WaitForKubernetesCluster` and `RequireKubernetesCluster`
+- `test/integration/grail/execute.go`: adds `TEST_DEBUG` DQL logging
+- `pkg/installer/azure/uninstall.go`: exports `MonitoringConfigExists`
+- `makefile`: parallel-safe test runner, `SEQUENTIAL` flag, test summary, 30 min timeout, `TEST_DEBUG` pass-through
+- `docs/contributing/testing.md`: updated to reflect parallel execution, `Parallelize` usage, and new infrastructure-dependent tests

--- a/openspec/changes/integration-test-improvements/specs/integration-test-improvements/spec.md
+++ b/openspec/changes/integration-test-improvements/specs/integration-test-improvements/spec.md
@@ -136,7 +136,40 @@ It SHALL skip if `az` is not found on PATH. It SHALL fatal with an actionable me
 
 ---
 
-### Requirement: `MonitoringConfigExists` reports whether the Azure monitoring configuration is present
+### Requirement: `TestGCPLifecycle` exercises the full Google Cloud installer lifecycle
+
+`TestGCPLifecycle` SHALL install the Google Cloud integration, verify the Dynatrace connection and monitoring configuration exist, then uninstall and verify both are gone.
+
+It SHALL skip if `gcloud` is not found on PATH. It SHALL fatal with an actionable message if no active GCP project is configured.
+
+#### Scenario: Skips when `gcloud` is not on PATH
+
+- **WHEN** `gcloud` is not found on PATH
+- **THEN** the test is skipped
+
+#### Scenario: Fatals when no active project is set
+
+- **WHEN** `gcloud config get-value project` returns an empty or unset value
+- **THEN** the test fatals with a message instructing the developer to run `gcloud auth login` and set a project
+
+#### Scenario: Full lifecycle succeeds
+
+- **WHEN** `gcloud` is installed and an active project is configured
+- **THEN** `InstallGCP` runs without error
+- **THEN** `gcp.ConnectionExists` returns true
+- **THEN** `gcp.MonitoringConfigExists` returns true
+- **THEN** `UninstallGCP` runs without error
+- **THEN** `gcp.ConnectionExists` returns false
+- **THEN** `gcp.MonitoringConfigExists` returns false
+
+#### Scenario: Safety-net cleanup runs on partial failure
+
+- **WHEN** the test fails after install but before explicit uninstall
+- **THEN** `t.Cleanup` calls `UninstallGCP` to remove any created resources
+
+---
+
+### Requirement: `azure.MonitoringConfigExists` reports whether the Azure monitoring configuration is present
 
 `azure.MonitoringConfigExists(envURL, platformToken string)` SHALL return `true` if a monitoring configuration named after the integration exists in the given Dynatrace environment, and `false` otherwise.
 
@@ -148,6 +181,22 @@ It SHALL skip if `az` is not found on PATH. It SHALL fatal with an actionable me
 #### Scenario: Returns false when configuration does not exist
 
 - **WHEN** no Azure monitoring configuration exists
+- **THEN** `MonitoringConfigExists` returns `(false, nil)`
+
+---
+
+### Requirement: `gcp.MonitoringConfigExists` reports whether the GCP monitoring configuration is present
+
+`gcp.MonitoringConfigExists(envURL, platformToken string)` SHALL return `true` if a monitoring configuration named after the integration exists in the given Dynatrace environment, and `false` otherwise.
+
+#### Scenario: Returns true when configuration exists
+
+- **WHEN** the GCP monitoring configuration has been created
+- **THEN** `MonitoringConfigExists` returns `(true, nil)`
+
+#### Scenario: Returns false when configuration does not exist
+
+- **WHEN** no GCP monitoring configuration exists
 - **THEN** `MonitoringConfigExists` returns `(false, nil)`
 
 ---

--- a/openspec/changes/integration-test-improvements/specs/integration-test-improvements/spec.md
+++ b/openspec/changes/integration-test-improvements/specs/integration-test-improvements/spec.md
@@ -1,0 +1,173 @@
+# Spec: Integration Test Improvements
+
+## ADDED Requirements
+
+### Requirement: Parallel test execution by default
+
+`make test-integration` SHALL run tests in parallel by default.
+
+When `SEQUENTIAL=true` is passed to make, it SHALL set `TEST_SEQUENTIAL=1` in the test binary environment, causing tests to run one at a time.
+
+#### Scenario: Default run is parallel
+
+- **WHEN** `make test-integration` is run without `SEQUENTIAL=true`
+- **THEN** `TEST_SEQUENTIAL` is not set in the test binary environment
+- **THEN** tests that call `Parallelize(t)` run concurrently
+
+#### Scenario: Sequential run when opted in
+
+- **WHEN** `make test-integration SEQUENTIAL=true` is run
+- **THEN** `TEST_SEQUENTIAL=1` is set in the test binary environment
+- **THEN** `Parallelize(t)` does not call `t.Parallel()`, so tests run one at a time
+
+---
+
+### Requirement: `Parallelize` helper respects `TEST_SEQUENTIAL`
+
+`integration.Parallelize(t)` SHALL call `t.Parallel()` unless the environment variable `TEST_SEQUENTIAL` is set to a non-empty value.
+
+#### Scenario: Marks test parallel when `TEST_SEQUENTIAL` is unset
+
+- **WHEN** `Parallelize(t)` is called and `TEST_SEQUENTIAL` is not set
+- **THEN** `t.Parallel()` is called
+
+#### Scenario: Does not mark test parallel when `TEST_SEQUENTIAL=1`
+
+- **WHEN** `Parallelize(t)` is called and `TEST_SEQUENTIAL=1` is set
+- **THEN** `t.Parallel()` is NOT called
+
+---
+
+### Requirement: `AutoConfirm` set once for the whole test binary
+
+`installer.AutoConfirm` SHALL be set to `true` in `TestMain` for the entire e2e test binary. Individual tests SHALL NOT save and restore this value.
+
+#### Scenario: AutoConfirm is true throughout a parallel run
+
+- **WHEN** multiple e2e tests run in parallel
+- **THEN** `installer.AutoConfirm` remains `true` for the duration of the run
+- **THEN** no test can accidentally reset it to `false` while other tests are running
+
+---
+
+### Requirement: Test summary printed after run
+
+After `make test-integration` finishes, it SHALL print a one-line summary with the count of passed, failed, and skipped tests.
+
+#### Scenario: Summary line appears after test output
+
+- **WHEN** `make test-integration` completes
+- **THEN** the last lines of output include a summary in the form `N passed, N failed, N skipped`
+
+---
+
+### Requirement: `TestKubernetesLifecycle` exercises the full Kubernetes installer lifecycle
+
+`TestKubernetesLifecycle` SHALL install the Dynatrace Operator, verify the cluster appears in Dynatrace, then uninstall and verify the namespace is gone.
+
+It SHALL skip if `kubectl` or `helm` are not found on PATH, or if no cluster is reachable via the current kubeconfig context.
+
+#### Scenario: Skips when `kubectl` is not on PATH
+
+- **WHEN** `kubectl` is not found on PATH
+- **THEN** the test is skipped
+
+#### Scenario: Skips when `helm` is not on PATH
+
+- **WHEN** `helm` is not found on PATH
+- **THEN** the test is skipped
+
+#### Scenario: Skips when no cluster is reachable
+
+- **WHEN** `kubectl cluster-info` fails
+- **THEN** the test is skipped
+
+#### Scenario: Full lifecycle succeeds
+
+- **WHEN** `kubectl`, `helm`, and a reachable cluster are available
+- **THEN** `InstallKubernetes` runs without error
+- **THEN** exactly 2 DynaKube custom resources exist in the `dynatrace` namespace
+- **THEN** the cluster name appears in Dynatrace topology within 5 minutes
+- **THEN** `UninstallKubernetes` runs without error
+- **THEN** the `dynatrace` namespace no longer exists
+
+#### Scenario: Safety-net cleanup runs on partial failure
+
+- **WHEN** the test fails after install but before explicit uninstall
+- **THEN** `t.Cleanup` calls `UninstallKubernetes` to remove any created resources
+
+---
+
+### Requirement: `TestAzureLifecycle` exercises the full Azure Monitor installer lifecycle
+
+`TestAzureLifecycle` SHALL install the Azure Monitor integration, verify the Dynatrace connection and monitoring configuration exist, then uninstall and verify both are gone.
+
+It SHALL skip if `az` is not found on PATH. It SHALL fatal with an actionable message if the `az` session is not active or the Graph token is expired.
+
+#### Scenario: Skips when `az` is not on PATH
+
+- **WHEN** `az` is not found on PATH
+- **THEN** the test is skipped
+
+#### Scenario: Fatals when not logged in to Azure
+
+- **WHEN** `az account show` exits with a non-zero code
+- **THEN** the test fatals with a message instructing the developer to run `az login`
+
+#### Scenario: Fatals when Graph token is expired
+
+- **WHEN** `az ad signed-in-user show` exits with a non-zero code
+- **THEN** the test fatals with a message explaining the Graph session is stale and instructing the developer to run `az login` again
+
+#### Scenario: Full lifecycle succeeds
+
+- **WHEN** `az` is installed, the session is active, and Graph token is valid
+- **THEN** `InstallAzure` runs without error
+- **THEN** `azure.ConnectionExists` returns true
+- **THEN** `azure.MonitoringConfigExists` returns true
+- **THEN** `UninstallAzure` runs without error
+- **THEN** `azure.ConnectionExists` returns false
+- **THEN** `azure.MonitoringConfigExists` returns false
+
+#### Scenario: Safety-net cleanup runs on partial failure
+
+- **WHEN** the test fails after install but before explicit uninstall
+- **THEN** `t.Cleanup` calls `UninstallAzure` to remove any created resources
+
+---
+
+### Requirement: `MonitoringConfigExists` reports whether the Azure monitoring configuration is present
+
+`azure.MonitoringConfigExists(envURL, platformToken string)` SHALL return `true` if a monitoring configuration named after the integration exists in the given Dynatrace environment, and `false` otherwise.
+
+#### Scenario: Returns true when configuration exists
+
+- **WHEN** the Azure monitoring configuration has been created
+- **THEN** `MonitoringConfigExists` returns `(true, nil)`
+
+#### Scenario: Returns false when configuration does not exist
+
+- **WHEN** no Azure monitoring configuration exists
+- **THEN** `MonitoringConfigExists` returns `(false, nil)`
+
+---
+
+### Requirement: `TEST_DEBUG` mode logs DQL queries and Kubernetes diagnostics
+
+When `TEST_DEBUG` is set to a non-empty value, the test binary SHALL log each DQL query string before it is sent. On a Kubernetes test failure, it SHALL also log the output of `kubectl get pods` and `kubectl get events` in the `dynatrace` namespace.
+
+#### Scenario: DQL query logged when `TEST_DEBUG` is set
+
+- **WHEN** `TEST_DEBUG=1` is set and a DQL query is executed
+- **THEN** the query string is logged via `log.Printf`
+
+#### Scenario: No DQL logging when `TEST_DEBUG` is unset
+
+- **WHEN** `TEST_DEBUG` is not set and a DQL query is executed
+- **THEN** the query string is NOT logged
+
+#### Scenario: Kubernetes diagnostics logged on test failure
+
+- **WHEN** `TEST_DEBUG=1` is set and `TestKubernetesLifecycle` fails
+- **THEN** `kubectl get pods -n dynatrace -o wide` output is logged
+- **THEN** `kubectl get events -n dynatrace` warning events are logged

--- a/openspec/changes/integration-test-improvements/tasks.md
+++ b/openspec/changes/integration-test-improvements/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Integration Test Improvements
+
+## 1. Parallel execution infrastructure
+
+- [x] 1.1 Add `Parallelize(t)` to `test/integration/setup.go`: calls `t.Parallel()` unless `TEST_SEQUENTIAL=1`
+- [x] 1.2 Create `test/e2e/main_test.go`: set `installer.AutoConfirm = true` in `TestMain` for the whole binary
+
+## 2. Update existing tests
+
+- [x] 2.1 `test/e2e/oneagent_test.go`: remove per-test `AutoConfirm` save/restore; add `integration.Parallelize(t)` call
+- [x] 2.2 `test/e2e/otel_test.go`: remove per-test `AutoConfirm` save/restore; add `integration.Parallelize(t)` call
+
+## 3. Kubernetes lifecycle test
+
+- [x] 3.1 Add `kubernetesClusterByNameQuery` to `test/integration/grail/helpers.go`
+- [x] 3.2 Create `test/integration/grail/kubernetes.go` with `WaitForKubernetesCluster` and `RequireKubernetesCluster`
+- [x] 3.3 Create `test/e2e/kubernetes_test.go` with `TestKubernetesLifecycle`: skips if `kubectl` or `helm` are not on PATH or no cluster is reachable; installs, verifies two DynaKube CRs and cluster topology in Dynatrace, then uninstalls and verifies namespace is gone
+
+## 4. Azure lifecycle test
+
+- [x] 4.1 Export `MonitoringConfigExists(envURL, platformToken string)` from `pkg/installer/azure/uninstall.go`
+- [x] 4.2 Create `test/e2e/azure_test.go` with `TestAzureLifecycle`: skips if `az` CLI is not on PATH; fatals with instructions if not logged in or Graph token is stale; installs, verifies connection and monitoring config exist, then uninstalls and verifies both are gone
+
+## 5. Debug mode
+
+- [x] 5.1 Add `TEST_DEBUG` check to `test/integration/grail/execute.go`: log DQL query string when `TEST_DEBUG != ""`
+- [x] 5.2 In `TestKubernetesLifecycle`, add `t.Cleanup` that logs `kubectl get pods` and `kubectl get events` on failure when `TEST_DEBUG` is set
+
+## 6. Make target
+
+- [x] 6.1 Update `make test-integration` to capture output, print it in real time, and print a pass/fail/skip summary after the run
+- [x] 6.2 Add `SEQUENTIAL` flag: when `SEQUENTIAL=true`, set `TEST_SEQUENTIAL=1` in the test environment
+- [x] 6.3 Raise timeout from 15 to 30 minutes
+- [x] 6.4 Export `TEST_DEBUG` from make so the test binary sees it
+- [x] 6.5 Add `RACE_FLAG` conditional: skip `-race` on Windows (race detector requires cgo)
+
+## 7. Documentation
+
+- [x] 7.1 Update `docs/contributing/testing.md`: document `Parallelize`, `SEQUENTIAL=true`, `TEST_DEBUG`, and the per-test infrastructure prerequisites table

--- a/openspec/changes/integration-test-improvements/tasks.md
+++ b/openspec/changes/integration-test-improvements/tasks.md
@@ -34,6 +34,11 @@
 - [x] 6.4 Export `TEST_DEBUG` from make so the test binary sees it
 - [x] 6.5 Add `RACE_FLAG` conditional: skip `-race` on Windows (race detector requires cgo)
 
+## 8. GCP lifecycle test
+
+- [x] 8.1 Export `MonitoringConfigExists(envURL, platformToken string)` from `pkg/installer/gcp/uninstall.go`
+- [x] 8.2 Create `test/e2e/gcp_test.go` with `TestGCPLifecycle`: skips if `gcloud` is not on PATH; fatals with instructions if no active project is set; installs, verifies connection and monitoring config exist, then uninstalls and verifies both are gone
+
 ## 7. Documentation
 
 - [x] 7.1 Update `docs/contributing/testing.md`: document `Parallelize`, `SEQUENTIAL=true`, `TEST_DEBUG`, and the per-test infrastructure prerequisites table

--- a/pkg/display/print_test.go
+++ b/pkg/display/print_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestHeader_PrintsIndentedTitle(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		Header("Connection Status")
 	})
 	if !strings.Contains(got, "  Connection Status\n") {
@@ -21,7 +21,7 @@ func TestHeader_PrintsIndentedTitle(t *testing.T) {
 }
 
 func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintSectionDivider()
 	})
 	if !strings.HasPrefix(got, "  ") {
@@ -36,7 +36,7 @@ func TestPrintSectionDivider_PrintsIndentedSeparator(t *testing.T) {
 }
 
 func TestPrintStatusLine_FormatsLabelAndMessage(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintStatusLine("Environment", "✓ https://abc.live.com", ColorOK)
 	})
 	want := "  Environment:  ✓ https://abc.live.com\n"
@@ -46,7 +46,7 @@ func TestPrintStatusLine_FormatsLabelAndMessage(t *testing.T) {
 }
 
 func TestPrintStatusLine_ErrorMessage(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintStatusLine("Access Token", "✗ not set (use --access-token)", ColorError)
 	})
 	want := "  Access Token:  ✗ not set (use --access-token)\n"
@@ -56,7 +56,7 @@ func TestPrintStatusLine_ErrorMessage(t *testing.T) {
 }
 
 func TestPrintStatusLine_EmptyMessage(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintStatusLine("Label", "", ColorOK)
 	})
 	want := "  Label:  \n"
@@ -66,7 +66,7 @@ func TestPrintStatusLine_EmptyMessage(t *testing.T) {
 }
 
 func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintFlagLine("DTWIZ_ALL_RUNTIMES", "✓ enabled (env)", ColorOK)
 	})
 	want := "  DTWIZ_ALL_RUNTIMES  ✓ enabled (env)\n"
@@ -76,7 +76,7 @@ func TestPrintFlagLine_NoColonAfterLabel(t *testing.T) {
 }
 
 func TestPrintError_FormatsLabelAndError(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintError("Setup", errors.New("connection refused"))
 	})
 	want := "  Setup: ✗ connection refused\n"
@@ -86,7 +86,7 @@ func TestPrintError_FormatsLabelAndError(t *testing.T) {
 }
 
 func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
-	got := testutil.CaptureErrorOutput(t, func() {
+	got := helpers.CaptureErrorOutput(t, func() {
 		PrintWarning("EKS Bottlerocket probe", errors.New("exit status 1"))
 	})
 	want := "  EKS Bottlerocket probe: ⚠ exit status 1\n"
@@ -97,8 +97,8 @@ func TestPrintWarning_FormatsLabelAndError(t *testing.T) {
 
 func TestPrintWarning_DiffersFromPrintError(t *testing.T) {
 	err := errors.New("kubectl timeout")
-	warning := testutil.CaptureErrorOutput(t, func() { PrintWarning("probe", err) })
-	errOut := testutil.CaptureOutput(t, func() { PrintError("probe", err) })
+	warning := helpers.CaptureErrorOutput(t, func() { PrintWarning("probe", err) })
+	errOut := helpers.CaptureOutput(t, func() { PrintError("probe", err) })
 	if warning == errOut {
 		t.Error("PrintWarning() and PrintError() should produce different output (⚠ vs ✗)")
 	}
@@ -137,7 +137,7 @@ func TestHyperlink_NonTTYEnvironment_NoEscapeCodes(t *testing.T) {
 
 func TestPrintInfoBox_RendersContentRow(t *testing.T) {
 	const boxWidth = 97
-	got := testutil.CaptureStdout(t, func() {
+	got := helpers.CaptureStdout(t, func() {
 		PrintInfoBox("hello world")
 	})
 	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
@@ -158,7 +158,7 @@ func TestPrintInfoBox_RendersContentRow(t *testing.T) {
 }
 
 func TestPrintInfoBox_BlankLineRendersEmptyRow(t *testing.T) {
-	got := testutil.CaptureStdout(t, func() {
+	got := helpers.CaptureStdout(t, func() {
 		PrintInfoBox("line one", "", "line two")
 	})
 	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
@@ -176,7 +176,7 @@ func TestPrintInfoBox_BlankLineRendersEmptyRow(t *testing.T) {
 }
 
 func TestPrintAlignedStatusLine_PadsLabelToWidth(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintAlignedStatusLine("API URL", "https://foo.com", 13, ColorDefault)
 	})
 	want := "  API URL:       https://foo.com\n"
@@ -186,7 +186,7 @@ func TestPrintAlignedStatusLine_PadsLabelToWidth(t *testing.T) {
 }
 
 func TestPrintln_IndentsAndFormats(t *testing.T) {
-	got := testutil.CaptureStdout(t, func() {
+	got := helpers.CaptureStdout(t, func() {
 		Println("hello %s", "world")
 	})
 	want := "  hello world\n"
@@ -196,7 +196,7 @@ func TestPrintln_IndentsAndFormats(t *testing.T) {
 }
 
 func TestPrintlnColored_IndentsMessage(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintlnColored(ColorDefault, "Dynatrace Kubernetes Integration")
 	})
 	want := "  Dynatrace Kubernetes Integration\n"
@@ -206,7 +206,7 @@ func TestPrintlnColored_IndentsMessage(t *testing.T) {
 }
 
 func TestPrintSteps_NumbersAndIndents(t *testing.T) {
-	got := testutil.CaptureStdout(t, func() {
+	got := helpers.CaptureStdout(t, func() {
 		PrintSteps("", "Ensure Helm is installed", "kubectl apply -f dynakube.yaml")
 	})
 	want := "  Steps:\n    1. Ensure Helm is installed\n    2. kubectl apply -f dynakube.yaml\n"
@@ -216,7 +216,7 @@ func TestPrintSteps_NumbersAndIndents(t *testing.T) {
 }
 
 func TestPrintStepsColored_NumbersAndIndents(t *testing.T) {
-	got := testutil.CaptureOutput(t, func() {
+	got := helpers.CaptureOutput(t, func() {
 		PrintStepsColored(ColorDefault, "", "step one", "step two")
 	})
 	want := "  Steps:\n    1. step one\n    2. step two\n"
@@ -227,8 +227,8 @@ func TestPrintStepsColored_NumbersAndIndents(t *testing.T) {
 
 func TestPrintFlagLine_DiffersFromPrintStatusLine(t *testing.T) {
 	label, message := "DTWIZ_ALL_RUNTIMES", "✓ enabled (cli)"
-	flagLine := testutil.CaptureOutput(t, func() { PrintFlagLine(label, message, ColorOK) })
-	statusLine := testutil.CaptureOutput(t, func() { PrintStatusLine(label, message, ColorOK) })
+	flagLine := helpers.CaptureOutput(t, func() { PrintFlagLine(label, message, ColorOK) })
+	statusLine := helpers.CaptureOutput(t, func() { PrintStatusLine(label, message, ColorOK) })
 	if flagLine == statusLine {
 		t.Error("PrintFlagLine() and PrintStatusLine() should produce different output (colon vs no colon)")
 	}

--- a/pkg/installer/azure/uninstall.go
+++ b/pkg/installer/azure/uninstall.go
@@ -23,6 +23,16 @@ func connectionExistsWithClient(dtc dtclient) (bool, error) {
 	return len(conns) > 0, err
 }
 
+// MonitoringConfigExists reports whether an Azure monitoring configuration named integrationName exists.
+func MonitoringConfigExists(envURL, platformToken string) (bool, error) {
+	dtc, err := newSDKDTClient(envURL, platformToken)
+	if err != nil {
+		return false, err
+	}
+	ids, err := dtc.findAllMonitoringConfigs(integrationName)
+	return len(ids) > 0, err
+}
+
 // azureGatherClientIDs collects client IDs to delete. Connection-bound IDs are trusted directly;
 // display-name matches are verified via federated credential (Entra names aren't unique).
 func azureGatherClientIDs(runner cmdRunner, conns []connRef, name, envURL string) []string {

--- a/pkg/installer/gcp/uninstall.go
+++ b/pkg/installer/gcp/uninstall.go
@@ -51,6 +51,16 @@ func gcpGatherServiceAccounts(conns []connRef, projectID string) []string {
 	return out
 }
 
+// MonitoringConfigExists reports whether a GCP monitoring configuration named integrationName exists.
+func MonitoringConfigExists(envURL, platformToken string) (bool, error) {
+	dtc, err := newSDKDTClient(envURL, platformToken)
+	if err != nil {
+		return false, err
+	}
+	ids, err := dtc.findAllMonitoringConfigs(integrationName)
+	return len(ids) > 0, err
+}
+
 func UninstallGCP(envURL, platformToken string, dryRun bool) error {
 	dtc, err := newSDKDTClient(envURL, platformToken)
 	if err != nil {

--- a/pkg/installer/kubernetes/helm_install_test.go
+++ b/pkg/installer/kubernetes/helm_install_test.go
@@ -176,3 +176,93 @@ func TestInstallHelmWindows_WingetSucceeds(t *testing.T) {
 		t.Errorf("expected no error when winget succeeds, got: %v", err)
 	}
 }
+
+// createFakeHelm writes a fake helm binary to a temp dir and returns that dir.
+// "helm version" echoes versionOutput; "helm list" echoes listOutput.
+func createFakeHelm(t *testing.T, versionOutput, listOutput string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(dir, "helm.bat")
+		content := "@echo off\r\n" +
+			"if \"%1\" == \"version\" echo " + versionOutput + "\r\n" +
+			"if \"%1\" == \"list\" echo " + listOutput + "\r\n"
+		if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+			t.Fatalf("createFakeHelm: %v", err)
+		}
+	} else {
+		script := filepath.Join(dir, "helm")
+		content := "#!/bin/sh\n" +
+			"case \"$1\" in\n" +
+			"  version) echo '" + versionOutput + "' ;;\n" +
+			"  list) echo '" + listOutput + "' ;;\n" +
+			"esac\n"
+		if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+			t.Fatalf("createFakeHelm: %v", err)
+		}
+	}
+	return dir
+}
+
+func TestIsHelmInstalled_Found(t *testing.T) {
+	dir := createFakeHelm(t, "v3.14.0", "")
+	t.Setenv("PATH", dir)
+	if !isHelmInstalled() {
+		t.Error("expected isHelmInstalled=true when helm is on PATH")
+	}
+}
+
+func TestIsHelmInstalled_NotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if isHelmInstalled() {
+		t.Error("expected isHelmInstalled=false when helm is not on PATH")
+	}
+}
+
+func TestHelmMajorVersion_V3(t *testing.T) {
+	dir := createFakeHelm(t, "v3.14.0+git", "")
+	t.Setenv("PATH", dir)
+	v, err := helmMajorVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 3 {
+		t.Errorf("expected major version 3, got %d", v)
+	}
+}
+
+func TestHelmMajorVersion_V4(t *testing.T) {
+	dir := createFakeHelm(t, "v4.0.0+git", "")
+	t.Setenv("PATH", dir)
+	v, err := helmMajorVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 4 {
+		t.Errorf("expected major version 4, got %d", v)
+	}
+}
+
+func TestHelmMajorVersion_NotInstalled(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := helmMajorVersion()
+	if err == nil {
+		t.Error("expected error when helm is not installed")
+	}
+}
+
+func TestIsOperatorInstalled_Installed(t *testing.T) {
+	dir := createFakeHelm(t, "v3.14.0", "dynatrace-operator")
+	t.Setenv("PATH", dir)
+	if !isOperatorInstalled() {
+		t.Error("expected isOperatorInstalled=true when operator is listed")
+	}
+}
+
+func TestIsOperatorInstalled_NotInstalled(t *testing.T) {
+	dir := createFakeHelm(t, "v3.14.0", "")
+	t.Setenv("PATH", dir)
+	if isOperatorInstalled() {
+		t.Error("expected isOperatorInstalled=false when operator is not listed")
+	}
+}

--- a/pkg/installer/kubernetes/install_test.go
+++ b/pkg/installer/kubernetes/install_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func baseTemplateData() dynakubeTemplateData {
@@ -274,6 +275,126 @@ func TestRenderDynakubeTemplate_AgentsDynaKubeStructure(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("DynaKube #2: expected %q in manifest", want)
+		}
+	}
+}
+
+func TestSanitizeK8sName(t *testing.T) {
+	cases := []struct{ input, want string }{
+		// Basic lowercasing
+		{"MyCluster", "mycluster"},
+		// Special chars replaced with hyphens
+		{"my_cluster.name", "my-cluster-name"},
+		// Leading/trailing hyphens trimmed
+		{"--my-cluster--", "my-cluster"},
+		// Empty input → fallback
+		{"", "dynakube"},
+		// All special chars → fallback
+		{"___", "dynakube"},
+		// 24 chars, truncated to 23 — no trailing hyphen
+		{"this-is-a-very-long-clux", "this-is-a-very-long-clu"},
+		// 24 chars, truncated to 23 — trailing hyphen trimmed
+		{"this-is-a-very-long-cl-x", "this-is-a-very-long-cl"},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			got := sanitizeK8sName(c.input)
+			if got != c.want {
+				t.Errorf("sanitizeK8sName(%q) = %q, want %q", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBuildDynakubeManifest(t *testing.T) {
+	const apiURL = "https://abc123.live.dynatracelabs.com"
+	const token = "dt0c01.test-token"
+	const clusterName = "test-cluster"
+
+	manifest, err := buildDynakubeManifest(apiURL, token, clusterName, "")
+	if err != nil {
+		t.Fatalf("buildDynakubeManifest: %v", err)
+	}
+	if manifest == "" {
+		t.Fatal("expected non-empty manifest")
+	}
+	if !strings.Contains(manifest, apiURL+"/api") {
+		t.Errorf("manifest does not contain API URL %q", apiURL+"/api")
+	}
+	if !strings.Contains(manifest, "name: "+clusterName) {
+		t.Errorf("manifest does not contain cluster name %q", clusterName)
+	}
+	if !strings.Contains(manifest, token) {
+		t.Error("manifest does not contain the token")
+	}
+}
+
+func TestResolveClusterName_ExplicitName(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"MyCluster", "mycluster"},
+		{"my_cluster", "my-cluster"},
+		{"this-is-a-very-long-cluster-name-wow", "this-is-a-very-long-clu"},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			got := resolveClusterName(c.input, "https://abc123.live.dynatracelabs.com")
+			if got != c.want {
+				t.Errorf("resolveClusterName(%q, ...) = %q, want %q", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveClusterName_FallsBackToNonEmpty(t *testing.T) {
+	// With no explicit name the function calls fetchClusterName, which always
+	// returns at least "dynakube". Verify the result is never empty.
+	got := resolveClusterName("", "https://abc123.live.dynatracelabs.com")
+	if got == "" {
+		t.Error("resolveClusterName with no explicit name returned empty string")
+	}
+}
+
+func TestHandleK8sDryRun(t *testing.T) {
+	// fmt.Println and display.PrintSteps go to os.Stdout (captured by CaptureStdout).
+	// display.PrintAlignedStatusLines goes to color.Output (not captured here).
+	out := helpers.CaptureStdout(t, func() {
+		handleK8sDryRun(
+			"https://abc123.live.dynatracelabs.com/api",
+			"my-cluster",
+			"EKS",
+			"install dynatrace-operator ...",
+		)
+	})
+	for _, want := range []string{
+		"[dry-run]",
+		"Ensure Helm is installed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("handleK8sDryRun: expected %q in output, got: %q", want, out)
+		}
+	}
+}
+
+func TestPrintK8sPreview(t *testing.T) {
+	// display.PrintlnColored, PrintAlignedStatusLines, and PrintStepsColored all
+	// write to color.Output — use CaptureOutput to capture them.
+	manifest := "kind: Secret\nmetadata:\n  name: test\n"
+	out := helpers.CaptureOutput(t, func() {
+		printK8sPreview(
+			"my-cluster",
+			"EKS",
+			"https://abc123.live.dynatracelabs.com/api",
+			manifest,
+			"helm install dynatrace-operator ...",
+		)
+	})
+	for _, want := range []string{
+		"my-cluster",
+		"EKS",
+		"helm install",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printK8sPreview: expected %q in output, got: %q", want, out)
 		}
 	}
 }

--- a/pkg/installer/kubernetes/uninstall_test.go
+++ b/pkg/installer/kubernetes/uninstall_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func withStdin(t *testing.T, input string, fn func()) {
@@ -36,7 +36,7 @@ func withFakeRunCmdQuiet(t *testing.T, fn func(name string, args ...string) erro
 
 func TestUninstallKubernetes_Cancelled(t *testing.T) {
 	withStdin(t, "n\n", func() {
-		out := testutil.CaptureStdout(t, func() {
+		out := helpers.CaptureStdout(t, func() {
 			err := UninstallKubernetes("my-ctx", analyzer.DistroAKS, false)
 			if err != nil {
 				t.Fatalf("expected nil on cancel, got: %v", err)
@@ -55,7 +55,7 @@ func TestUninstallKubernetes_ShowsClusterInfo(t *testing.T) {
 
 	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		_ = UninstallKubernetes("FreeTrialKubernetesTest", analyzer.DistroAKS, false)
 	})
 	if !strings.Contains(out, "The affected cluster is: AKS context=FreeTrialKubernetesTest") {
@@ -70,7 +70,7 @@ func TestUninstallKubernetes_NoClusterInfoWhenContextEmpty(t *testing.T) {
 
 	withFakeRunCmdQuiet(t, func(_ string, _ ...string) error { return nil })
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		_ = UninstallKubernetes("", "", false)
 	})
 	if strings.Contains(out, "The affected cluster is") {
@@ -89,7 +89,7 @@ func TestUninstallKubernetes_Success(t *testing.T) {
 		return nil
 	})
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		if err := UninstallKubernetes("my-ctx", analyzer.DistroGKE, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,7 +117,7 @@ func TestUninstallKubernetes_EdgeConnectDeletedEvenWhenDynaKubeFails(t *testing.
 		return nil
 	})
 
-	testutil.CaptureStdout(t, func() { _ = UninstallKubernetes("my-ctx", analyzer.DistroEKS, false) })
+	helpers.CaptureStdout(t, func() { _ = UninstallKubernetes("my-ctx", analyzer.DistroEKS, false) })
 
 	ranEdgeConnect := false
 	for _, c := range calls {
@@ -142,7 +142,7 @@ func TestUninstallKubernetes_KubectlDeleteFails(t *testing.T) {
 		return nil
 	})
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := UninstallKubernetes("my-ctx", analyzer.DistroEKS, false)
 		if err == nil {
 			t.Fatal("expected error when kubectl delete dynakube fails")
@@ -162,7 +162,7 @@ func TestUninstallKubernetes_HelmUninstallFails(t *testing.T) {
 		return nil
 	})
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := UninstallKubernetes("my-ctx", analyzer.DistroEKS, false)
 		if err == nil {
 			t.Fatal("expected error when helm uninstall fails")
@@ -187,7 +187,7 @@ func TestUninstallKubernetes_HelmFailContinuesToNamespaceDeletion(t *testing.T) 
 		return nil
 	})
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		err := UninstallKubernetes("my-ctx", analyzer.DistroEKS, false)
 		if err == nil {
 			t.Fatal("expected error when helm uninstall fails")
@@ -222,7 +222,7 @@ func TestUninstallKubernetes_KubectlDeleteFailContinuesToEnd(t *testing.T) {
 		return nil
 	})
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := UninstallKubernetes("my-ctx", analyzer.DistroEKS, false)
 		if err == nil {
 			t.Fatal("expected error when kubectl delete dynakube fails")
@@ -253,7 +253,7 @@ func TestUninstallKubernetes_DryRun(t *testing.T) {
 		return nil
 	})
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		if err := UninstallKubernetes("my-ctx", "GKE", true); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -281,7 +281,7 @@ func TestUninstallKubernetes_DryRun_NoClusterInfoWhenContextEmpty(t *testing.T) 
 		return nil
 	})
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		if err := UninstallKubernetes("", "", true); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -320,7 +320,7 @@ func TestUninstallKubernetes_MultipleStepsFail(t *testing.T) {
 		return nil
 	})
 
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		err := UninstallKubernetes("my-ctx", analyzer.DistroEKS, false)
 		if err == nil {
 			t.Fatal("expected error when multiple steps fail")
@@ -332,5 +332,73 @@ func TestUninstallKubernetes_MultipleStepsFail(t *testing.T) {
 
 	if !strings.Contains(out, "Uninstall completed with errors") {
 		t.Errorf("expected completion-with-errors message, got: %q", out)
+	}
+}
+
+func TestUninstallKubernetes_Step2WaitFailsNonFatal(t *testing.T) {
+	orig := installer.AutoConfirm
+	installer.AutoConfirm = true
+	t.Cleanup(func() { installer.AutoConfirm = orig })
+
+	var calls []string
+	withFakeRunCmdQuiet(t, func(name string, args ...string) error {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		// kubectl -n dynatrace wait ... → args[2] == "wait"
+		if name == "kubectl" && len(args) > 2 && args[2] == "wait" {
+			return errors.New("kubectl: timed out waiting for pods")
+		}
+		return nil
+	})
+
+	out := helpers.CaptureStdout(t, func() {
+		if err := UninstallKubernetes("my-ctx", analyzer.DistroGKE, false); err != nil {
+			t.Fatalf("expected success when only step 2 fails, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "uninstalled successfully") {
+		t.Errorf("expected success message, got: %q", out)
+	}
+	ranHelm, ranNamespace := false, false
+	for _, c := range calls {
+		if strings.Contains(c, "helm uninstall") {
+			ranHelm = true
+		}
+		if strings.Contains(c, "delete namespace") {
+			ranNamespace = true
+		}
+	}
+	if !ranHelm {
+		t.Error("expected helm uninstall to run after step 2 warning")
+	}
+	if !ranNamespace {
+		t.Error("expected namespace deletion to run after step 2 warning")
+	}
+}
+
+func TestUninstallKubernetes_NamespaceOnlyFails(t *testing.T) {
+	orig := installer.AutoConfirm
+	installer.AutoConfirm = true
+	t.Cleanup(func() { installer.AutoConfirm = orig })
+
+	withFakeRunCmdQuiet(t, func(name string, args ...string) error {
+		if name == "kubectl" && len(args) > 1 && args[0] == "delete" && args[1] == "namespace" {
+			return errors.New("kubectl: namespace not found")
+		}
+		return nil
+	})
+
+	out := helpers.CaptureStdout(t, func() {
+		err := UninstallKubernetes("my-ctx", analyzer.DistroGKE, false)
+		if err == nil {
+			t.Fatal("expected error when namespace deletion fails")
+		}
+		if !strings.Contains(err.Error(), "one or more steps failed") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Uninstall completed with errors") {
+		t.Errorf("expected errors message, got: %q", out)
 	}
 }

--- a/pkg/installer/oneagent/uninstall.go
+++ b/pkg/installer/oneagent/uninstall.go
@@ -11,6 +11,7 @@ import (
 // UninstallOptions configures the OneAgent V2 uninstall behaviour.
 type UninstallOptions struct {
 	DryRun bool
+	Quiet  bool
 }
 
 // UninstallOneAgentV2 removes Dynatrace OneAgent from the current host.
@@ -29,13 +30,15 @@ func UninstallOneAgentV2(opts UninstallOptions) error {
 		return nil
 	}
 
-	ok, err := installer.ConfirmProceed("  Proceed with OneAgent uninstall?")
-	if err != nil {
-		return fmt.Errorf("reading confirmation: %w", err)
-	}
-	if !ok {
-		display.PrintStatusLine("result", "uninstall cancelled", display.ColorMuted)
-		return installer.ErrInstallCancelled
+	if !opts.Quiet {
+		ok, err := installer.ConfirmProceed("  Proceed with OneAgent uninstall?")
+		if err != nil {
+			return fmt.Errorf("reading confirmation: %w", err)
+		}
+		if !ok {
+			display.PrintStatusLine("result", "uninstall cancelled", display.ColorMuted)
+			return installer.ErrInstallCancelled
+		}
 	}
 
 	if err := runUninstallFn(); err != nil {

--- a/pkg/installer/otel/collector_container_test.go
+++ b/pkg/installer/otel/collector_container_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 // TestOtelContainerImagePattern verifies the regex that identifies OTel Collector
@@ -113,7 +113,7 @@ func TestSelectCollector_ContainerDisplay(t *testing.T) {
 		r.Close()
 	}()
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_, _ = selectCollector(instances)
 	})
 
@@ -150,7 +150,7 @@ func TestSelectCollector_HostMountedConfigDisplay(t *testing.T) {
 		r.Close()
 	}()
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_, _ = selectCollector(instances)
 	})
 
@@ -186,7 +186,7 @@ func TestSelectCollector_NativeProcessStatus(t *testing.T) {
 		r.Close()
 	}()
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_, _ = selectCollector(instances)
 	})
 

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestCheckDemoExists(t *testing.T) {
@@ -47,10 +47,10 @@ func TestConfirmProceedAutoConfirm(t *testing.T) {
 // the full interactive flow (project detection) but makes no changes on disk.
 func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 	dir := t.TempDir()
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "y\n")
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		err := InstallOtelCollectorWithProject(
 			"https://fake.live.dynatrace.com", "tok", "tok", "", true,
 		)

--- a/pkg/installer/otel/golang_test.go
+++ b/pkg/installer/otel/golang_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestDetectGoProjects_Found(t *testing.T) {
@@ -17,7 +17,7 @@ func TestDetectGoProjects_Found(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectGoProjects()
 	found := false
 	for _, p := range projects {
@@ -37,7 +37,7 @@ func TestDetectGoProjects_None(t *testing.T) {
 	dir := t.TempDir()
 	realDir, _ := filepath.EvalSymlinks(dir)
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectGoProjects()
 	for _, p := range projects {
 		if p.Path == dir || p.Path == realDir {
@@ -97,7 +97,7 @@ func TestDetectGoPlan_FindsProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
 	plan := DetectGoPlan("https://tenant.live.dynatrace.com", "token")
@@ -119,7 +119,7 @@ func TestGoInstrumentationPlan_Runtime(t *testing.T) {
 func TestGoInstrumentationPlan_PrintPlanSteps(t *testing.T) {
 	plan := &GoInstrumentationPlan{Project: GoProject{ScannedProject: ScannedProject{Path: "/tmp/go-svc"}, ModuleName: "github.com/example/go-svc"}}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -137,7 +137,7 @@ func TestGoInstrumentationPlan_Execute(t *testing.T) {
 		EnvVars: map[string]string{"OTEL_SERVICE_NAME": "go-svc"},
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.Execute()
 	})
 

--- a/pkg/installer/otel/java_process_test.go
+++ b/pkg/installer/otel/java_process_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func mustCreateFile(t *testing.T, path string) {
@@ -308,7 +308,7 @@ func TestDetectJavaEntrypoints_NoEntrypoint(t *testing.T) {
 
 func TestPromptEntrypointSelection_AutoSelectsSingle(t *testing.T) {
 	eps := []JavaEntrypoint{{Command: "java -jar app.jar", Description: "app"}}
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		got := promptEntrypointSelection(eps)
 		if got == nil {
 			t.Fatal("expected auto-selection, got nil")
@@ -325,7 +325,7 @@ func TestPromptEntrypointSelection_MultipleSelect(t *testing.T) {
 		{Command: "java -jar b.jar", Description: "b"},
 	}
 	setTestStdin(t, "2\n")
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		got := promptEntrypointSelection(eps)
 		if got == nil {
 			t.Fatal("expected selection, got nil")
@@ -342,7 +342,7 @@ func TestPromptEntrypointSelection_Skip(t *testing.T) {
 		{Command: "java -jar b.jar"},
 	}
 	setTestStdin(t, "\n")
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		got := promptEntrypointSelection(eps)
 		if got != nil {
 			t.Fatalf("expected nil on empty input, got %+v", got)

--- a/pkg/installer/otel/java_test.go
+++ b/pkg/installer/otel/java_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 // ── test helpers ──────────────────────────────────────────────────────────────
@@ -53,7 +53,7 @@ func makeMavenProjectWithFatJar(t *testing.T) {
 		t.Fatal(err)
 	}
 	makeTestJar(t, targetDir, "app.jar", "Manifest-Version: 1.0\nMain-Class: com.example.App\n")
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 }
 
@@ -83,7 +83,7 @@ func TestDetectJavaProjects_Maven(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectJavaProjects()
 	if len(projects) == 0 {
 		t.Fatal("expected at least one Java project, got none")
@@ -109,7 +109,7 @@ func TestDetectJavaProjects_Gradle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectJavaProjects()
 	if len(projects) == 0 {
 		t.Fatal("expected at least one Java project, got none")
@@ -138,7 +138,7 @@ func TestDetectJavaProjects_None(t *testing.T) {
 	dir := t.TempDir()
 	realDir, _ := filepath.EvalSymlinks(dir)
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectJavaProjects()
 	for _, p := range projects {
 		if p.Path == dir || p.Path == realDir {
@@ -165,7 +165,7 @@ func TestDetectJavaPlan_FindsProject(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
 	plan := DetectJavaPlan("https://tenant.live.dynatrace.com", "token")
@@ -211,7 +211,7 @@ func TestJavaInstrumentationPlan_Runtime(t *testing.T) {
 func TestJavaInstrumentationPlan_PrintPlanSteps(t *testing.T) {
 	plan := &JavaInstrumentationPlan{Project: ScannedProject{Path: "/tmp/service"}}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -232,7 +232,7 @@ func TestJavaInstrumentationPlan_PrintPlanSteps_Updated(t *testing.T) {
 		},
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -258,7 +258,7 @@ func TestJavaInstrumentationPlan_Execute(t *testing.T) {
 		EnvVars: map[string]string{"OTEL_SERVICE_NAME": "orders-api"},
 	}
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		plan.Execute()
 	})
 }
@@ -310,7 +310,7 @@ func TestJavaInstrumentationPlan_Execute_MultiModuleDispatch(t *testing.T) {
 		},
 	}
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		plan.Execute()
 	})
 	output := colorBuf.String()
@@ -347,7 +347,7 @@ func TestDetectJavaPlan_MultiModule_HasSubModules(t *testing.T) {
 		}
 	}
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	setTestStdin(t, "1\n")
 
 	plan := DetectJavaPlan("https://tenant.live.dynatrace.com", "token")
@@ -375,7 +375,7 @@ func TestDownloadJavaAgent_CreatesDirectory(t *testing.T) {
 	defer srv.Close()
 	redirectAgentDownloadURL(t, srv)
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		path, err := downloadJavaAgent()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -494,7 +494,7 @@ func TestInstallOtelJava_DryRun(t *testing.T) {
 	skipIfNoJava(t)
 	makeMavenProjectWithFatJar(t)
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		err := InstallOtelJava("https://tenant.live.dynatrace.com", "tok", "test-svc", "", true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -522,10 +522,10 @@ func TestInstallOtelJava_SkipReturnsInstallCancelled(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "\n") // skip project selection
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := InstallOtelJava("https://tenant.live.dynatrace.com", "tok", "", "", false)
 		if !errors.Is(err, installer.ErrInstallCancelled) {
 			t.Errorf("expected installer.ErrInstallCancelled when skipping, got %v", err)
@@ -541,10 +541,10 @@ func TestInstallOtelJava_NoBuildArtifact_NoRunningProcess(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := InstallOtelJava("https://tenant.live.dynatrace.com", "tok", "", "", false)
 		if err == nil {
 			t.Fatal("expected error when no build tool is present, got nil")
@@ -566,10 +566,10 @@ func TestInstallOtelJava_AutoBuildFails(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := InstallOtelJava("https://tenant.live.dynatrace.com", "tok", "", "", false)
 		if err == nil {
 			t.Fatal("expected error when auto-build fails, got nil")

--- a/pkg/installer/otel/nodejs_project_test.go
+++ b/pkg/installer/otel/nodejs_project_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestDetectNodeProjects_Found(t *testing.T) {
@@ -15,7 +15,7 @@ func TestDetectNodeProjects_Found(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectNodeProjects()
 	found := false
 	for _, p := range projects {
@@ -43,7 +43,7 @@ func TestDetectNodeProjects_ExcludesNodeModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectNodeProjects()
 	for _, p := range projects {
 		if filepath.Base(filepath.Dir(p.Path)) == "node_modules" {
@@ -212,7 +212,7 @@ func TestDetectNodeProjects_Monorepo(t *testing.T) {
 		}
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectNodeProjects()
 
 	// Should include the root and both workspace packages.

--- a/pkg/installer/otel/nodejs_test.go
+++ b/pkg/installer/otel/nodejs_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestBuildNodeInstrumentationPlan(t *testing.T) {
@@ -69,7 +69,7 @@ func TestDetectNodePlan_FindsProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
 	plan, _ := DetectNodePlan("https://tenant.live.dynatrace.com", "token")
@@ -96,7 +96,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_Regular(t *testing.T) {
 		OtelDir:        "/tmp/node-svc/.otel",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -128,7 +128,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_NextJS(t *testing.T) {
 		Framework:      "next",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -161,7 +161,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_NextJS_BuildOutputExists(t *test
 		Framework:      "next",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -183,7 +183,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_Nuxt(t *testing.T) {
 		Framework:      "nuxt",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -225,7 +225,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_Nuxt_BuildOutputExists(t *testin
 		Framework:      "nuxt",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -272,7 +272,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_PackageManager(t *testing.T) {
 				PackageManager: pm,
 				OtelDir:        "/tmp/svc/.otel",
 			}
-			output := testutil.CaptureStdout(t, func() {
+			output := helpers.CaptureStdout(t, func() {
 				plan.PrintPlanSteps()
 			})
 			if !strings.Contains(output, "Package manager: "+pm) {
@@ -481,7 +481,7 @@ func TestNodeInstrumentationPlan_PrintPlanSteps_ShowsRunningPIDs(t *testing.T) {
 		OtelDir:        "/tmp/node-svc/.otel",
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 

--- a/pkg/installer/otel/process_test.go
+++ b/pkg/installer/otel/process_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestManagedProcessHelper(t *testing.T) {
@@ -72,7 +72,7 @@ func TestWaitResult_StillRunning(t *testing.T) {
 }
 
 func TestPrintProcessSummary_AllCrashed_NoAliveNames(t *testing.T) {
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		aliveNames, _ := PrintProcessSummary([]*ManagedProcess{
 			crashedManagedProcess("svc-a", errors.New("exit status 1")),
 			crashedManagedProcess("svc-b", errors.New("exit status 2")),
@@ -98,7 +98,7 @@ func TestPrintProcessSummary_SomeCrashed_OnlyAliveReturned(t *testing.T) {
 }
 
 func TestPrintProcessSummary_CrashedNonZeroExit_SummaryLabel(t *testing.T) {
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		PrintProcessSummary([]*ManagedProcess{
 			crashedManagedProcess("svc", errors.New("exit status 1")),
 		}, 0)
@@ -109,7 +109,7 @@ func TestPrintProcessSummary_CrashedNonZeroExit_SummaryLabel(t *testing.T) {
 }
 
 func TestPrintProcessSummary_CleanExit_SummaryLabel(t *testing.T) {
-	out := testutil.CaptureStdout(t, func() {
+	out := helpers.CaptureStdout(t, func() {
 		PrintProcessSummary([]*ManagedProcess{
 			cleanExitedManagedProcess("svc"),
 		}, 0)
@@ -184,7 +184,7 @@ func TestStartManagedProcess_CleanExit(t *testing.T) {
 
 func TestPrintSummaryLine_Crashed_IncludesLabel(t *testing.T) {
 	p := crashedManagedProcess("my-svc", errors.New("exit status 1"))
-	out := testutil.CaptureStdout(t, func() { p.PrintSummaryLine() })
+	out := helpers.CaptureStdout(t, func() { p.PrintSummaryLine() })
 	if !strings.Contains(out, "[crashed:") {
 		t.Fatalf("expected [crashed: in output, got %q", out)
 	}
@@ -195,7 +195,7 @@ func TestPrintSummaryLine_Crashed_IncludesLabel(t *testing.T) {
 
 func TestPrintSummaryLine_CleanExit_IncludesLabel(t *testing.T) {
 	p := cleanExitedManagedProcess("my-svc")
-	out := testutil.CaptureStdout(t, func() { p.PrintSummaryLine() })
+	out := helpers.CaptureStdout(t, func() { p.PrintSummaryLine() })
 	if !strings.Contains(out, "[exited cleanly]") {
 		t.Fatalf("expected [exited cleanly] in output, got %q", out)
 	}
@@ -206,7 +206,7 @@ func TestPrintSummaryLine_CleanExit_IncludesLabel(t *testing.T) {
 // a localhost URL if lsof happens to find one — both are valid "running" states.
 func TestPrintSummaryLine_Running_IncludesRunningStatus(t *testing.T) {
 	p := runningManagedProcess("my-svc")
-	out := testutil.CaptureStdout(t, func() { p.PrintSummaryLine() })
+	out := helpers.CaptureStdout(t, func() { p.PrintSummaryLine() })
 	if !strings.Contains(out, "running") && !strings.Contains(out, "localhost") {
 		t.Fatalf("expected running status in output, got %q", out)
 	}
@@ -214,7 +214,7 @@ func TestPrintSummaryLine_Running_IncludesRunningStatus(t *testing.T) {
 
 func TestPrintSummaryLine_LogNameIncluded(t *testing.T) {
 	p := cleanExitedManagedProcess("my-svc") // LogName is "my-svc.log"
-	out := testutil.CaptureStdout(t, func() { p.PrintSummaryLine() })
+	out := helpers.CaptureStdout(t, func() { p.PrintSummaryLine() })
 	if !strings.Contains(out, "my-svc.log") {
 		t.Fatalf("expected log name in output, got %q", out)
 	}

--- a/pkg/installer/otel/python_test.go
+++ b/pkg/installer/otel/python_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 // ── generateOtelPythonEnvVars ─────────────────────────────────────────────────
@@ -161,7 +161,7 @@ func TestDetectPythonProjects_Found(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := detectPythonProjects()
 	found := false
 	for _, p := range projects {
@@ -184,7 +184,7 @@ func TestDetectPythonProjects_AllMarkers(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			testutil.SetTestWorkingDir(t, dir)
+			helpers.SetTestWorkingDir(t, dir)
 			projects := detectPythonProjects()
 			found := false
 			for _, p := range projects {
@@ -312,7 +312,7 @@ func TestDetectPythonPlan_FindsProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "1\n")
 
 	plan := DetectPythonPlan("https://tenant.live.dynatrace.com", "token")
@@ -325,7 +325,7 @@ func TestDetectPythonPlan_FindsProject(t *testing.T) {
 }
 
 func TestPrintManualInstructions(t *testing.T) {
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		printManualInstructions(map[string]string{"OTEL_SERVICE_NAME": "py-svc"})
 	})
 
@@ -351,7 +351,7 @@ func TestPythonInstrumentationPlan_PrintPlanSteps(t *testing.T) {
 		NeedsVenv:   true,
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.PrintPlanSteps()
 	})
 
@@ -371,7 +371,7 @@ func TestPythonInstrumentationPlan_ExecuteFailsWithoutPythonForVenvCreation(t *t
 		EnvVars:   map[string]string{"OTEL_SERVICE_NAME": "py-svc"},
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		plan.Execute()
 	})
 
@@ -617,10 +617,10 @@ func TestInstallOtelPython_SkipReturnsInstallCancelled(t *testing.T) {
 	t.Setenv("PATH", pythonDir)
 
 	dir := t.TempDir() // no Python project markers
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	setTestStdin(t, "\n") // skip project selection
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		err := InstallOtelPython("https://tenant.live.dynatrace.com", "tok", "ptok", "", "", false)
 		if !errors.Is(err, installer.ErrInstallCancelled) {
 			t.Errorf("expected installer.ErrInstallCancelled when skipping, got %v", err)

--- a/pkg/installer/otel/python_venv_test.go
+++ b/pkg/installer/otel/python_venv_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestValidatePythonPrerequisites_PythonNotFound(t *testing.T) {
@@ -172,7 +172,7 @@ func TestRemoveStaleVirtualenv_UserDeclines(t *testing.T) {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		withStdinText(t, "n\n", func() {
 			removed, err := removeStaleVirtualenv(venvDir)
 			if err != nil {

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestIsIgnoredDir(t *testing.T) {
@@ -135,7 +135,7 @@ func TestScanProjectDirs_CWD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 	found := false
 	for _, p := range projects {
@@ -163,7 +163,7 @@ func TestScanProjectDirs_SubDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"package.json"}, nil)
 	realSubDir, _ := filepath.EvalSymlinks(subDir)
 	found := false
@@ -188,7 +188,7 @@ func TestScanProjectDirs_ExcludeDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"package.json"}, []string{"node_modules"})
 	for _, p := range projects {
 		if strings.Contains(p.Path, "node_modules") {
@@ -208,7 +208,7 @@ func TestScanProjectDirs_MultipleMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"pom.xml", "build.gradle"}, nil)
 	found := false
 	for _, p := range projects {
@@ -227,7 +227,7 @@ func TestScanProjectDirs_MultipleMarkers(t *testing.T) {
 func TestScanProjectDirs_NoMarkers(t *testing.T) {
 	dir := t.TempDir()
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 	realDir, _ := filepath.EvalSymlinks(dir)
 	for _, p := range projects {
@@ -256,7 +256,7 @@ func TestScanProjectDirs_NoiseDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	for _, p := range projects {
@@ -286,7 +286,7 @@ func TestScanProjectDirs_DotDirSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 	for _, p := range projects {
 		if strings.Contains(p.Path, ".hidden") {
@@ -312,7 +312,7 @@ func TestScanProjectDirs_MonorepoGrouping(t *testing.T) {
 		}
 	}
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	paths := make(map[string]bool, len(projects))
@@ -338,7 +338,7 @@ func TestScanProjectDirs_DeepNesting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	want := filepath.Join("a", "b", "c", "d")
@@ -375,7 +375,7 @@ func TestScanProjectDirs_SubtreePruning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	count := 0
@@ -405,7 +405,7 @@ func TestScanProjectDirs_ParentNotScanned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, cwd)
+	helpers.SetTestWorkingDir(t, cwd)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	if len(projects) != 0 {
@@ -447,7 +447,7 @@ func TestScanProjectDirs_WindowsSystemDirSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
 		if strings.Contains(p.Path, "System32") {
 			t.Errorf("Windows system dir 'System32' must be skipped, got %s", p.Path)
@@ -466,7 +466,7 @@ func TestScanProjectDirs_DevDirFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	found := false
 	for _, p := range scanProjectDirs([]string{"go.mod"}, nil) {
 		if strings.HasSuffix(filepath.ToSlash(p.Path), "/dev") {
@@ -497,7 +497,7 @@ func TestScanProjectDirs_WideParallelTree(t *testing.T) {
 		}
 	}
 
-	testutil.SetTestWorkingDir(t, root)
+	helpers.SetTestWorkingDir(t, root)
 	projects := scanProjectDirs([]string{"go.mod"}, nil)
 
 	found := make(map[string]bool, siblings)
@@ -554,7 +554,7 @@ func TestParseWinProcessOutput_SingleLine(t *testing.T) {
 func TestPromptProjectSelection_SingleProjectRangeHint(t *testing.T) {
 	projects := []ScannedProject{{Path: "/home/user/myapp", Markers: []string{"package.json"}}}
 	setTestStdin(t, "\n") // skip selection
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		promptProjectSelection("Node.js", projects)
 	})
 	if !strings.Contains(output, "instrument [1] or press") {

--- a/pkg/installer/otel/uninstall_python_test.go
+++ b/pkg/installer/otel/uninstall_python_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 // testRuntimeCleaner is a mock RuntimeCleaner used for deterministic testing.
@@ -62,7 +62,7 @@ func TestUninstallOtelCollector_PythonSectionAlwaysPresent(t *testing.T) {
 	testCleaner := &testRuntimeCleaner{label: "Python", processes: []DetectedProcess{}}
 	runtimeCleaners = []RuntimeCleaner{testCleaner}
 
-	output := stripANSI(testutil.CaptureStdout(t, func() {
+	output := stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 
@@ -74,7 +74,7 @@ func TestUninstallOtelCollector_PythonSectionAlwaysPresent(t *testing.T) {
 		{PID: 1234, Command: "python app.py"},
 	}
 
-	output = stripANSI(testutil.CaptureStdout(t, func() {
+	output = stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 
@@ -94,7 +94,7 @@ func TestUninstallOtelCollector_PythonPIDsInOutput(t *testing.T) {
 		processes: []DetectedProcess{{PID: 5555, Command: "python app.py"}},
 	}}
 
-	output := stripANSI(testutil.CaptureStdout(t, func() {
+	output := stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 
@@ -111,7 +111,7 @@ func TestUninstallOtelCollector_ScanErrorHandling(t *testing.T) {
 
 	runtimeCleaners = []RuntimeCleaner{&testRuntimeCleaner{label: "Python", processes: nil}}
 
-	output := stripANSI(testutil.CaptureStdout(t, func() {
+	output := stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 

--- a/pkg/installer/otel/uninstall_test.go
+++ b/pkg/installer/otel/uninstall_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestFindNodeOtelDirs_Found(t *testing.T) {
@@ -31,7 +31,7 @@ func TestFindNodeOtelDirs_Found(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	dirs := findNodeOtelDirs()
 
 	// Resolve symlinks for comparison (macOS /tmp → /private/tmp).
@@ -68,7 +68,7 @@ func TestFindNodeOtelDirs_ChildProjects(t *testing.T) {
 		expectedDirs = append(expectedDirs, realDir)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	dirs := findNodeOtelDirs()
 
 	// Resolve all found dirs for comparison.
@@ -98,7 +98,7 @@ func TestFindNodeOtelDirs_IgnoresNonOtelDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	dirs := findNodeOtelDirs()
 
 	realOtelDir, _ := filepath.EvalSymlinks(otelDir)
@@ -112,7 +112,7 @@ func TestFindNodeOtelDirs_IgnoresNonOtelDirs(t *testing.T) {
 
 func TestFindNodeOtelDirs_NoDirs(t *testing.T) {
 	dir := t.TempDir()
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 
 	dirs := findNodeOtelDirs()
 	if len(dirs) != 0 {
@@ -138,7 +138,7 @@ func TestFindNodeOtelDirs_ParentNotScanned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, cwd)
+	helpers.SetTestWorkingDir(t, cwd)
 	dirs := findNodeOtelDirs()
 
 	realOtelDir, _ := filepath.EvalSymlinks(otelDir)
@@ -159,7 +159,7 @@ func TestFindNodeOtelDirs_NoPackageJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 	dirs := findNodeOtelDirs()
 
 	realOtelDir, _ := filepath.EvalSymlinks(otelDir)
@@ -233,9 +233,9 @@ func TestUninstallOtelCollector_IncludesNodeDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.SetTestWorkingDir(t, dir)
+	helpers.SetTestWorkingDir(t, dir)
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true) // dry-run
 	})
 
@@ -343,7 +343,7 @@ func TestUninstallOtelCollector_JavaDryRun_NothingPresent(t *testing.T) {
 	t.Cleanup(func() { runtimeCleaners = origCleaners })
 	runtimeCleaners = []RuntimeCleaner{}
 
-	output := stripANSI(testutil.CaptureStdout(t, func() {
+	output := stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 
@@ -379,7 +379,7 @@ func TestUninstallOtelCollector_JavaDryRun_AgentDirExists(t *testing.T) {
 	t.Cleanup(func() { runtimeCleaners = origCleaners })
 	runtimeCleaners = []RuntimeCleaner{}
 
-	output := stripANSI(testutil.CaptureStdout(t, func() {
+	output := stripANSI(helpers.CaptureStdout(t, func() {
 		_ = UninstallOtelCollector(true)
 	}))
 

--- a/pkg/installer/otel/update_test.go
+++ b/pkg/installer/otel/update_test.go
@@ -8,7 +8,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/testutil"
+	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
 func TestDtOTLPEndpoint(t *testing.T) {
@@ -452,7 +452,7 @@ func TestUpdateOtelConfig_ContainerDryRun_HostMounted(t *testing.T) {
 		}
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_ = UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", "", true)
 	})
 
@@ -494,7 +494,7 @@ func TestUpdateOtelConfig_ContainerDryRun_NotInRestartPlan(t *testing.T) {
 		}
 	}
 
-	output := testutil.CaptureStdout(t, func() {
+	output := helpers.CaptureStdout(t, func() {
 		_ = UpdateOtelConfig(configPath, "https://env.live.dynatrace.com", "mytoken", "", true)
 	})
 
@@ -574,7 +574,7 @@ service:
 	}
 	w.Close()
 
-	testutil.CaptureStdout(t, func() {
+	helpers.CaptureStdout(t, func() {
 		if err := UpdateOtelConfigInteractive("https://env.live.dynatrace.com", "mytoken", "", true); err != nil {
 			t.Errorf("UpdateOtelConfigInteractive dry-run error: %v", err)
 		}

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/azure"
+	"github.com/dynatrace-oss/dtwiz/test/integration"
+)
+
+// TestAzureLifecycle exercises the full Azure Monitor integration lifecycle
+// against a real Azure subscription and a real Dynatrace tenant: install
+// (Entra App Registration + federated credential + role assignment +
+// Dynatrace connection/monitoring config) → uninstall (reverses all of it).
+//
+// It requires the `az` CLI to be logged in (`az login`) to a subscription
+// where the signed-in account can create App Registrations and role
+// assignments at subscription scope. This test does not attempt to log in or
+// validate permissions beyond what the installer itself checks — pointing it
+// at an appropriate subscription/tenant is the caller's responsibility.
+func TestAzureLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("az"); err != nil {
+		t.Skip("az CLI not found in PATH")
+	}
+	if out, err := exec.Command("az", "account", "show", "-o", "json").CombinedOutput(); err != nil {
+		t.Fatalf("not logged in to Azure: run `az login` and retry (needs an active session with permission "+
+			"to create App Registrations and role assignments at subscription scope)\n%s", out)
+	}
+	// `az account show` only proves the ARM-scoped token is valid. `az ad ...`
+	// commands (used mid-install) need a separate Graph-scoped token, which can
+	// expire independently under MFA/conditional-access policies. Catch that
+	// here so we fail before creating any resources, not partway through.
+	if out, err := exec.Command("az", "ad", "signed-in-user", "show", "-o", "json").CombinedOutput(); err != nil {
+		t.Fatalf("Azure Graph session appears stale (MFA/token expired): run `az login` again and retry\n%s", out)
+	}
+
+	integration.Parallelize(t)
+	env := integration.SetupIntegration(t)
+	t.Logf("test ID: %s", env.TestID)
+
+	// Safety-net cleanup: always attempt it, even on a partial failure — install
+	// can create real Azure/Dynatrace resources (e.g. the DT connection) before
+	// failing on a later step, and UninstallAzure is safe to call when there is
+	// nothing (or only partial state) to remove.
+	t.Cleanup(func() {
+		if err := azure.UninstallAzure(env.EnvURL, env.PlatformToken, false); err != nil {
+			t.Logf("cleanup: uninstall failed: %v", err)
+		}
+	})
+
+	t.Log("installing Azure Monitor integration")
+	if err := azure.InstallAzure(env.EnvURL, env.PlatformToken, false, time.Time{}); err != nil {
+		t.Fatalf("InstallAzure: %v", err)
+	}
+
+	t.Log("verifying Dynatrace connection and monitoring configuration exist")
+	requireAzureResources(t, env, true)
+
+	t.Log("uninstalling Azure Monitor integration")
+	if err := azure.UninstallAzure(env.EnvURL, env.PlatformToken, false); err != nil {
+		t.Fatalf("UninstallAzure: %v", err)
+	}
+
+	t.Log("verifying Dynatrace connection and monitoring configuration are gone")
+	requireAzureResources(t, env, false)
+}
+
+// requireAzureResources fatals/errors unless the Azure connection and
+// monitoring configuration existence both match want.
+func requireAzureResources(t *testing.T, env *integration.TestEnv, want bool) {
+	t.Helper()
+
+	connExists, err := azure.ConnectionExists(env.EnvURL, env.PlatformToken)
+	if err != nil {
+		t.Fatalf("ConnectionExists: %v", err)
+	}
+	if connExists != want {
+		t.Errorf("azure connection exists = %v, want %v", connExists, want)
+	}
+
+	configExists, err := azure.MonitoringConfigExists(env.EnvURL, env.PlatformToken)
+	if err != nil {
+		t.Fatalf("MonitoringConfigExists: %v", err)
+	}
+	if configExists != want {
+		t.Errorf("azure monitoring configuration exists = %v, want %v", configExists, want)
+	}
+}

--- a/test/e2e/gcp_test.go
+++ b/test/e2e/gcp_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/gcp"
+	"github.com/dynatrace-oss/dtwiz/test/integration"
+)
+
+// TestGCPLifecycle exercises the full Google Cloud integration lifecycle
+// against a real GCP project and a real Dynatrace tenant: install
+// (service account + IAM bindings + Dynatrace connection/monitoring config)
+// → uninstall (reverses all of it).
+//
+// It requires the `gcloud` CLI to be on PATH with an active project set.
+// The signed-in account must be able to create service accounts and manage
+// IAM policy bindings at the project level.
+func TestGCPLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		t.Skip("gcloud not found in PATH")
+	}
+	out, err := exec.Command("gcloud", "config", "get-value", "project").CombinedOutput()
+	project := strings.TrimSpace(string(out))
+	if err != nil || project == "" || strings.Contains(project, "(unset)") {
+		t.Fatalf("no active Google Cloud project: run `gcloud auth login` and `gcloud config set project <id>`, then retry\n%s", out)
+	}
+
+	integration.Parallelize(t)
+	env := integration.SetupIntegration(t)
+	t.Logf("test ID: %s", env.TestID)
+	t.Logf("target project: %s", project)
+
+	// Safety-net cleanup: always attempt it, even on a partial failure — install
+	// can create real GCP/Dynatrace resources before failing on a later step, and
+	// UninstallGCP is safe to call when there is nothing (or only partial state) to remove.
+	t.Cleanup(func() {
+		if err := gcp.UninstallGCP(env.EnvURL, env.PlatformToken, false); err != nil {
+			t.Logf("cleanup: uninstall failed: %v", err)
+		}
+	})
+
+	t.Log("installing Google Cloud integration")
+	if err := gcp.InstallGCP(env.EnvURL, env.PlatformToken, false, time.Time{}); err != nil {
+		t.Fatalf("InstallGCP: %v", err)
+	}
+
+	t.Log("verifying Dynatrace connection and monitoring configuration exist")
+	requireGCPResources(t, env, true)
+
+	t.Log("uninstalling Google Cloud integration")
+	if err := gcp.UninstallGCP(env.EnvURL, env.PlatformToken, false); err != nil {
+		t.Fatalf("UninstallGCP: %v", err)
+	}
+
+	t.Log("verifying Dynatrace connection and monitoring configuration are gone")
+	requireGCPResources(t, env, false)
+}
+
+// requireGCPResources fatals/errors unless the GCP connection and
+// monitoring configuration existence both match want.
+func requireGCPResources(t *testing.T, env *integration.TestEnv, want bool) {
+	t.Helper()
+
+	connExists, err := gcp.ConnectionExists(env.EnvURL, env.PlatformToken)
+	if err != nil {
+		t.Fatalf("ConnectionExists: %v", err)
+	}
+	if connExists != want {
+		t.Errorf("GCP connection exists = %v, want %v", connExists, want)
+	}
+
+	configExists, err := gcp.MonitoringConfigExists(env.EnvURL, env.PlatformToken)
+	if err != nil {
+		t.Fatalf("MonitoringConfigExists: %v", err)
+	}
+	if configExists != want {
+		t.Errorf("GCP monitoring configuration exists = %v, want %v", configExists, want)
+	}
+}

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
+	k8s "github.com/dynatrace-oss/dtwiz/pkg/installer/kubernetes"
+	"github.com/dynatrace-oss/dtwiz/test/integration"
+	"github.com/dynatrace-oss/dtwiz/test/integration/grail"
+)
+
+// countDynakubes returns the number of DynaKube custom resources in the
+// dynatrace namespace, or -1 if the query itself fails (e.g. namespace gone).
+func countDynakubes(t *testing.T) int {
+	t.Helper()
+	out, err := exec.Command("kubectl", "get", "dynakube", "-n", "dynatrace", "--no-headers").CombinedOutput()
+	if err != nil {
+		return -1
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return 0
+	}
+	return len(strings.Split(trimmed, "\n"))
+}
+
+
+// TestKubernetesLifecycle exercises the full Dynatrace Operator lifecycle
+// against a real Kubernetes cluster and a real Dynatrace tenant: install
+// (Helm chart + DynaKube CR, wait for pods to become ready) → uninstall
+// (delete DynaKube CRs, wait for managed pods to terminate, Helm uninstall,
+// delete the dynatrace namespace).
+//
+// It requires kubectl and helm on PATH and a cluster reachable via the
+// current kubeconfig context — this test does not provision a cluster. Point
+// kubectl at a disposable cluster (e.g. kind or minikube) before running it.
+func TestKubernetesLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Skip("kubectl not found in PATH")
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not found in PATH")
+	}
+
+	k8sInfo := analyzer.DetectKubernetes()
+	if !k8sInfo.Available {
+		t.Skip("no reachable Kubernetes cluster (kubectl cluster-info failed); point kubectl at a disposable cluster before running this test")
+	}
+
+	integration.Parallelize(t)
+	env := integration.SetupIntegration(t)
+	t.Logf("test ID: %s", env.TestID)
+	t.Logf("target cluster: context=%s distro=%s", k8sInfo.Context, k8sInfo.Distribution)
+
+	// Safety-net cleanup: runs on partial failure — e.g. `helm install
+	// --create-namespace` can leave the dynatrace namespace (or CRs) behind,
+	// and --atomic only rolls back the Helm release, not the namespace.
+	// Skipped when the explicit uninstall step below already succeeded.
+	uninstalled := false
+	t.Cleanup(func() {
+		if uninstalled {
+			return
+		}
+		if err := k8s.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution, false); err != nil {
+			t.Logf("cleanup: uninstall failed: %v", err)
+		}
+	})
+	if os.Getenv("TEST_DEBUG") != "" {
+		t.Cleanup(func() {
+			if !t.Failed() {
+				return
+			}
+			if out, err := exec.Command("kubectl", "get", "pods", "-n", "dynatrace", "-o", "wide").CombinedOutput(); err == nil {
+				t.Logf("debug: pods in dynatrace namespace:\n%s", out)
+			}
+			if out, err := exec.Command("kubectl", "get", "events", "-n", "dynatrace", "--sort-by=.lastTimestamp", "--field-selector", "type=Warning").CombinedOutput(); err == nil {
+				t.Logf("debug: warning events:\n%s", out)
+			}
+		})
+	}
+
+	t.Log("installing Dynatrace Operator (waits for pods to become ready, up to 10 min)")
+	if err := k8s.InstallKubernetes(env.EnvURL, env.ClassicToken, env.TestID, k8sInfo.Distribution, false); err != nil {
+		t.Fatalf("InstallKubernetes: %v", err)
+	}
+
+	t.Log("verifying DynaKube custom resources exist")
+	// The installer renders two DynaKube CRs by design: one for
+	// kubernetes-monitoring/KSPM and one ("-agents") for OneAgent + routing
+	// ActiveGate. See pkg/installer/kubernetes/dynakube.tmpl.
+	if n := countDynakubes(t); n != 2 {
+		t.Fatalf("expected exactly 2 dynakubes in namespace dynatrace, got %d", n)
+	}
+
+	t.Log("verifying cluster topology was reported to Dynatrace")
+	grail.RequireKubernetesCluster(t, env.Client, strings.ToLower(k8sInfo.Context),
+		grail.WithTimeout(5*time.Minute),
+		grail.WithInterval(20*time.Second),
+	)
+
+	t.Log("uninstalling Dynatrace Operator (waits for pods to terminate, up to 5 min)")
+	if err := k8s.UninstallKubernetes(k8sInfo.Context, k8sInfo.Distribution, false); err != nil {
+		t.Fatalf("UninstallKubernetes: %v", err)
+	}
+	uninstalled = true
+
+	t.Log("verifying dynatrace namespace is gone")
+	if err := exec.Command("kubectl", "get", "namespace", "dynatrace").Run(); err == nil {
+		t.Error("expected namespace dynatrace to be gone after uninstall")
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+)
+
+func TestMain(m *testing.M) {
+	// Set AutoConfirm once for the entire test binary. Per-test save/restore
+	// is unsafe when tests run in parallel: a finishing test restores the
+	// global to false while other tests are still in progress.
+	installer.AutoConfirm = true
+	os.Exit(m.Run())
+}

--- a/test/e2e/oneagent_test.go
+++ b/test/e2e/oneagent_test.go
@@ -3,6 +3,7 @@
 package e2e_test
 
 import (
+	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,8 @@ import (
 	"github.com/dynatrace-oss/dtwiz/test/integration"
 	"github.com/dynatrace-oss/dtwiz/test/integration/grail"
 )
+
+var oneAgentQuiet = flag.Bool("quiet", false, "run OneAgent install/uninstall in quiet mode (no confirmation prompts; requires elevated privileges on Windows)")
 
 // oneAgentInstallDir returns OneAgent's well-known install location for the
 // current OS. The package-internal variable of the same name is not exported,
@@ -67,7 +70,7 @@ func TestOneAgentLifecycle(t *testing.T) {
 		if !installed {
 			return
 		}
-		if uerr := oneagent.UninstallOneAgentV2(oneagent.UninstallOptions{}); uerr != nil {
+		if uerr := oneagent.UninstallOneAgentV2(oneagent.UninstallOptions{Quiet: *oneAgentQuiet}); uerr != nil {
 			t.Logf("cleanup: uninstall failed: %v", uerr)
 		}
 	})
@@ -75,6 +78,7 @@ func TestOneAgentLifecycle(t *testing.T) {
 	t.Log("installing OneAgent (fullstack)")
 	if err := oneagent.InstallOneAgentV2(env.Client, oneagent.InstallOptions{
 		HostGroup: env.TestID, // unique tag to aid correlation and manual debugging
+		Quiet:     *oneAgentQuiet,
 	}); err != nil {
 		t.Fatalf("InstallOneAgentV2: %v", err)
 	}
@@ -96,7 +100,7 @@ func TestOneAgentLifecycle(t *testing.T) {
 	t.Logf("found %d host record(s) for %q", len(hosts), hostName)
 
 	t.Log("uninstalling OneAgent")
-	if err := oneagent.UninstallOneAgentV2(oneagent.UninstallOptions{}); err != nil {
+	if err := oneagent.UninstallOneAgentV2(oneagent.UninstallOptions{Quiet: *oneAgentQuiet}); err != nil {
 		t.Fatalf("UninstallOneAgentV2: %v", err)
 	}
 	installed = false // uninstall succeeded; safety-net cleanup is no longer needed

--- a/test/e2e/oneagent_test.go
+++ b/test/e2e/oneagent_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/oneagent"
 	"github.com/dynatrace-oss/dtwiz/test/integration"
 	"github.com/dynatrace-oss/dtwiz/test/integration/grail"
@@ -56,12 +55,9 @@ func TestOneAgentLifecycle(t *testing.T) {
 
 	installDir := oneAgentInstallDir()
 
+	integration.Parallelize(t)
 	env := integration.SetupIntegration(t)
 	t.Logf("test ID: %s", env.TestID)
-
-	originalAutoConfirm := installer.AutoConfirm
-	installer.AutoConfirm = true
-	t.Cleanup(func() { installer.AutoConfirm = originalAutoConfirm })
 
 	// Safety-net cleanup: only runs if install succeeded, so the host is never
 	// left permanently monitored if a later assertion fails.

--- a/test/e2e/otel_test.go
+++ b/test/e2e/otel_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel"
 	"github.com/dynatrace-oss/dtwiz/test/integration"
 	"github.com/dynatrace-oss/dtwiz/test/integration/grail"
@@ -28,9 +27,7 @@ type otelCase struct {
 }
 
 func TestOTelAutoInstrumentation(t *testing.T) {
-	originalAutoConfirm := installer.AutoConfirm
-	installer.AutoConfirm = true
-	t.Cleanup(func() { installer.AutoConfirm = originalAutoConfirm })
+	integration.Parallelize(t)
 
 	cases := []otelCase{
 		{

--- a/test/helpers/stdout.go
+++ b/test/helpers/stdout.go
@@ -1,4 +1,4 @@
-package testutil
+package helpers
 
 import (
 	"bytes"

--- a/test/helpers/workdir.go
+++ b/test/helpers/workdir.go
@@ -1,4 +1,4 @@
-package testutil
+package helpers
 
 import (
 	"os"

--- a/test/integration/grail/execute.go
+++ b/test/integration/grail/execute.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/client"
 )
+
+var debugDQL = os.Getenv("TEST_DEBUG") != ""
 
 func executeDQL(ctx context.Context, platform *client.PlatformClient, dql string) ([]TraceRecord, error) {
 	payload := map[string]interface{}{
@@ -15,6 +18,9 @@ func executeDQL(ctx context.Context, platform *client.PlatformClient, dql string
 		"maxResultRecords":           200,
 	}
 
+	if debugDQL {
+		log.Printf("DQL execute: query: %s", dql)
+	}
 	log.Printf("DQL execute: posting query to %s", grailExecutePath)
 	var resp grailResponse
 	raw, err := platform.HTTP().R().

--- a/test/integration/grail/helpers.go
+++ b/test/integration/grail/helpers.go
@@ -36,3 +36,10 @@ func hostByNameQuery(hostName string) string {
 		hostName,
 	)
 }
+
+func kubernetesClusterByNameQuery(clusterName string) string {
+	return fmt.Sprintf(
+		`fetch logs, from: now()-10m | filter k8s.cluster.name == %q | limit 1`,
+		clusterName,
+	)
+}

--- a/test/integration/grail/helpers.go
+++ b/test/integration/grail/helpers.go
@@ -39,7 +39,7 @@ func hostByNameQuery(hostName string) string {
 
 func kubernetesClusterByNameQuery(clusterName string) string {
 	return fmt.Sprintf(
-		`fetch logs, from: now()-10m | filter k8s.cluster.name == %q | limit 1`,
+		`smartscapeNodes "K8S_CLUSTER", from: -30m, to: now() | filter name == %q`,
 		clusterName,
 	)
 }

--- a/test/integration/grail/kubernetes.go
+++ b/test/integration/grail/kubernetes.go
@@ -1,0 +1,29 @@
+package grail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/client"
+)
+
+// RequireKubernetesCluster calls WaitForKubernetesCluster and fatals if it errors or returns no records.
+func RequireKubernetesCluster(t *testing.T, c *client.Client, clusterName string, opts ...PollOption) []TraceRecord {
+	t.Helper()
+	clusters, err := WaitForKubernetesCluster(context.Background(), c, clusterName, opts...)
+	if err != nil {
+		t.Fatalf("WaitForKubernetesCluster: %v", err)
+	}
+	if len(clusters) == 0 {
+		t.Fatalf("expected Kubernetes cluster %q to appear in topology, got none", clusterName)
+	}
+	return clusters
+}
+
+// WaitForKubernetesCluster polls the DQL endpoint via PlatformClient until a
+// K8S_CLUSTER entity named clusterName appears in the Smartscape topology or
+// the timeout is exceeded. It is used to confirm that the Dynatrace Operator
+// actually reported cluster topology, not just that its pods became ready.
+func WaitForKubernetesCluster(ctx context.Context, c *client.Client, clusterName string, options ...PollOption) ([]TraceRecord, error) {
+	return waitForRecords(ctx, c, kubernetesClusterByNameQuery(clusterName), "Kubernetes cluster "+clusterName+" in topology", options...)
+}

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -61,6 +61,17 @@ func SetupIntegration(t *testing.T) *TestEnv {
 	}
 }
 
+// Parallelize marks the test as parallel unless TEST_SEQUENTIAL=1 is set.
+// Use it at the top of each top-level integration test so that
+// `make test-integration` runs them concurrently by default; pass
+// SEQUENTIAL=true to the make invocation to opt out.
+func Parallelize(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TEST_SEQUENTIAL") == "" {
+		t.Parallel()
+	}
+}
+
 func requireEnv(t *testing.T, key string) string {
 	t.Helper()
 	val := os.Getenv(key)

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -61,9 +61,9 @@ func SetupIntegration(t *testing.T) *TestEnv {
 	}
 }
 
-// Parallelize marks the test as parallel unless TEST_SEQUENTIAL=1 is set.
-// Use it at the top of each top-level integration test so that
-// `make test-integration` runs them concurrently by default; pass
+// Parallelize marks the test as parallel unless TEST_SEQUENTIAL is set to a
+// non-empty value. Use it at the top of each top-level integration test so
+// that `make test-integration` runs them concurrently by default; pass
 // SEQUENTIAL=true to the make invocation to opt out.
 func Parallelize(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): Test infrastructure improvements

Adds parallel execution, Kubernetes and Azure lifecycle tests, a test summary, and a debug mode to the integration test suite.

## How to test
1. Run `make test-integration` — tests should run in parallel and print a passed/failed/skipped summary at the end.
2. Run `make test-integration SEQUENTIAL=true` — tests should run one at a time (this will last really long)
3. With `kubectl` pointing at a disposable cluster and `az` logged in, verify `TestKubernetesLifecycle` and `TestAzureLifecycle` pass.
4. Run `make test-integration TEST_DEBUG=1` and confirm DQL queries are logged to stdout.

## Which other features are affected?
1. None — no CLI behavior changes.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.