### PR TITLE
fix: show preview notice when GCP principal is not provisioned

### DIFF
--- a/pkg/installer/gcp/dtapi.go
+++ b/pkg/installer/gcp/dtapi.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -65,6 +66,11 @@ const (
 
 	gcpFeatureSetEnumKey = "FeatureSetsType"
 )
+
+// errNoPrincipal is returned by dtServiceAccount when the gcp-dynatrace-principal
+// schema exists but contains no service-account email — indicating the GCP integration
+// is not yet provisioned on this tenant (currently a Preview feature).
+var errNoPrincipal = errors.New("no Dynatrace GCP principal found")
 
 type connRef struct {
 	objectID            string
@@ -134,7 +140,10 @@ func (d *sdkDTClient) createConnection(name string) (string, error) {
 // gcp-dynatrace-principal schema. The exact field name is environment-managed,
 // so the value is located by scanning for a Google service-account email.
 func (d *sdkDTClient) dtServiceAccount() (string, error) {
-	list, err := d.Settings.ListObjects(context.Background(), dtPrincipalSchemaID, "environment", 0)
+	// Same quirk as findAllConnections: filtering by scopes=environment returns zero
+	// results for this schema even when the object is environment-scoped — drop the
+	// filter so the query param is omitted entirely.
+	list, err := d.Settings.ListObjects(context.Background(), dtPrincipalSchemaID, "", 0)
 	if err != nil {
 		return "", fmt.Errorf("resolve Dynatrace GCP principal: %w", err)
 	}
@@ -144,7 +153,7 @@ func (d *sdkDTClient) dtServiceAccount() (string, error) {
 			return email, nil
 		}
 	}
-	return "", fmt.Errorf("no Dynatrace GCP principal found under schema %q", dtPrincipalSchemaID)
+	return "", errNoPrincipal
 }
 
 func (d *sdkDTClient) updateConnection(objectID, name, serviceAccountEmail string) error {

--- a/pkg/installer/gcp/dtapi_test.go
+++ b/pkg/installer/gcp/dtapi_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -83,8 +84,8 @@ func TestSDKDTServiceAccount_NotFound(t *testing.T) {
 	defer srv.Close()
 
 	_, err := newTestSDKClient(t, srv.URL).dtServiceAccount()
-	if err == nil {
-		t.Fatal("expected error when no principal found, got nil")
+	if !errors.Is(err, errNoPrincipal) {
+		t.Fatalf("expected errNoPrincipal, got %v", err)
 	}
 }
 

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -202,6 +203,10 @@ func installGCPWithRunner(
 
 	dtPrincipal, err := dtc.dtServiceAccount()
 	if err != nil {
+		if errors.Is(err, errNoPrincipal) {
+			fmt.Println("  GCP is currently in Preview. Please first subscribe to it on https://docs.dynatrace.com/docs/whats-new/preview-releases.")
+			return installer.ErrInstallCancelled
+		}
 		return fmt.Errorf("resolving Dynatrace principal: %w", err)
 	}
 

--- a/pkg/installer/gcp/install_test.go
+++ b/pkg/installer/gcp/install_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -181,6 +182,40 @@ func TestGCPDTPrincipalUnresolvedFailsBeforeMutations(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when DT principal cannot be resolved, got nil")
+	}
+	if mutating != 0 {
+		t.Errorf("expected 0 mutating gcloud calls, got %d", mutating)
+	}
+}
+
+func TestGCPPreviewNoticeWhenNoPrincipal(t *testing.T) {
+	defer stubExecLookPath(t)()
+
+	mutating := 0
+	dtc := happyFakeDTClient()
+	dtc.dtSAErr = errNoPrincipal
+
+	var out string
+	err := func() error {
+		r, w, _ := os.Pipe()
+		old := os.Stdout
+		os.Stdout = w
+		runErr := installGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, happyGcloudRunner(&mutating), noSleep, dtc)
+		os.Stdout = old
+		w.Close()
+		b, _ := io.ReadAll(r)
+		out = string(b)
+		return runErr
+	}()
+
+	if !errors.Is(err, installer.ErrInstallCancelled) {
+		t.Fatalf("expected ErrInstallCancelled, got: %v", err)
+	}
+	if !strings.Contains(out, "Preview") {
+		t.Errorf("expected Preview notice in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "docs.dynatrace.com") {
+		t.Errorf("expected docs URL in output; got:\n%s", out)
 	}
 	if mutating != 0 {
 		t.Errorf("expected 0 mutating gcloud calls, got %d", mutating)


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. use `https://bzu85488.apps.dynatrace.com/` and platform token from that env
2. make sure gcp is not enabled on that env (by checking settings app)
3. make sure you are connected to gcp cloud
4. run `dtwiz setup`, select `gcp`
5. make sure `GCP is currently in Preview. Please first subscribe to it on https://docs.dynatrace.com/docs/whats-new/preview-releases. ` is visible and dtwiz exits.
6. now use any dev tenant, make sure gcp is enabled on that tenant
7. run `dtwiz setup`, select `gcp`
8. make sure gcp is installed

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
