### PR TITLE
fix: support users with old azure cli

### DIFF
--- a/pkg/installer/azure/helpers.go
+++ b/pkg/installer/azure/helpers.go
@@ -68,8 +68,8 @@ func azureDeleteFedCred(runner cmdRunner, clientID string) error {
 }
 
 // azureListAppIDsByName finds leftover App Registrations from interrupted installs.
-// `az ad sp create-for-rbac --name X` reuses an existing app with that name, so a leftover
-// keeps the same appId across runs and triggers the DT "Constraints violated" error on reinstall.
+// A leftover app with the same display name keeps the same appId across runs and
+// triggers the DT "Constraints violated" error on reinstall.
 func azureListAppIDsByName(runner cmdRunner, name string) ([]string, error) {
 	out, err := runner("az", []string{"ad", "app", "list", "--display-name", name, "-o", "json"}, nil)
 	if err != nil {

--- a/pkg/installer/azure/helpers_test.go
+++ b/pkg/installer/azure/helpers_test.go
@@ -50,15 +50,21 @@ func captureStdoutErr(fn func() error) error {
 
 func noSleep(_ time.Duration) {}
 
-// stubExecLookPath overrides execLookPath to pretend az is always available.
+// stubExecLookPath overrides execLookPath to pretend az is always available,
+// and stubs hasSupportedAzVersion to return true (modern az, no legacy path).
 // Returns a restore function to defer.
 func stubExecLookPath(t *testing.T) func() {
 	t.Helper()
-	orig := execLookPath
+	origLookPath := execLookPath
+	origHasCP := hasSupportedAzVersion
 	execLookPath = func(_ string) (string, error) {
 		return "/usr/local/bin/az", nil
 	}
-	return func() { execLookPath = orig }
+	hasSupportedAzVersion = func() bool { return true }
+	return func() {
+		execLookPath = origLookPath
+		hasSupportedAzVersion = origHasCP
+	}
 }
 
 // ── mock dtclient implementations ─────────────────────────────────────────────

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -133,9 +133,6 @@ func installAzureWithRunner(
 	if err != nil {
 		return err
 	}
-	if !hasSupportedAzVersion() {
-		return fmt.Errorf("please update Azure CLI to the latest version: https://aka.ms/install-azure-cli")
-	}
 
 	existing, err := dtc.findAllConnections(integrationName)
 	if err != nil {
@@ -148,6 +145,9 @@ func installAzureWithRunner(
 			return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, runner, dtc)
 		}
 		return fmt.Errorf("azure connection '%s' already exists but is incomplete or duplicated: run `dtwiz uninstall azure` then `dtwiz install azure` for a clean setup", integrationName)
+	}
+	if err := requireSupportedAzVersion(); err != nil {
+		return err
 	}
 
 	// Only check RBAC when actually installing — role assignment creation requires it; update does not.
@@ -272,7 +272,7 @@ func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Durati
 	return nil
 }
 
-// parseAppID extracts appId from `az ad app create` output.
+// parseAppID extracts appId from `az ad sp create-for-rbac` output.
 func parseAppID(out string) (string, error) {
 	var app struct {
 		AppID string `json:"appId"`

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -37,8 +37,7 @@ func azureBuildStepCommands(cfg azureConfig) ([]string, error) {
 	return []string{
 		fmt.Sprintf("DT Settings API: create Azure connection '%s' (federatedIdentityCredential)  [env=%s token=***]",
 			cfg.ConnectionName, cfg.EnvURL),
-		fmt.Sprintf("az ad sp create-for-rbac --name %s --create-password false -o json",
-			cfg.ConnectionName),
+		fmt.Sprintf("az ad sp create-for-rbac --name %s --create-password false -o json", cfg.ConnectionName),
 		fmt.Sprintf(`az ad app federated-credential create --id %s --parameters '{"name":"%s","issuer":"%s","subject":"dt:connection-id/%s","audiences":["%s"]}'`,
 			clientID, fedCredName, issuer, connID, audience),
 		fmt.Sprintf("az ad sp show --id %s -o json", clientID),
@@ -134,6 +133,9 @@ func installAzureWithRunner(
 	if err != nil {
 		return err
 	}
+	if !hasSupportedAzVersion() {
+		return fmt.Errorf("Azure CLI 2.88.0 or later is required. Upgrade with: https://aka.ms/install-azure-cli")
+	}
 
 	existing, err := dtc.findAllConnections(integrationName)
 	if err != nil {
@@ -201,8 +203,7 @@ func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Durati
 		azurePartialFailureHint(cfg, completed)
 		return err
 	}
-	completed[2] = true
-	clientID, tenantID, err := parseCreateSPOutput(out2)
+	clientID, err := parseAppID(out2)
 	if err != nil {
 		azurePartialFailureHint(cfg, completed)
 		return fmt.Errorf("step 2: parsing SP output: %w", err)
@@ -212,9 +213,7 @@ func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Durati
 		return fmt.Errorf("step 2: az returned empty appId")
 	}
 	cfg.ClientID = clientID
-	if tenantID != "" {
-		cfg.TenantID = tenantID
-	}
+	completed[2] = true
 	display.ColorOK.Printf("  ✓ Service Principal created: %s\n", cfg.ClientID)
 
 	fedJSON, err := azureBuildFedCredJSON(connObjectID, cfg.EnvURL)
@@ -273,16 +272,15 @@ func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Durati
 	return nil
 }
 
-// parseCreateSPOutput extracts appId and tenant from `az ad sp create-for-rbac` output.
-func parseCreateSPOutput(out string) (appID, tenantID string, err error) {
-	var sp struct {
-		AppID  string `json:"appId"`
-		Tenant string `json:"tenant"`
+// parseAppID extracts appId from `az ad app create` output.
+func parseAppID(out string) (string, error) {
+	var app struct {
+		AppID string `json:"appId"`
 	}
-	if err = json.Unmarshal([]byte(out), &sp); err != nil {
-		return "", "", err
+	if err := json.Unmarshal([]byte(out), &app); err != nil {
+		return "", err
 	}
-	return sp.AppID, sp.Tenant, nil
+	return app.AppID, nil
 }
 
 // createOrReplaceFedCred creates the federated credential, replacing a stale one from a previous partial install if present.

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -134,7 +134,7 @@ func installAzureWithRunner(
 		return err
 	}
 	if !hasSupportedAzVersion() {
-		return fmt.Errorf("Please update Azure CLI to the latest version: https://aka.ms/install-azure-cli")
+		return fmt.Errorf("please update Azure CLI to the latest version: https://aka.ms/install-azure-cli")
 	}
 
 	existing, err := dtc.findAllConnections(integrationName)

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -134,7 +134,7 @@ func installAzureWithRunner(
 		return err
 	}
 	if !hasSupportedAzVersion() {
-		return fmt.Errorf("Azure CLI 2.88.0 or later is required. Upgrade with: https://aka.ms/install-azure-cli")
+		return fmt.Errorf("Please update Azure CLI to the latest version: https://aka.ms/install-azure-cli")
 	}
 
 	existing, err := dtc.findAllConnections(integrationName)

--- a/pkg/installer/azure/install_test.go
+++ b/pkg/installer/azure/install_test.go
@@ -113,6 +113,35 @@ func TestAzureDryRun(t *testing.T) {
 	}
 }
 
+func TestAzureInstallRequiresSupportedAzVersion(t *testing.T) {
+	defer stubExecLookPath(t)()
+	hasSupportedAzVersion = func() bool { return false }
+
+	azCallsAfterAccountShow := 0
+	runner := func(name string, args []string, _ []string) (string, error) {
+		switch {
+		case name == "az" && len(args) > 1 && args[0] == "account" && args[1] == "show":
+			return stockAccountJSON, nil
+		default:
+			azCallsAfterAccountShow++
+			return "{}", nil
+		}
+	}
+
+	err := captureStdoutErr(func() error {
+		return installAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, runner, noSleep, &noopDTClient{})
+	})
+	if err == nil {
+		t.Fatal("expected unsupported Azure CLI version error, got nil")
+	}
+	if !strings.Contains(err.Error(), "update Azure CLI") {
+		t.Errorf("expected Azure CLI update guidance, got: %v", err)
+	}
+	if azCallsAfterAccountShow != 0 {
+		t.Errorf("expected no az calls after account preflight, got %d", azCallsAfterAccountShow)
+	}
+}
+
 func TestAzureConnectionIDFlowsToStep3(t *testing.T) {
 	old := installer.AutoConfirm
 	installer.AutoConfirm = true
@@ -295,6 +324,7 @@ func TestAzureInstallWithCompleteConnectionDelegatesToUpdate(t *testing.T) {
 	installer.AutoConfirm = true
 	defer func() { installer.AutoConfirm = old }()
 	defer stubExecLookPath(t)()
+	hasSupportedAzVersion = func() bool { return false }
 
 	azMutatingCalls := 0
 	runner := func(name string, args []string, _ []string) (string, error) {

--- a/pkg/installer/azure/install_test.go
+++ b/pkg/installer/azure/install_test.go
@@ -46,7 +46,7 @@ func buildHappyPathAzRunner(t *testing.T) *fakeAzureRunner {
 		calls: []fakeCall{
 			{name: "az", stdout: stockAccountJSON}, // preflight: account show
 			{name: "az", stdout: stockRBACJSON},    // preflight: signed-in-user (fails parse → RBAC skipped)
-			{name: "az", stdout: stockSPJSON},      // step 2
+			{name: "az", stdout: stockSPJSON},      // step 2: create-for-rbac
 			{name: "az", stdout: `{}`},             // step 3
 			{name: "az", stdout: stockSPShowJSON},  // step 4
 			{name: "az", stdout: `{}`},             // step 5
@@ -379,7 +379,7 @@ func TestAzureStep2FailsMentionsDTConnection(t *testing.T) {
 			return stockAccountJSON, nil
 		case name == "az" && len(args) > 0 && args[0] == "rest":
 			return stockRBACJSON, nil
-		case name == "az" && len(args) > 1 && args[0] == "ad" && args[1] == "sp":
+		case name == "az" && len(args) > 2 && args[0] == "ad" && args[1] == "sp" && args[2] == "create-for-rbac":
 			return "", fmt.Errorf("az ad sp create-for-rbac: permission denied")
 		default:
 			return "{}", nil
@@ -765,7 +765,7 @@ func TestAzureBuildStepCommands_RealValues(t *testing.T) {
 		want string
 	}{
 		{1, "dtwiz-azure"},               // connection name
-		{2, "dtwiz-azure"},               // sp create --name
+		{2, "dtwiz-azure"},               // sp create-for-rbac --name
 		{3, "client-id-000"},             // fed-cred create --id
 		{3, "conn-id-001"},               // subject dt:connection-id/<connID>
 		{3, fedCredName},                 // fed cred name constant

--- a/pkg/installer/azure/preflight.go
+++ b/pkg/installer/azure/preflight.go
@@ -36,6 +36,13 @@ var hasSupportedAzVersion = func() bool {
 	return maj > 2 || (maj == 2 && min >= 88)
 }
 
+func requireSupportedAzVersion() error {
+	if !hasSupportedAzVersion() {
+		return fmt.Errorf("please update Azure CLI to the latest version: https://aka.ms/install-azure-cli")
+	}
+	return nil
+}
+
 // azureAccountInfo returns the active Azure subscription and tenant IDs from `az account show`.
 func azureAccountInfo(runner cmdRunner) (subscriptionID, tenantID string, err error) {
 	if _, err = execLookPath("az"); err != nil {

--- a/pkg/installer/azure/preflight.go
+++ b/pkg/installer/azure/preflight.go
@@ -3,10 +3,38 @@ package azure
 import (
 	"encoding/json"
 	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
+
+// hasSupportedAzVersion reports whether the installed az CLI supports --create-password false
+// in az ad sp create-for-rbac (requires az CLI >= 2.88). Stubbable for tests.
+var hasSupportedAzVersion = func() bool {
+	out, err := exec.Command("az", "version", "-o", "json").Output()
+	if err != nil {
+		return false
+	}
+	var v struct {
+		CLI string `json:"azure-cli"`
+	}
+	if err := json.Unmarshal(out, &v); err != nil || v.CLI == "" {
+		return false
+	}
+	parts := strings.SplitN(v.CLI, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	maj, err1 := strconv.Atoi(parts[0])
+	min, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return maj > 2 || (maj == 2 && min >= 88)
+}
 
 // azureAccountInfo returns the active Azure subscription and tenant IDs from `az account show`.
 func azureAccountInfo(runner cmdRunner) (subscriptionID, tenantID string, err error) {

--- a/pkg/installer/azure/update.go
+++ b/pkg/installer/azure/update.go
@@ -16,6 +16,9 @@ func UpdateAzure(envURL, platformToken string, dryRun bool, startTime time.Time)
 	if err != nil {
 		return err
 	}
+	if err := requireSupportedAzVersion(); err != nil {
+		return err
+	}
 	return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, realRunner, dtc)
 }
 

--- a/pkg/installer/azure/update_test.go
+++ b/pkg/installer/azure/update_test.go
@@ -156,6 +156,20 @@ func TestUpdateAzureCancelled(t *testing.T) {
 	}
 }
 
+func TestUpdateAzureRequiresSupportedAzVersion(t *testing.T) {
+	oldHasSupportedAzVersion := hasSupportedAzVersion
+	hasSupportedAzVersion = func() bool { return false }
+	defer func() { hasSupportedAzVersion = oldHasSupportedAzVersion }()
+
+	err := UpdateAzure("https://abc.live.dynatrace.com", "tok", true, time.Time{})
+	if err == nil {
+		t.Fatal("expected unsupported Azure CLI version error, got nil")
+	}
+	if !strings.Contains(err.Error(), "update Azure CLI") {
+		t.Errorf("expected Azure CLI update guidance, got: %v", err)
+	}
+}
+
 func TestUpdateAzureNoUsableConnection(t *testing.T) {
 	old := installer.AutoConfirm
 	installer.AutoConfirm = true


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Show warning when old Azure version is used

## How to test
1. check out the code locally
2. make sure you're logged to AZURE (`az login`)
3. change `hasSupportedAzVersion` to expect a version bigger than 3
4. run `go run main.go setup`
5. try running and see the update warning: `Please update Azure CLI to the latest version`...
6. revert the change
7. try again `go run main.go setup`
8. no warning, you can abort before starting

## Which other features are affected?
1. just azure install

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
