### PR TITLE
feat: improve wording

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -216,7 +216,6 @@ var setupCmd = &cobra.Command{
 		case recommender.MethodGCP:
 			installErr = gcp.InstallGCP(envURL, platformTok, setupDryRun, StartTime)
 		case recommender.MethodGCPUpdate:
-			logger.Debug("setup selected GCP update")
 			installErr = gcp.UpdateGCP(envURL, platformTok, setupDryRun, StartTime)
 		default:
 			return fmt.Errorf("unsupported method: %s", selected.Method)
@@ -227,12 +226,18 @@ var setupCmd = &cobra.Command{
 			}
 			return installErr
 		}
+		if setupDryRun {
+			return nil
+		}
 		// AWS scopes its watch to the account (WatchIngestAWS); Azure and GCP run their
-		// own generic watch from inside the installer; both start their own watch, so
-		// the generic post-install watch here is only used for the other methods.
-		if !setupDryRun && selected.Method != recommender.MethodAWS &&
-			selected.Method != recommender.MethodAzure && selected.Method != recommender.MethodAzureUpdate &&
-			selected.Method != recommender.MethodGCP && selected.Method != recommender.MethodGCPUpdate {
+		// own generic watch from inside the installer. Only the methods below use the
+		// generic post-install watch.
+		switch selected.Method {
+		case recommender.MethodOneAgent,
+			recommender.MethodKubernetes,
+			recommender.MethodDocker,
+			recommender.MethodOtelCollector,
+			recommender.MethodOtelUpdate:
 			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		}
 		return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -53,6 +53,25 @@ var setupCmd = &cobra.Command{
 		}
 		fmt.Println(info.Summary())
 
+		// Pre-check Azure/GCP connection status so the recommender can emit the
+		// right method (install vs update) for each cloud integration.
+		if envURL, _, platformTok, credErr := getDtEnvironment(); credErr == nil {
+			if err := installer.RunConcurrently(
+				func() error {
+					exists, err := azure.ConnectionExists(envURL, platformTok)
+					info.AzureConfigured = exists
+					return err
+				},
+				func() error {
+					exists, err := gcp.ConnectionExists(envURL, platformTok)
+					info.GCPConfigured = exists
+					return err
+				},
+			); err != nil {
+				logger.Debug("connection existence check failed, assuming not configured", "err", err)
+			}
+		}
+
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")
 		recs := recommender.GenerateRecommendations(info)
@@ -73,43 +92,8 @@ var setupCmd = &cobra.Command{
 			return nil
 		}
 
-		// Pre-check Azure/GCP status so we can badge those entries in the list.
-		azureConfigured := false
-		gcpConfigured := false
-		if envURL, _, platformTok, credErr := getDtEnvironment(); credErr == nil {
-			if err := installer.RunConcurrently(
-				func() error {
-					exists, err := azure.ConnectionExists(envURL, platformTok)
-					azureConfigured = exists
-					return err
-				},
-				func() error {
-					exists, err := gcp.ConnectionExists(envURL, platformTok)
-					gcpConfigured = exists
-					return err
-				},
-			); err != nil {
-				logger.Debug("connection existence check failed, badging as not configured", "err", err)
-			}
-		}
-
 		for i, r := range actionable {
-			title := r.Title
-			if r.Method == recommender.MethodAzure {
-				if azureConfigured {
-					title += "  [update]"
-				} else {
-					title += "  [install]"
-				}
-			}
-			if r.Method == recommender.MethodGCP {
-				if gcpConfigured {
-					title += "  [update]"
-				} else {
-					title += "  [install]"
-				}
-			}
-			fmt.Printf("  %s  %s\n", display.ColorHeader.Sprintf("[%d]", i+1), title)
+			fmt.Printf("  %s  %s\n", display.ColorHeader.Sprintf("[%d]", i+1), r.Title)
 		}
 		// Show coming-soon items (informational only, not selectable).
 		for _, r := range recs {
@@ -186,8 +170,7 @@ var setupCmd = &cobra.Command{
 		}
 
 		headerVerb := "Installing"
-		if (selected.Method == recommender.MethodAzure && azureConfigured) ||
-			(selected.Method == recommender.MethodGCP && gcpConfigured) {
+		if selected.Method == recommender.MethodAzureUpdate || selected.Method == recommender.MethodGCPUpdate {
 			headerVerb = "Updating"
 		}
 		display.Header(fmt.Sprintf("%s: %s", headerVerb, selected.Title))
@@ -221,18 +204,14 @@ var setupCmd = &cobra.Command{
 		case recommender.MethodAWS:
 			installErr = installer.InstallAWS(c.Platform, envURL, platformTok, setupDryRun, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		case recommender.MethodAzure:
-			if azureConfigured {
-				installErr = azure.UpdateAzure(envURL, platformTok, setupDryRun, StartTime)
-			} else {
-				installErr = azure.InstallAzure(envURL, platformTok, setupDryRun, StartTime)
-			}
+			installErr = azure.InstallAzure(envURL, platformTok, setupDryRun, StartTime)
+		case recommender.MethodAzureUpdate:
+			installErr = azure.UpdateAzure(envURL, platformTok, setupDryRun, StartTime)
 		case recommender.MethodGCP:
-			logger.Debug("setup selected GCP", "configured", gcpConfigured)
-			if gcpConfigured {
-				installErr = gcp.UpdateGCP(envURL, platformTok, setupDryRun, StartTime)
-			} else {
-				installErr = gcp.InstallGCP(envURL, platformTok, setupDryRun, StartTime)
-			}
+			installErr = gcp.InstallGCP(envURL, platformTok, setupDryRun, StartTime)
+		case recommender.MethodGCPUpdate:
+			logger.Debug("setup selected GCP update")
+			installErr = gcp.UpdateGCP(envURL, platformTok, setupDryRun, StartTime)
 		default:
 			return fmt.Errorf("unsupported method: %s", selected.Method)
 		}
@@ -246,7 +225,8 @@ var setupCmd = &cobra.Command{
 		// own generic watch from inside the installer; both start their own watch, so
 		// the generic post-install watch here is only used for the other methods.
 		if !setupDryRun && selected.Method != recommender.MethodAWS &&
-			selected.Method != recommender.MethodAzure && selected.Method != recommender.MethodGCP {
+			selected.Method != recommender.MethodAzure && selected.Method != recommender.MethodAzureUpdate &&
+			selected.Method != recommender.MethodGCP && selected.Method != recommender.MethodGCPUpdate {
 			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format("2006-01-02T15:04:05Z"))
 		}
 		return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -56,19 +56,25 @@ var setupCmd = &cobra.Command{
 		// Pre-check Azure/GCP connection status so the recommender can emit the
 		// right method (install vs update) for each cloud integration.
 		if envURL, _, platformTok, credErr := getDtEnvironment(); credErr == nil {
-			if err := installer.RunConcurrently(
-				func() error {
+			var checks []func() error
+			if info.Azure != nil && info.Azure.Available {
+				checks = append(checks, func() error {
 					exists, err := azure.ConnectionExists(envURL, platformTok)
 					info.AzureConfigured = exists
 					return err
-				},
-				func() error {
+				})
+			}
+			if info.GCP != nil && info.GCP.Available {
+				checks = append(checks, func() error {
 					exists, err := gcp.ConnectionExists(envURL, platformTok)
 					info.GCPConfigured = exists
 					return err
-				},
-			); err != nil {
-				logger.Debug("connection existence check failed, assuming not configured", "err", err)
+				})
+			}
+			if len(checks) > 0 {
+				if err := installer.RunConcurrently(checks...); err != nil {
+					logger.Debug("connection existence check failed, assuming not configured", "err", err)
+				}
 			}
 		}
 

--- a/openspec/changes/cloud-install-ux-improvement/.openspec.yaml
+++ b/openspec/changes/cloud-install-ux-improvement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/cloud-install-ux-improvement/design.md
+++ b/openspec/changes/cloud-install-ux-improvement/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`watchIngest` in `pkg/installer/ingest_watch.go` renders a footer after every install. Currently it always links to QuickStart. Cloud installs (AWS, GCP, Azure) should link to the Clouds app instead, as QuickStart won't show cloud resources at GA.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cloud installs show the Clouds app footer.
+- Non-cloud installs keep the QuickStart footer unchanged.
+
+**Non-Goals:**
+- Changing any other part of the watch screen.
+- Changing footer behavior for OneAgent, OTel, Docker, or Kubernetes.
+
+## Decisions
+
+**Add `cloudInstall bool` to internal `watchIngest`, expose `WatchIngestCloud` publicly.**
+
+The internal function already carries an `awsAccountID` string, which implicitly signals AWS. Rather than reusing that as a placeholder for GCP/Azure (which would trigger AWS-specific DQL queries), a dedicated bool cleanly separates the concern. A new exported `WatchIngestCloud` function lets GCP and Azure call without duplicating logic.
+
+Alternatives considered:
+- Reuse `awsAccountID` as placeholder — rejected: would incorrectly run AWS DQL queries for GCP/Azure.
+- Pass footer URL/label as strings — rejected: over-engineered for a binary choice.
+
+## Risks / Trade-offs
+
+- Minimal risk — pure rendering change, no API or data model impact.
+- If a future cloud method is added, callers must remember to use `WatchIngestCloud`. Mitigated: function name is self-documenting.

--- a/openspec/changes/cloud-install-ux-improvement/design.md
+++ b/openspec/changes/cloud-install-ux-improvement/design.md
@@ -1,3 +1,5 @@
+# Design: Cloud Install Footer
+
 ## Context
 
 `watchIngest` in `pkg/installer/ingest_watch.go` renders a footer after every install. Currently it always links to QuickStart. Cloud installs (AWS, GCP, Azure) should link to the Clouds app instead, as QuickStart won't show cloud resources at GA.
@@ -5,10 +7,12 @@
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Cloud installs show the Clouds app footer.
 - Non-cloud installs keep the QuickStart footer unchanged.
 
 **Non-Goals:**
+
 - Changing any other part of the watch screen.
 - Changing footer behavior for OneAgent, OTel, Docker, or Kubernetes.
 
@@ -19,6 +23,7 @@
 The internal function already carries an `awsAccountID` string, which implicitly signals AWS. Rather than reusing that as a placeholder for GCP/Azure (which would trigger AWS-specific DQL queries), a dedicated bool cleanly separates the concern. A new exported `WatchIngestCloud` function lets GCP and Azure call without duplicating logic.
 
 Alternatives considered:
+
 - Reuse `awsAccountID` as placeholder — rejected: would incorrectly run AWS DQL queries for GCP/Azure.
 - Pass footer URL/label as strings — rejected: over-engineered for a binary choice.
 
@@ -26,3 +31,4 @@ Alternatives considered:
 
 - Minimal risk — pure rendering change, no API or data model impact.
 - If a future cloud method is added, callers must remember to use `WatchIngestCloud`. Mitigated: function name is self-documenting.
+

--- a/openspec/changes/cloud-install-ux-improvement/design.md
+++ b/openspec/changes/cloud-install-ux-improvement/design.md
@@ -31,4 +31,3 @@ Alternatives considered:
 
 - Minimal risk — pure rendering change, no API or data model impact.
 - If a future cloud method is added, callers must remember to use `WatchIngestCloud`. Mitigated: function name is self-documenting.
-

--- a/openspec/changes/cloud-install-ux-improvement/proposal.md
+++ b/openspec/changes/cloud-install-ux-improvement/proposal.md
@@ -28,4 +28,3 @@ Two UX gaps for cloud installs: the watch screen footer links to QuickStart (whi
 - `pkg/recommender/recommender.go` — new methods, updated titles
 - `pkg/analyzer/analyzer.go` — `AzureConfigured`, `GCPConfigured` fields on `SystemInfo`
 - `cmd/setup.go` — connection pre-check moved earlier, dispatches on new method constants
-

--- a/openspec/changes/cloud-install-ux-improvement/proposal.md
+++ b/openspec/changes/cloud-install-ux-improvement/proposal.md
@@ -1,3 +1,5 @@
+# Proposal: Cloud Install UX Improvement
+
 ## Why
 
 Two UX gaps for cloud installs: the watch screen footer links to QuickStart (which doesn't show cloud resources yet), and the setup menu doesn't distinguish install vs update for Azure/GCP. OTel recommendation wording also needed clarification.
@@ -13,6 +15,7 @@ Two UX gaps for cloud installs: the watch screen footer links to QuickStart (whi
 ## Capabilities
 
 ### New Capabilities
+
 - `cloud-install-footer`: Footer variant for cloud installs linking to the Clouds app.
 - `cloud-recommend-ux`: Recommender and setup menu distinguish install vs update for Azure/GCP; OTel wording fixes.
 
@@ -25,3 +28,4 @@ Two UX gaps for cloud installs: the watch screen footer links to QuickStart (whi
 - `pkg/recommender/recommender.go` — new methods, updated titles
 - `pkg/analyzer/analyzer.go` — `AzureConfigured`, `GCPConfigured` fields on `SystemInfo`
 - `cmd/setup.go` — connection pre-check moved earlier, dispatches on new method constants
+

--- a/openspec/changes/cloud-install-ux-improvement/proposal.md
+++ b/openspec/changes/cloud-install-ux-improvement/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Two UX gaps for cloud installs: the watch screen footer links to QuickStart (which doesn't show cloud resources yet), and the setup menu doesn't distinguish install vs update for Azure/GCP. OTel recommendation wording also needed clarification.
+
+## What Changes
+
+- Watch screen footer shows "See your cloud resources in the Clouds app" with an "Open Clouds" link for AWS, GCP, and Azure installs.
+- All other install methods keep the existing QuickStart footer.
+- Setup menu shows "Azure cloud services (update)" / "GCP cloud services (update)" when already configured.
+- Recommender emits distinct `MethodAzureUpdate` / `MethodGCPUpdate` methods so setup dispatches correctly without local boolean state.
+- OTel wording: "patch existing" → "update existing"; "via OpenTelemetry" → "via new OpenTelemetry Collector".
+
+## Capabilities
+
+### New Capabilities
+- `cloud-install-footer`: Footer variant for cloud installs linking to the Clouds app.
+- `cloud-recommend-ux`: Recommender and setup menu distinguish install vs update for Azure/GCP; OTel wording fixes.
+
+### Modified Capabilities
+
+## Impact
+
+- `pkg/installer/ingest_watch.go` — footer rendering logic
+- `pkg/installer/gcp/install.go`, `pkg/installer/azure/install.go` — call site changes
+- `pkg/recommender/recommender.go` — new methods, updated titles
+- `pkg/analyzer/analyzer.go` — `AzureConfigured`, `GCPConfigured` fields on `SystemInfo`
+- `cmd/setup.go` — connection pre-check moved earlier, dispatches on new method constants

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Cloud installs show Clouds app footer
+After a successful AWS, GCP, or Azure install, the watch screen footer SHALL display "See your cloud resources in the Clouds app" with a link labelled "Open Clouds" pointing to `<appsURL>/ui/apps/dynatrace.clouds/smartscape/services`.
+
+#### Scenario: AWS install footer
+- **WHEN** `dtwiz install aws` completes and the watch screen renders
+- **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
+
+#### Scenario: GCP install footer
+- **WHEN** `dtwiz install gcp` completes and the watch screen renders
+- **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
+
+#### Scenario: Azure install footer
+- **WHEN** `dtwiz install azure` completes and the watch screen renders
+- **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
+
+### Requirement: Non-cloud installs keep QuickStart footer
+For all other install methods, the watch screen footer SHALL continue to show "See all your data and findings in Dynatrace QuickStart" with an "Open Dynatrace QuickStart" link.
+
+#### Scenario: OneAgent/OTel/Docker/K8s footer unchanged
+- **WHEN** any non-cloud install completes and the watch screen renders
+- **THEN** the footer shows the QuickStart link, not the Clouds app link

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
@@ -1,23 +1,32 @@
+# Cloud Install Footer Specification
+
 ## ADDED Requirements
 
 ### Requirement: Cloud installs show Clouds app footer
+
 After a successful AWS, GCP, or Azure install, the watch screen footer SHALL display "See your cloud resources in the Clouds app" with a link labelled "Open Clouds" pointing to `<appsURL>/ui/apps/dynatrace.clouds/smartscape/services`.
 
 #### Scenario: AWS install footer
+
 - **WHEN** `dtwiz install aws` completes and the watch screen renders
 - **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
 
 #### Scenario: GCP install footer
+
 - **WHEN** `dtwiz install gcp` completes and the watch screen renders
 - **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
 
 #### Scenario: Azure install footer
+
 - **WHEN** `dtwiz install azure` completes and the watch screen renders
 - **THEN** the footer shows "See your cloud resources in the Clouds app" and "Open Clouds" linking to the tenant's Clouds app URL
 
 ### Requirement: Non-cloud installs keep QuickStart footer
+
 For all other install methods, the watch screen footer SHALL continue to show "See all your data and findings in Dynatrace QuickStart" with an "Open Dynatrace QuickStart" link.
 
 #### Scenario: OneAgent/OTel/Docker/K8s footer unchanged
+
 - **WHEN** any non-cloud install completes and the watch screen renders
 - **THEN** the footer shows the QuickStart link, not the Clouds app link
+

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-install-footer/spec.md
@@ -29,4 +29,3 @@ For all other install methods, the watch screen footer SHALL continue to show "S
 
 - **WHEN** any non-cloud install completes and the watch screen renders
 - **THEN** the footer shows the QuickStart link, not the Clouds app link
-

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
@@ -48,4 +48,3 @@ The OTel update recommendation SHALL read "update existing OpenTelemetry Collect
 
 - **WHEN** no OTel Collector is running and `dtwiz setup` or `dtwiz recommend` lists recommendations
 - **THEN** the title contains "via new OpenTelemetry Collector"
-

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Setup menu distinguishes install vs update for Azure and GCP
+When Azure or GCP is already configured, the recommender SHALL emit a distinct update method (`MethodAzureUpdate` / `MethodGCPUpdate`) and title ("Azure cloud services (update)" / "GCP cloud services (update)"). Setup SHALL dispatch on these constants directly, without local boolean state.
+
+#### Scenario: Azure already configured — menu shows update
+- **WHEN** `dtwiz setup` runs and Azure is already configured
+- **THEN** the menu shows "Azure cloud services (update)" and selecting it runs the update flow
+
+#### Scenario: GCP already configured — menu shows update
+- **WHEN** `dtwiz setup` runs and GCP is already configured
+- **THEN** the menu shows "GCP cloud services (update)" and selecting it runs the update flow
+
+#### Scenario: Azure not configured — menu shows install
+- **WHEN** `dtwiz setup` runs and Azure is not configured
+- **THEN** the menu shows "Azure cloud services" and selecting it runs the install flow
+
+#### Scenario: GCP not configured — menu shows install
+- **WHEN** `dtwiz setup` runs and GCP is not configured
+- **THEN** the menu shows "GCP cloud services" and selecting it runs the install flow
+
+### Requirement: Connection pre-check runs before recommendations
+Setup SHALL check Azure and GCP connection status before generating recommendations, so the recommender receives accurate `AzureConfigured` / `GCPConfigured` state.
+
+#### Scenario: Pre-check feeds recommender
+- **WHEN** `dtwiz setup` runs
+- **THEN** Azure and GCP connection checks complete before `GenerateRecommendations` is called
+
+### Requirement: OTel recommendation titles use consistent wording
+The OTel update recommendation SHALL read "update existing OpenTelemetry Collector" (not "patch"). The new collector recommendation SHALL read "via new OpenTelemetry Collector".
+
+#### Scenario: OTel update title
+- **WHEN** an OTel Collector is already running and `dtwiz setup` or `dtwiz recommend` lists recommendations
+- **THEN** the title contains "update existing OpenTelemetry Collector"
+
+#### Scenario: New OTel collector title
+- **WHEN** no OTel Collector is running and `dtwiz setup` or `dtwiz recommend` lists recommendations
+- **THEN** the title contains "via new OpenTelemetry Collector"

--- a/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
+++ b/openspec/changes/cloud-install-ux-improvement/specs/cloud-recommend-ux/spec.md
@@ -1,38 +1,51 @@
+# Cloud Recommend UX Specification
+
 ## ADDED Requirements
 
 ### Requirement: Setup menu distinguishes install vs update for Azure and GCP
+
 When Azure or GCP is already configured, the recommender SHALL emit a distinct update method (`MethodAzureUpdate` / `MethodGCPUpdate`) and title ("Azure cloud services (update)" / "GCP cloud services (update)"). Setup SHALL dispatch on these constants directly, without local boolean state.
 
 #### Scenario: Azure already configured — menu shows update
+
 - **WHEN** `dtwiz setup` runs and Azure is already configured
 - **THEN** the menu shows "Azure cloud services (update)" and selecting it runs the update flow
 
 #### Scenario: GCP already configured — menu shows update
+
 - **WHEN** `dtwiz setup` runs and GCP is already configured
 - **THEN** the menu shows "GCP cloud services (update)" and selecting it runs the update flow
 
 #### Scenario: Azure not configured — menu shows install
+
 - **WHEN** `dtwiz setup` runs and Azure is not configured
 - **THEN** the menu shows "Azure cloud services" and selecting it runs the install flow
 
 #### Scenario: GCP not configured — menu shows install
+
 - **WHEN** `dtwiz setup` runs and GCP is not configured
 - **THEN** the menu shows "GCP cloud services" and selecting it runs the install flow
 
 ### Requirement: Connection pre-check runs before recommendations
+
 Setup SHALL check Azure and GCP connection status before generating recommendations, so the recommender receives accurate `AzureConfigured` / `GCPConfigured` state.
 
 #### Scenario: Pre-check feeds recommender
+
 - **WHEN** `dtwiz setup` runs
 - **THEN** Azure and GCP connection checks complete before `GenerateRecommendations` is called
 
 ### Requirement: OTel recommendation titles use consistent wording
+
 The OTel update recommendation SHALL read "update existing OpenTelemetry Collector" (not "patch"). The new collector recommendation SHALL read "via new OpenTelemetry Collector".
 
 #### Scenario: OTel update title
+
 - **WHEN** an OTel Collector is already running and `dtwiz setup` or `dtwiz recommend` lists recommendations
 - **THEN** the title contains "update existing OpenTelemetry Collector"
 
 #### Scenario: New OTel collector title
+
 - **WHEN** no OTel Collector is running and `dtwiz setup` or `dtwiz recommend` lists recommendations
 - **THEN** the title contains "via new OpenTelemetry Collector"
+

--- a/openspec/changes/cloud-install-ux-improvement/tasks.md
+++ b/openspec/changes/cloud-install-ux-improvement/tasks.md
@@ -1,3 +1,5 @@
+# Cloud Install UX Improvement Tasks
+
 ## 1. Core Implementation
 
 - [x] 1.1 Add `cloudInstall bool` param to `watchIngest` in `pkg/installer/ingest_watch.go`
@@ -24,3 +26,4 @@
 
 - [x] 4.1 Verify build passes: `make build`
 - [x] 4.2 Verify tests pass: `make test`
+

--- a/openspec/changes/cloud-install-ux-improvement/tasks.md
+++ b/openspec/changes/cloud-install-ux-improvement/tasks.md
@@ -1,0 +1,26 @@
+## 1. Core Implementation
+
+- [x] 1.1 Add `cloudInstall bool` param to `watchIngest` in `pkg/installer/ingest_watch.go`
+- [x] 1.2 Render Clouds app footer when `cloudInstall` is true; keep QuickStart footer otherwise
+- [x] 1.3 Add exported `WatchIngestCloud` function calling `watchIngest` with `cloudInstall: true`
+- [x] 1.4 Update `WatchIngestAWS` to pass `cloudInstall: true`
+- [x] 1.5 Update existing `WatchIngest` and `WatchIngestWithStatus` callers to pass `cloudInstall: false`
+
+## 2. Call Site Updates
+
+- [x] 2.1 Update `pkg/installer/gcp/install.go` — replace `installer.WatchIngest` with `installer.WatchIngestCloud`
+- [x] 2.2 Update `pkg/installer/azure/install.go` — replace `installer.WatchIngest` with `installer.WatchIngestCloud`
+
+## 3. Recommender UX (af173ca)
+
+- [x] 3.1 Add `AzureConfigured`, `GCPConfigured` to `SystemInfo` in `pkg/analyzer/analyzer.go`
+- [x] 3.2 Add `MethodAzureUpdate`, `MethodGCPUpdate` constants in `pkg/recommender/recommender.go`
+- [x] 3.3 Emit update method + title when already configured in `GenerateRecommendations`
+- [x] 3.4 Fix OTel titles: "patch" → "update", add "new" to collector title
+- [x] 3.5 Move connection pre-check before recommendations in `cmd/setup.go`
+- [x] 3.6 Dispatch on `MethodAzureUpdate`/`MethodGCPUpdate` in setup switch; remove local boolean state
+
+## 4. Tests
+
+- [x] 4.1 Verify build passes: `make build`
+- [x] 4.2 Verify tests pass: `make test`

--- a/openspec/changes/cloud-install-ux-improvement/tasks.md
+++ b/openspec/changes/cloud-install-ux-improvement/tasks.md
@@ -26,4 +26,3 @@
 
 - [x] 4.1 Verify build passes: `make build`
 - [x] 4.2 Verify tests pass: `make test`
-

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -144,7 +144,9 @@ type SystemInfo struct {
 	OtelConfigPath   string           `json:"otel_config_path,omitempty"`
 	AWS              *AWSInfo         `json:"aws,omitempty"`
 	Azure            *AzureInfo       `json:"azure,omitempty"`
+	AzureConfigured  bool             `json:"azure_configured,omitempty"`
 	GCP              *GCPInfo         `json:"gcp,omitempty"`
+	GCPConfigured    bool             `json:"gcp_configured,omitempty"`
 	Services         []string         `json:"services"`
 }
 

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -197,7 +197,7 @@ func azureWatchIngest(cfg azureConfig, startTime time.Time) {
 		return
 	}
 	fromClause := startTime.UTC().Format("2006-01-02T15:04:05Z")
-	installer.WatchIngest(cfg.EnvURL, cfg.PlatformToken, fromClause)
+	installer.WatchIngestCloud(cfg.EnvURL, cfg.PlatformToken, fromClause)
 }
 
 func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Duration), dtc dtclient) error {

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -97,8 +97,8 @@ func azurePartialFailureHint(cfg azureConfig, completedSteps map[int]bool) {
 		return
 	}
 	fmt.Println()
-	display.ColorWarning.Println("  The following resources were already created and may need to be cleaned up")
-	display.ColorWarning.Println("  (or just re-run `dtwiz uninstall azure`, which removes them all):")
+	display.ColorWarning.Println("  Installation stopped. Resources created so far need to be cleaned up")
+	display.ColorWarning.Println("  (run `dtwiz uninstall azure` to remove them all, or delete manually):")
 	if completedSteps[1] {
 		fmt.Printf("    • DT connection '%s': delete with: dtctl delete azure connection --name %s\n",
 			cfg.ConnectionName, cfg.ConnectionName)

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -126,8 +126,8 @@ func gcpPartialFailureHint(cfg gcpConfig, completedSteps map[int]bool) {
 	}
 	saEmail := cfg.serviceAccountEmail()
 	fmt.Println()
-	display.ColorWarning.Println("  The following resources were already created and may need to be cleaned up")
-	display.ColorWarning.Println("  (or just re-run `dtwiz uninstall gcp`, which removes them all):")
+	display.ColorWarning.Println("  Installation stopped. Resources created so far need to be cleaned up")
+	display.ColorWarning.Println("  (run `dtwiz uninstall gcp` to remove them all, or delete manually):")
 	if completedSteps[2] {
 		fmt.Printf("    • DT connection '%s': delete with: dtctl delete gcp connection --name %s\n",
 			cfg.ConnectionName, cfg.ConnectionName)

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -250,7 +250,7 @@ func gcpWatchIngest(cfg gcpConfig, startTime time.Time) {
 		return
 	}
 	fromClause := startTime.UTC().Format("2006-01-02T15:04:05Z")
-	installer.WatchIngest(cfg.EnvURL, cfg.PlatformToken, fromClause)
+	installer.WatchIngestCloud(cfg.EnvURL, cfg.PlatformToken, fromClause)
 }
 
 func runInstallSteps(cfg gcpConfig, runner cmdRunner, sleeper func(time.Duration), dtc dtclient) error {

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fatih/color"
 	"golang.org/x/term"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -96,7 +97,7 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 	_ = green
 
 	linkFn := func(url, label string) string {
-		return termHyperlink(url, label, isTTY)
+		return termHyperlink(url, label, display.StdoutSupportsHyperlinks())
 	}
 
 	var prevLines int

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -53,7 +53,7 @@ type watchState struct {
 // fromClause is injected directly into DQL queries — accepts RFC3339 timestamps
 // or DQL relative expressions (e.g. "now()-1h").
 func WatchIngest(envURL, pToken, fromClause string) {
-	watchIngest(envURL, pToken, fromClause, nil, "")
+	watchIngest(envURL, pToken, fromClause, nil, "", false)
 }
 
 // WatchIngestWithStatus is like WatchIngest but displays a background-task
@@ -61,17 +61,24 @@ func WatchIngest(envURL, pToken, fromClause string) {
 // The caller sends status messages to statusCh; the most recent message is
 // shown on every render. Passing a nil channel disables status updates.
 func WatchIngestWithStatus(envURL, pToken, fromClause string, statusCh <-chan string) {
-	watchIngest(envURL, pToken, fromClause, statusCh, "")
+	watchIngest(envURL, pToken, fromClause, statusCh, "", false)
 }
 
 // WatchIngestAWS is like WatchIngestWithStatus but additionally scopes the
 // cloud-platform signal queries (metrics + da-* logs) to a specific AWS
 // account ID so noise from other accounts in the same tenant is filtered out.
 func WatchIngestAWS(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string) {
-	watchIngest(envURL, pToken, fromClause, statusCh, awsAccountID)
+	watchIngest(envURL, pToken, fromClause, statusCh, awsAccountID, true)
 }
 
-func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string) {
+// WatchIngestCloud is like WatchIngest but shows a "See your cloud resources
+// in the Clouds app" footer instead of the QuickStart link. Use this for
+// AWS, GCP, and Azure installs.
+func WatchIngestCloud(envURL, pToken, fromClause string) {
+	watchIngest(envURL, pToken, fromClause, nil, "", true)
+}
+
+func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string, cloudInstall bool) {
 	if pToken == "" {
 		fmt.Println("  Platform token required for watch. Set --platform-token or DT_PLATFORM_TOKEN.")
 		return
@@ -163,11 +170,16 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 		renderSection(&buf, "Requests", state.Requests, appsURL, highlight, dim, bold, linkFn)
 		renderSection(&buf, "Exceptions", state.Exceptions, appsURL, highlight, dim, bold, linkFn)
 
-		// QuickStart footer
+		// Footer
 		separator := " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
 		highlight.Fprint(&buf, separator)
-		highlight.Fprintf(&buf, " 👉 See all your data and findings in Dynatrace QuickStart\n")
-		fmt.Fprintf(&buf, "    %s\n", linkFn(appsURL+"/ui/apps/dynatrace.quickstart/", "→ Open Dynatrace QuickStart"))
+		if cloudInstall {
+			highlight.Fprintf(&buf, " 👉 See your cloud resources in the Clouds app\n")
+			fmt.Fprintf(&buf, "    %s\n", linkFn(appsURL+"/ui/apps/dynatrace.clouds/smartscape/services", "→ Open Clouds"))
+		} else {
+			highlight.Fprintf(&buf, " 👉 See all your data and findings in Dynatrace QuickStart\n")
+			fmt.Fprintf(&buf, "    %s\n", linkFn(appsURL+"/ui/apps/dynatrace.quickstart/", "→ Open Dynatrace QuickStart"))
+		}
 		highlight.Fprint(&buf, separator)
 		buf.WriteString("\n")
 		dim.Fprint(&buf, " Press Enter to continue or keep watching...")

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -23,7 +23,9 @@ const (
 	MethodOtelUpdate       IngestMethod = "otel-update"
 	MethodAWS              IngestMethod = "aws"
 	MethodAzure            IngestMethod = "azure"
+	MethodAzureUpdate      IngestMethod = "azure-update"
 	MethodGCP              IngestMethod = "gcp"
+	MethodGCPUpdate        IngestMethod = "gcp-update"
 	MethodAlreadyInstalled IngestMethod = "already-installed"
 	MethodNotSupported     IngestMethod = "not-supported"
 )
@@ -69,7 +71,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		recs = append(recs, Recommendation{
 			Method:   MethodOtelUpdate,
 			Priority: 0,
-			Title:    "This machine's services (patch existing OpenTelemetry Collector)",
+			Title:    "This machine's services (update existing OpenTelemetry Collector)",
 			Description: fmt.Sprintf(
 				"An OpenTelemetry Collector is running%s. Add the Dynatrace OTLP exporter to send telemetry to Dynatrace.",
 				configHint,
@@ -87,7 +89,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 	recs = append(recs, Recommendation{
 		Method:        MethodOtelCollector,
 		Priority:      0,
-		Title:         "This machine's services (via OpenTelemetry)",
+		Title:         "This machine's services (via new OpenTelemetry Collector)",
 		Description:   "Deploy the Dynatrace OpenTelemetry Collector to ingest traces, metrics, and logs via OTLP.",
 		Prerequisites: []string{"Dynatrace API token with ingest scopes"},
 		Steps: []string{
@@ -161,20 +163,32 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 
 	// 8. Azure detected.
 	if system.Azure != nil && system.Azure.Available {
+		method := MethodAzure
+		title := "Azure cloud services"
+		if system.AzureConfigured {
+			method = MethodAzureUpdate
+			title = "Azure cloud services (update)"
+		}
 		recs = append(recs, Recommendation{
-			Method:      MethodAzure,
+			Method:      method,
 			Priority:    50,
-			Title:       "Azure cloud services",
+			Title:       title,
 			Description: fmt.Sprintf("Azure subscription detected (%s).", system.Azure.SubscriptionID),
 		})
 	}
 
 	// 9. GCP detected.
 	if system.GCP != nil && system.GCP.Available {
+		method := MethodGCP
+		title := "GCP cloud services"
+		if system.GCPConfigured {
+			method = MethodGCPUpdate
+			title = "GCP cloud services (update)"
+		}
 		recs = append(recs, Recommendation{
-			Method:      MethodGCP,
+			Method:      method,
 			Priority:    50,
-			Title:       "GCP cloud services",
+			Title:       title,
 			Description: fmt.Sprintf("GCP project detected (%s).", system.GCP.ProjectID),
 		})
 	}

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -228,6 +228,9 @@ func TestGenerateRecommendations_Azure(t *testing.T) {
 			if r.ComingSoon {
 				t.Error("expected ComingSoon=false for Azure recommendation")
 			}
+			if r.Title != "Azure cloud services" {
+				t.Errorf("expected title %q, got %q", "Azure cloud services", r.Title)
+			}
 		}
 	}
 	if !found {
@@ -254,6 +257,9 @@ func TestGenerateRecommendations_AzureConfigured(t *testing.T) {
 		}
 		if r.Method == recommender.MethodAzureUpdate {
 			foundUpdate = true
+			if r.Title != "Azure cloud services (update)" {
+				t.Errorf("expected title %q, got %q", "Azure cloud services (update)", r.Title)
+			}
 		}
 	}
 	if !foundUpdate {
@@ -278,6 +284,9 @@ func TestGenerateRecommendations_GCP(t *testing.T) {
 			found = true
 			if r.ComingSoon {
 				t.Error("expected ComingSoon=false for GCP recommendation")
+			}
+			if r.Title != "GCP cloud services" {
+				t.Errorf("expected title %q, got %q", "GCP cloud services", r.Title)
 			}
 		}
 	}
@@ -305,6 +314,9 @@ func TestGenerateRecommendations_GCPConfigured(t *testing.T) {
 		}
 		if r.Method == recommender.MethodGCPUpdate {
 			foundUpdate = true
+			if r.Title != "GCP cloud services (update)" {
+				t.Errorf("expected title %q, got %q", "GCP cloud services (update)", r.Title)
+			}
 		}
 	}
 	if !foundUpdate {

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -231,7 +231,33 @@ func TestGenerateRecommendations_Azure(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("expected azure recommendation when Azure is available")
+		t.Error("expected azure install recommendation when Azure is available and not configured")
+	}
+}
+
+func TestGenerateRecommendations_AzureConfigured(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimeNone,
+		Orchestrator:     analyzer.OrchestratorNone,
+		Azure: &analyzer.AzureInfo{
+			Available:      true,
+			SubscriptionID: "sub-123",
+		},
+		AzureConfigured: true,
+	}
+	recs := recommender.GenerateRecommendations(system)
+	foundUpdate := false
+	for _, r := range recs {
+		if r.Method == recommender.MethodAzure {
+			t.Error("expected MethodAzureUpdate, not MethodAzure, when Azure is already configured")
+		}
+		if r.Method == recommender.MethodAzureUpdate {
+			foundUpdate = true
+		}
+	}
+	if !foundUpdate {
+		t.Error("expected azure-update recommendation when Azure is available and already configured")
 	}
 }
 
@@ -256,7 +282,33 @@ func TestGenerateRecommendations_GCP(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("expected gcp recommendation when GCP is available")
+		t.Error("expected gcp install recommendation when GCP is available and not configured")
+	}
+}
+
+func TestGenerateRecommendations_GCPConfigured(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimeNone,
+		Orchestrator:     analyzer.OrchestratorNone,
+		GCP: &analyzer.GCPInfo{
+			Available: true,
+			ProjectID: "my-project",
+		},
+		GCPConfigured: true,
+	}
+	recs := recommender.GenerateRecommendations(system)
+	foundUpdate := false
+	for _, r := range recs {
+		if r.Method == recommender.MethodGCP {
+			t.Error("expected MethodGCPUpdate, not MethodGCP, when GCP is already configured")
+		}
+		if r.Method == recommender.MethodGCPUpdate {
+			foundUpdate = true
+		}
+	}
+	if !foundUpdate {
+		t.Error("expected gcp-update recommendation when GCP is available and already configured")
 	}
 }
 


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): UX wording improvements

Improvements:
- recommender option labels for install and update cases
- Cloud install watch links to the Clouds app, since QuickStart does not show cloud resources yet.

## How to test

1. Make sure you have an Azure and GCP account
2. log in to each cloud provider and select the project/subscription
3. Run `dtwiz setup` and notice both GCP and Azure are shown as logged in
4. install one of them
5. Run `dtwiz setup` when Azure or GCP is already configured and verify the menu shows the "update" label.
6. Complete any cloud install (GCP, or Azure) and verify the watch screen footer says "Open Clouds", not "Open Dynatrace QuickStart".
7. run `dtwiz uninstall [gcp/azure]` (write only the Cloud provider you selected) - testing with 1 is enough, but you are free to test with more
8. Run `dtwiz setup` and this time install Otel monitoring
9. Run `dtwiz recommend` on a machine with an existing OTel Collector and verify the title says "update existing OpenTelemetry Collector".
10. Run `dtwiz uninstall otel` to clean up OTel.

(one cloud provider is enough to test the PR)

## Which other features are affected

1. `dtwiz setup` recommend and dispatch flow.
2. AWS, GCP, and Azure install watch component (footer change).

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
