### PR TITLE
fix: improve parsing of aws url

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Two URL families — getting this wrong causes 404s or auth errors:
 
 **URL conversion helpers in `pkg/installer/installer.go`:**
 
-- `APIURL()` / `ClassicAPIURL()` — strip `.apps.` → classic URL
+- `APIURL()` — strip `.apps.` → classic URL (also trims trailing slash)
 - `AppsURL()` — insert `.apps.` → platform URL
 - `ExtractTenantID()` — first DNS label from URL
 

--- a/pkg/display/tty.go
+++ b/pkg/display/tty.go
@@ -21,7 +21,14 @@ func stdoutSupportsHyperlinks() bool {
 	// Apple Terminal renders OSC 8 as underlined text but doesn't provide a
 	// right-click "Open URL" option. Fall back to plain text so its built-in
 	// URL detection can make the URL itself right-clickable.
-	return os.Getenv("TERM_PROGRAM") != "Apple_Terminal"
+	if os.Getenv("TERM_PROGRAM") == "Apple_Terminal" {
+		return false
+	}
+	// AWS CloudShell doesn't render OSC 8 hyperlinks.
+	if os.Getenv("AWS_EXECUTION_ENV") == "CloudShell" {
+		return false
+	}
+	return true
 }
 
 // StdoutSupportsHyperlinks reports whether stdout supports OSC 8 hyperlinks.

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -68,7 +68,6 @@ func isAWSCLIInstalled() bool {
 	return err == nil
 }
 
-// promptLine prints a prompt, reads a single line from stdin and trims
 // getAWSCallerInfo returns the AWS account ID and the configured default region.
 func getAWSCallerInfo() (accountID, region string, err error) {
 	// Account ID from STS

--- a/pkg/installer/aws.go
+++ b/pkg/installer/aws.go
@@ -69,17 +69,6 @@ func isAWSCLIInstalled() bool {
 }
 
 // promptLine prints a prompt, reads a single line from stdin and trims
-// classicAPIURL strips the ".apps." segment from a Dynatrace apps URL so that
-// requests target the classic /api/v2 endpoint.
-//
-//	https://abc.apps.dynatracelabs.com  ->  https://abc.dynatracelabs.com
-func classicAPIURL(envURL string) string {
-	envURL = strings.TrimRight(envURL, "/")
-	envURL = strings.ReplaceAll(envURL, ".apps.dynatracelabs.com", ".dynatracelabs.com")
-	envURL = strings.ReplaceAll(envURL, ".apps.dynatrace.com", ".dynatrace.com")
-	return envURL
-}
-
 // getAWSCallerInfo returns the AWS account ID and the configured default region.
 func getAWSCallerInfo() (accountID, region string, err error) {
 	// Account ID from STS

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -171,7 +171,7 @@ func listLambdaFunctions() ([]lambdaFunction, error) {
 // getDTConnectionInfo calls the Dynatrace connection info API to obtain tenant
 // UUID and cluster ID for Lambda env vars.
 func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
-	apiURL := ClassicAPIURL(envURL)
+	apiURL := APIURL(envURL)
 	endpoint := apiURL + "/api/v1/deployment/installer/agent/connectioninfo"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -217,7 +217,7 @@ func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
 	return &dtConnectionInfo{
 		TenantUUID: info.TenantUUID,
 		ClusterID:  clusterID,
-		BaseURL:    ClassicAPIURL(envURL),
+		BaseURL:    APIURL(envURL),
 		Token:      connToken,
 	}, nil
 }
@@ -225,7 +225,7 @@ func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
 // getClusterID fetches the numeric cluster ID from the Dynatrace Classic API.
 // Endpoint: GET /api/v1/config/clusterid → { "clusterId": 997993252 }
 func getClusterID(envURL, token string) (string, error) {
-	apiURL := ClassicAPIURL(envURL)
+	apiURL := APIURL(envURL)
 	endpoint := apiURL + "/api/v1/config/clusterid"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -268,7 +268,7 @@ func getClusterID(envURL, token string) (string, error) {
 // Endpoint: GET /api/v2/tokens/agentConnectionToken
 // Required scope: environment-api:agent-connection-tokens:read
 func getAgentConnectionToken(envURL, token string) (string, error) {
-	apiURL := ClassicAPIURL(envURL)
+	apiURL := APIURL(envURL)
 	endpoint := apiURL + "/api/v2/agentConnectionToken"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -324,7 +324,7 @@ func getLambdaLayerARN(cache layerARNCache, envURL, token, techtype, arch, regio
 		return arn, nil
 	}
 
-	apiURL := ClassicAPIURL(envURL)
+	apiURL := APIURL(envURL)
 	endpoint := fmt.Sprintf("%s/api/v1/deployment/lambda/layer?arch=%s&techtype=%s&region=%s&withCollector=excluded",
 		apiURL, archToDTArch(arch), techtype, region)
 

--- a/pkg/installer/aws_lambda.go
+++ b/pkg/installer/aws_lambda.go
@@ -171,7 +171,7 @@ func listLambdaFunctions() ([]lambdaFunction, error) {
 // getDTConnectionInfo calls the Dynatrace connection info API to obtain tenant
 // UUID and cluster ID for Lambda env vars.
 func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
-	apiURL := classicAPIURL(envURL)
+	apiURL := ClassicAPIURL(envURL)
 	endpoint := apiURL + "/api/v1/deployment/installer/agent/connectioninfo"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -217,7 +217,7 @@ func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
 	return &dtConnectionInfo{
 		TenantUUID: info.TenantUUID,
 		ClusterID:  clusterID,
-		BaseURL:    classicAPIURL(envURL),
+		BaseURL:    ClassicAPIURL(envURL),
 		Token:      connToken,
 	}, nil
 }
@@ -225,7 +225,7 @@ func getDTConnectionInfo(envURL, token string) (*dtConnectionInfo, error) {
 // getClusterID fetches the numeric cluster ID from the Dynatrace Classic API.
 // Endpoint: GET /api/v1/config/clusterid → { "clusterId": 997993252 }
 func getClusterID(envURL, token string) (string, error) {
-	apiURL := classicAPIURL(envURL)
+	apiURL := ClassicAPIURL(envURL)
 	endpoint := apiURL + "/api/v1/config/clusterid"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -268,7 +268,7 @@ func getClusterID(envURL, token string) (string, error) {
 // Endpoint: GET /api/v2/tokens/agentConnectionToken
 // Required scope: environment-api:agent-connection-tokens:read
 func getAgentConnectionToken(envURL, token string) (string, error) {
-	apiURL := classicAPIURL(envURL)
+	apiURL := ClassicAPIURL(envURL)
 	endpoint := apiURL + "/api/v2/agentConnectionToken"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -324,7 +324,7 @@ func getLambdaLayerARN(cache layerARNCache, envURL, token, techtype, arch, regio
 		return arn, nil
 	}
 
-	apiURL := classicAPIURL(envURL)
+	apiURL := ClassicAPIURL(envURL)
 	endpoint := fmt.Sprintf("%s/api/v1/deployment/lambda/layer?arch=%s&techtype=%s&region=%s&withCollector=excluded",
 		apiURL, archToDTArch(arch), techtype, region)
 

--- a/pkg/installer/aws_lambda_test.go
+++ b/pkg/installer/aws_lambda_test.go
@@ -440,9 +440,9 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-// TestLambdaAPIClassicURL is a regression test: *.apps.dynatrace.com must map
-// to *.live.dynatrace.com, not *.dynatrace.com
-func TestLambdaAPIClassicURL(t *testing.T) {
+// TestLambdaAPIURL is a regression test: *.apps.dynatrace.com must map to
+// *.live.dynatrace.com (not *.dynatrace.com), and trailing slashes must be stripped.
+func TestLambdaAPIURL(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -452,11 +452,13 @@ func TestLambdaAPIClassicURL(t *testing.T) {
 		{"https://abc123.dev.apps.dynatracelabs.com", "https://abc123.dev.dynatracelabs.com"},
 		{"https://bzu85488.live.dynatrace.com", "https://bzu85488.live.dynatrace.com"},
 		{"https://abc123.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
+		{"https://bzu85488.apps.dynatrace.com/", "https://bzu85488.live.dynatrace.com"},
+		{"https://abc123.apps.dynatracelabs.com/", "https://abc123.dynatracelabs.com"},
 	}
 	for _, tt := range tests {
-		got := ClassicAPIURL(tt.input)
+		got := APIURL(tt.input)
 		if got != tt.want {
-			t.Errorf("ClassicAPIURL(%q) = %q, want %q — Lambda API calls would hit wrong host", tt.input, got, tt.want)
+			t.Errorf("APIURL(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/pkg/installer/aws_lambda_test.go
+++ b/pkg/installer/aws_lambda_test.go
@@ -1,6 +1,10 @@
 package installer
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -434,4 +438,188 @@ func TestTruncate(t *testing.T) {
 			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 		}
 	}
+}
+
+// TestLambdaAPIClassicURL is a regression test: *.apps.dynatrace.com must map
+// to *.live.dynatrace.com, not *.dynatrace.com
+func TestLambdaAPIClassicURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://bzu85488.apps.dynatrace.com", "https://bzu85488.live.dynatrace.com"},
+		{"https://abc123.apps.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
+		{"https://abc123.dev.apps.dynatracelabs.com", "https://abc123.dev.dynatracelabs.com"},
+		{"https://bzu85488.live.dynatrace.com", "https://bzu85488.live.dynatrace.com"},
+		{"https://abc123.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
+	}
+	for _, tt := range tests {
+		got := ClassicAPIURL(tt.input)
+		if got != tt.want {
+			t.Errorf("ClassicAPIURL(%q) = %q, want %q — Lambda API calls would hit wrong host", tt.input, got, tt.want)
+		}
+	}
+}
+
+func lambdaAPIServer(t *testing.T, tenantUUID, clusterID, connToken, layerARN string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/deployment/installer/agent/connectioninfo":
+			fmt.Fprintf(w, `{"tenantUUID":%q}`, tenantUUID)
+		case "/api/v1/config/clusterid":
+			fmt.Fprintf(w, `{"clusterId":%s}`, clusterID)
+		case "/api/v2/agentConnectionToken":
+			fmt.Fprintf(w, `{"token":%q}`, connToken)
+		case "/api/v1/deployment/lambda/layer":
+			fmt.Fprintf(w, `{"arns":[{"arn":%q}]}`, layerARN)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestGetDTConnectionInfo(t *testing.T) {
+	srv := lambdaAPIServer(t, "abc12345", "997993252", "dt0a01.mytoken", "")
+	defer srv.Close()
+
+	conn, err := getDTConnectionInfo(srv.URL, "dt0c01.testtoken")
+	if err != nil {
+		t.Fatalf("getDTConnectionInfo failed: %v", err)
+	}
+	if conn.TenantUUID != "abc12345" {
+		t.Errorf("TenantUUID = %q, want abc12345", conn.TenantUUID)
+	}
+	if conn.ClusterID != "997993252" {
+		t.Errorf("ClusterID = %q, want 997993252", conn.ClusterID)
+	}
+	if conn.Token != "dt0a01.mytoken" {
+		t.Errorf("Token = %q, want dt0a01.mytoken", conn.Token)
+	}
+	if conn.BaseURL != srv.URL {
+		t.Errorf("BaseURL = %q, want %q", conn.BaseURL, srv.URL)
+	}
+}
+
+func TestGetDTConnectionInfo_Errors(t *testing.T) {
+	t.Run("403 returns scope hint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		_, err := getDTConnectionInfo(srv.URL, "bad-token")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !contains(err.Error(), "InstallerDownload") {
+			t.Errorf("error %q should mention InstallerDownload scope", err.Error())
+		}
+	})
+
+	t.Run("non-200 includes status code", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, "service down")
+		}))
+		defer srv.Close()
+
+		_, err := getDTConnectionInfo(srv.URL, "token")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !contains(err.Error(), "503") {
+			t.Errorf("error %q should contain HTTP status 503", err.Error())
+		}
+	})
+}
+
+func TestGetClusterID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/config/clusterid" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"clusterId":123456789}`)
+	}))
+	defer srv.Close()
+
+	got, err := getClusterID(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("getClusterID failed: %v", err)
+	}
+	if got != "123456789" {
+		t.Errorf("clusterID = %q, want 123456789", got)
+	}
+}
+
+func TestGetAgentConnectionToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/agentConnectionToken" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"dt0a01.abc.secret"}`)
+	}))
+	defer srv.Close()
+
+	got, err := getAgentConnectionToken(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("getAgentConnectionToken failed: %v", err)
+	}
+	if got != "dt0a01.abc.secret" {
+		t.Errorf("token = %q, want dt0a01.abc.secret", got)
+	}
+}
+
+func TestGetLambdaLayerARN(t *testing.T) {
+	wantARN := "arn:aws:lambda:us-east-1:657959507023:layer:Dynatrace_OneAgent_nodejs_x86:42"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/deployment/lambda/layer" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		b, _ := json.Marshal(map[string]any{"arns": []map[string]string{{"arn": wantARN}}})
+		w.Write(b) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	cache := layerARNCache{}
+
+	got, err := getLambdaLayerARN(cache, srv.URL, "token", "nodejs", "x86_64", "us-east-1")
+	if err != nil {
+		t.Fatalf("getLambdaLayerARN failed: %v", err)
+	}
+	if got != wantARN {
+		t.Errorf("ARN = %q, want %q", got, wantARN)
+	}
+
+	// Second call must use the cache (server closed below).
+	srv.Close()
+	cached, err := getLambdaLayerARN(cache, srv.URL, "token", "nodejs", "x86_64", "us-east-1")
+	if err != nil {
+		t.Fatalf("cached getLambdaLayerARN failed: %v", err)
+	}
+	if cached != wantARN {
+		t.Errorf("cached ARN = %q, want %q", cached, wantARN)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -127,19 +127,6 @@ func AuthHeader(token string) string {
 	return "Bearer " + token
 }
 
-// ClassicAPIURL converts a Dynatrace Platform URL to the equivalent Classic API
-// base URL used by the Classic API and the OneAgent installer endpoint.
-//
-// Mapping rules:
-//   - *.apps.dynatrace.com      → *.live.dynatrace.com      (production SaaS)
-//   - *.apps.dynatracelabs.com  → *.dynatracelabs.com       (dev/sprint envs)
-func ClassicAPIURL(environmentURL string) string {
-	s := environmentURL
-	s = strings.Replace(s, ".apps.dynatrace.com", ".live.dynatrace.com", 1)
-	s = strings.Replace(s, ".apps.dynatracelabs.com", ".dynatracelabs.com", 1)
-	return s
-}
-
 // APIURL converts any Dynatrace environment URL to the Classic API base URL.
 //
 // Mapping rules:

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -23,33 +23,22 @@ func TestAuthHeader(t *testing.T) {
 	}
 }
 
-func TestClassicAPIURL(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"https://abc123.apps.dynatrace.com", "https://abc123.live.dynatrace.com"},
-		{"https://abc123.apps.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
-		{"https://abc123.live.dynatrace.com", "https://abc123.live.dynatrace.com"},
-		{"https://abc123.dev.dynatracelabs.com", "https://abc123.dev.dynatracelabs.com"},
-	}
-	for _, tt := range tests {
-		got := ClassicAPIURL(tt.input)
-		if got != tt.want {
-			t.Errorf("ClassicAPIURL(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestAPIURL(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
 	}{
+		// apps → classic conversion
 		{"https://abc123.apps.dynatrace.com", "https://abc123.live.dynatrace.com"},
 		{"https://abc123.apps.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
+		{"https://abc123.dev.apps.dynatracelabs.com", "https://abc123.dev.dynatracelabs.com"},
+		// already-classic URLs returned unchanged
+		{"https://abc123.live.dynatrace.com", "https://abc123.live.dynatrace.com"},
+		{"https://abc123.dynatracelabs.com", "https://abc123.dynatracelabs.com"},
+		{"https://abc123.dev.dynatracelabs.com", "https://abc123.dev.dynatracelabs.com"},
+		// trailing slashes stripped
+		{"https://abc123.apps.dynatrace.com/", "https://abc123.live.dynatrace.com"},
 		{"https://abc123.live.dynatrace.com/", "https://abc123.live.dynatrace.com"},
-		{"https://abc123.dev.dynatracelabs.com/", "https://abc123.dev.dynatracelabs.com"},
 	}
 	for _, tt := range tests {
 		got := APIURL(tt.input)


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Fix the issue in AWS lambda's URL parsing

## How to test
1. use proper credentials (contact me for providing them)
2. go to QuickStart app on tested tenant ([link](https://bzu85488.apps.dynatrace.com/ui/apps/dynatrace.quickstart/))
3. go to User Permissions Manager (feel free to contact me for the link)
4. use cloud shell on aws and copy credentials from `QuickStart`
5. check if aws lambda is detected ([Clouds app](https://bzu85488.apps.dynatrace.com/ui/apps/dynatrace.clouds/smartscape/functions?perspective=health))

## Which other features are affected?
1. just aws lambda setup is affected

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
