### PR TITLE
fix: azure check extension ready

### DIFF
--- a/openspec/changes/fix-extension-activation-race/design.md
+++ b/openspec/changes/fix-extension-activation-race/design.md
@@ -1,0 +1,89 @@
+# Design
+
+## Context
+
+The Dynatrace Extensions 2.0 hub install endpoint (`POST /platform/extensions/v2/extensions/{name}`)
+returns **202 Accepted**, not 200 OK. The response body contains the installed version
+but the extension is not immediately usable — the DT backend completes activation
+asynchronously. The `Active` field on the extension version list (`GET /platform/extensions/v2/extensions/{name}`)
+flips to `true` once activation is complete.
+
+Previously, `installExtension()` returned `error` only and the caller had no way to
+distinguish a fresh install from an already-installed idempotent no-op. Both cases
+returned `nil`, so the caller always proceeded directly to monitoring configuration
+creation.
+
+This change also builds on `install-cloud-extensions-before-monitoring-config`, which
+first introduced the `installExtension()` call in both install flows.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate the first-install race without adding unnecessary latency to the common
+  (already-installed) path.
+- Surface wait progress to the user so the terminal does not appear hung.
+- Keep the polling logic testable via the injected `sleeper`.
+
+**Non-Goals:**
+
+- Retry monitoring configuration creation on failure (active-poll replaces blind retry).
+- Change the update flow behavior (extensions are always active by update time).
+- Configure the poll timeout via a flag (60 s is sufficient for observed activation times).
+
+## Decisions
+
+### Readiness signal: `Active` field
+
+The `GET /platform/extensions/v2/extensions/{name}` response includes `"active": true`
+on the version item once the hub install completes. This is the correct readiness signal
+because it reflects the DT backend's own activation state, not a proxy (e.g. schema
+availability or monitoring config acceptance).
+
+Alternatives considered:
+
+- **Retry `createMonitoring` on 400**: rejected — it mixes activation lag with a
+  genuine bad-request error and gives no user-visible progress during the wait.
+- **Fixed sleep**: rejected — wastes time when activation is fast (usually < 10 s) and
+  is still a race condition at the boundary.
+- **Poll `FetchExtensionSchema`**: rejected — the schema endpoint may return 200 before
+  `CreateMonitoringConfiguration` accepts a config; `Active` is the authoritative signal.
+
+### Interface change: `installExtension() (bool, error)`
+
+Returning a bool from `installExtension()` is the minimal contract change needed to let
+the caller decide whether to wait. The alternative — always waiting inside
+`installExtension()` — would require threading the sleeper into the method, changing
+the interface in a more invasive way and making the `sdkDTClient` depend on a
+test-injectable sleep function it currently does not hold.
+
+### Shared `IsExtensionActive` on `ExtensionClient`
+
+Both Azure and GCP packages wrap `ExtensionClient`. Adding `IsExtensionActive` there
+avoids duplicating the `Extension.Get()` call in each package and keeps extension-API
+access centralised.
+
+### Timeout: 60 s (12 × 5 s)
+
+Observed activation times across dev and prod tenants are under 10 s. 60 s gives a
+4–6× safety margin without committing users to a multi-minute wait on a true failure.
+On timeout the flow logs debug info and proceeds; the subsequent `createMonitoring`
+call will then surface the real error with the full API response.
+
+### Update flows: ignore fresh-install signal
+
+The update flow calls `installExtension()` to ensure the extension exists before
+reconciling monitoring configs. At update time the extension is always already installed
+(it was installed by the preceding `dtwiz install`), so `installExtension()` always
+returns `false`. No wait is needed and the `_` discard is intentional.
+
+## Risks / Trade-offs
+
+- If a DT environment never sets `Active: true` (e.g. a backend bug), the 60 s poll
+  exhausts and the flow proceeds to `createMonitoring`, which may fail. The error from
+  the Extensions API is then surfaced directly to the user with no spurious timeout
+  message — the timeout is silent (debug-level only).
+- The `fakeDTClient` in tests returns `(false, nil)` from `installExtension()` so no
+  wait loop runs in unit tests. The `isExtensionActive()` fake returns `(true, nil)`
+  unconditionally; integration coverage for the wait loop relies on the injected
+  `sleeper` being `noSleep` in tests that exercise the fresh-install path.

--- a/openspec/changes/fix-extension-activation-race/proposal.md
+++ b/openspec/changes/fix-extension-activation-race/proposal.md
@@ -1,0 +1,52 @@
+# Proposal
+
+## Why
+
+The Dynatrace hub extension install endpoint returns **202 Accepted** — the activation
+is asynchronous. On a tenant where the extension has never been installed, dtwiz called
+`installExtension()` and immediately attempted to create the monitoring configuration.
+The extension was not yet active, so the DT Extensions API returned a 400 validation
+error. The install appeared to fail at step 7, even though all cloud-side resources were
+correctly set up.
+
+Users who ran `dtwiz uninstall azure` and then `dtwiz install azure` again succeeded
+because the extension was already installed (and fully active) from the previous attempt
+— `installExtension()` skipped the hub call and returned immediately.
+
+## What Changes
+
+- `installExtension()` on the `dtclient` interface (Azure and GCP) now returns
+  `(bool, error)` — `true` when the extension was freshly installed, `false` when it
+  was already present.
+- A new `isExtensionActive() (bool, error)` method is added to both `dtclient`
+  interfaces. It checks the `Active` field on the extension version list.
+- `IsExtensionActive(extensionName string) (bool, error)` is added to the shared
+  `ExtensionClient` in `pkg/installer/`.
+- When a fresh install is detected, both the Azure and GCP install flows poll
+  `isExtensionActive()` (every 5 s, up to 60 s) before proceeding to monitoring
+  configuration creation. Progress is surfaced to the user:
+  - `"Extension freshly installed — waiting for it to become active..."`
+  - `"✓ Extension is active"` on success, or a debug log and graceful proceed on timeout.
+- The `update` flows ignore the fresh-install signal (`_, err`) — extensions are already
+  active by the time an update runs.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `azure-monitor-install`: After a fresh extension hub install, poll for `Active == true`
+  before creating the monitoring configuration.
+- `gcp-monitor-install`: Same as above for the GCP extension.
+
+## Impact
+
+- Affected code: `pkg/installer/extension_client.go`, `pkg/installer/azure/dtapi.go`,
+  `pkg/installer/azure/install.go`, `pkg/installer/gcp/dtapi.go`,
+  `pkg/installer/gcp/install.go`, and both packages' test helpers.
+- The `dtclient` interface in both packages gains two methods; all fakes are updated.
+- Worst-case added latency on a fresh install: 60 s (12 × 5 s). In practice the
+  extension becomes active in a few seconds and the wait terminates early.
+- No change to behavior when the extension is already installed (the common case for
+  updates and re-installs after a partial failure).
+- Rollback: revert the interface signature changes and remove the `waitForExtensionActive`
+  call; the direct `createMonitoring` call is restored.

--- a/openspec/changes/fix-extension-activation-race/specs/azure-monitor/spec.md
+++ b/openspec/changes/fix-extension-activation-race/specs/azure-monitor/spec.md
@@ -1,0 +1,53 @@
+# Azure Monitor: Extension Activation Race Fix
+
+## CHANGED Requirements
+
+### Requirement: Wait for extension to be active before creating monitoring config
+
+After a fresh hub install of the Azure data-acquisition extension, `dtwiz install azure`
+must poll until the extension is active before creating the monitoring configuration.
+It polls every 5 s for up to 60 s and shows progress to the user.
+
+#### Scenario: Fresh install, extension becomes active in time
+
+- **GIVEN** the da-azure extension is not installed on the tenant
+- **WHEN** `dtwiz install azure` runs
+- **THEN** step 6 (update connection) completes
+- **AND** `installExtension()` installs the extension and returns `freshlyInstalled = true`
+- **AND** the install flow prints `"Extension freshly installed -- waiting for it to become active..."`
+- **AND** the flow polls `isExtensionActive()` until `Active == true`
+- **AND** `"Extension is active"` is printed
+- **AND** step 7 (create monitoring configuration) succeeds
+
+#### Scenario: Extension already installed, no wait needed
+
+- **GIVEN** the da-azure extension is already installed and active on the tenant
+- **WHEN** `dtwiz install azure` runs (e.g. after a partial failure at step 7)
+- **THEN** `installExtension()` returns `freshlyInstalled = false`
+- **AND** no polling runs
+- **AND** step 7 proceeds immediately
+
+#### Scenario: Fresh install, activation poll times out
+
+- **GIVEN** the da-azure extension is freshly installed
+- **AND** the extension is not active within 60 s
+- **WHEN** the poll exhausts all attempts
+- **THEN** a debug log is written
+- **AND** step 7 runs and the Extensions API response determines the outcome
+
+### Requirement: `installExtension()` returns whether the extension was freshly installed
+
+`dtclient.installExtension()` returns `(bool, error)`, where `true` means the extension
+was just installed from the hub (202 Accepted) and `false` means it was already present.
+
+#### Scenario: Extension already installed
+
+- **GIVEN** `LatestExtensionVersion` succeeds (extension found in the version list)
+- **WHEN** `installExtension()` is called
+- **THEN** it returns `(false, nil)` without calling `InstallFromHub`
+
+#### Scenario: Extension freshly installed from hub
+
+- **GIVEN** `LatestExtensionVersion` fails (extension not found)
+- **WHEN** `installExtension()` is called and `InstallFromHub` succeeds
+- **THEN** it returns `(true, nil)`

--- a/openspec/changes/fix-extension-activation-race/specs/gcp-monitor/spec.md
+++ b/openspec/changes/fix-extension-activation-race/specs/gcp-monitor/spec.md
@@ -1,0 +1,36 @@
+# GCP Monitor: Extension Activation Race Fix
+
+## CHANGED Requirements
+
+### Requirement: Wait for extension to be active before creating monitoring config
+
+After a fresh hub install of the GCP data-acquisition extension, `dtwiz install gcp`
+must poll until the extension is active before creating the monitoring configuration.
+It polls every 5 s for up to 60 s and shows progress to the user.
+
+#### Scenario: Fresh install, extension becomes active in time
+
+- **GIVEN** the da-gcp extension is not installed on the tenant
+- **WHEN** `dtwiz install gcp` runs
+- **THEN** step 6 (update connection) completes
+- **AND** `installExtension()` installs the extension and returns `freshlyInstalled = true`
+- **AND** the install flow prints `"Extension freshly installed -- waiting for it to become active..."`
+- **AND** the flow polls `isExtensionActive()` until `Active == true`
+- **AND** `"Extension is active"` is printed
+- **AND** step 7 (create monitoring configuration) succeeds
+
+#### Scenario: Extension already installed, no wait needed
+
+- **GIVEN** the da-gcp extension is already installed and active on the tenant
+- **WHEN** `dtwiz install gcp` runs
+- **THEN** `installExtension()` returns `freshlyInstalled = false`
+- **AND** no polling runs
+- **AND** step 7 proceeds immediately
+
+#### Scenario: Fresh install, activation poll times out
+
+- **GIVEN** the da-gcp extension is freshly installed
+- **AND** the extension is not active within 60 s
+- **WHEN** the poll exhausts all attempts
+- **THEN** a debug log is written
+- **AND** step 7 runs and the Extensions API response determines the outcome

--- a/openspec/changes/fix-extension-activation-race/tasks.md
+++ b/openspec/changes/fix-extension-activation-race/tasks.md
@@ -11,7 +11,7 @@
 - [x] 2.3 Add `sdkDTClient.isExtensionActive()` delegating to `e.IsExtensionActive(extensionName)`.
 - [x] 2.4 Add `extensionActiveMaxAttempts` / `extensionActiveRetryDelay` constants and `waitForExtensionActive(dtc, sleeper)` in `pkg/installer/azure/install.go`.
 - [x] 2.5 Update `runInstallSteps` in `pkg/installer/azure/install.go`: capture `freshlyInstalled` from `installExtension()`; if true, print wait message, call `waitForExtensionActive`, print `"✓ Extension is active"` on success.
-- [x] 2.6 Update `pkg/installer/azure/update.go`: discard the bool (`_, err`).
+- [x] 2.6 Update `pkg/installer/azure/update.go`: add `sleeper func(time.Duration)` parameter to `updateAzureWithRunner`; capture the bool from `installExtension()` and, when true, call `waitForExtensionActive(dtc, sleeper)` before reconciling. Pass `time.Sleep` from `UpdateAzure` and thread the injected sleeper from `installAzureWithRunner`.
 - [x] 2.7 Update `fakeDTClient` and `noopDTClient` in `pkg/installer/azure/helpers_test.go` for new signatures. `fakeDTClient.installExtension()` returns `(false, err)` (no wait in tests); `isExtensionActive()` returns `(true, nil)`.
 - [x] 2.8 `go test ./pkg/installer/azure/...` passes.
 
@@ -21,6 +21,6 @@
 - [x] 3.2 Update `sdkDTClient.installExtension()` and add `sdkDTClient.isExtensionActive()` (same pattern as Azure).
 - [x] 3.3 Add `extensionActiveMaxAttempts` / `extensionActiveRetryDelay` constants and `waitForExtensionActive(dtc, sleeper)` in `pkg/installer/gcp/install.go`.
 - [x] 3.4 Update `runInstallSteps` in `pkg/installer/gcp/install.go` with the same fresh-install wait pattern.
-- [x] 3.5 Update `pkg/installer/gcp/update.go`: discard the bool (`_, err`).
+- [x] 3.5 Update `pkg/installer/gcp/update.go`: add `sleeper func(time.Duration)` parameter to `updateGCPWithRunner`; capture the bool from `installExtension()` and, when true, call `waitForExtensionActive(dtc, sleeper)` before reconciling. Pass `time.Sleep` from `UpdateGCP` and thread the injected sleeper from `installGCPWithRunner`.
 - [x] 3.6 Update `fakeDTClient` and `noopDTClient` in `pkg/installer/gcp/helpers_test.go` for new signatures.
 - [x] 3.7 `go test ./pkg/installer/gcp/...` passes.

--- a/openspec/changes/fix-extension-activation-race/tasks.md
+++ b/openspec/changes/fix-extension-activation-race/tasks.md
@@ -1,0 +1,26 @@
+# Implementation Tasks
+
+## Shared
+
+- [x] 1.1 Add `IsExtensionActive(extensionName string) (bool, error)` to `pkg/installer/extension_client.go`. Calls `Extension.Get()` and returns `true` if any item has `Active == true`.
+
+## Azure
+
+- [x] 2.1 Change `dtclient.installExtension()` signature in `pkg/installer/azure/dtapi.go` to `(bool, error)`. Add `isExtensionActive() (bool, error)` to the interface.
+- [x] 2.2 Update `sdkDTClient.installExtension()`: return `(false, nil)` when already installed, `(true, nil)` after a fresh `InstallFromHub` call.
+- [x] 2.3 Add `sdkDTClient.isExtensionActive()` delegating to `e.IsExtensionActive(extensionName)`.
+- [x] 2.4 Add `extensionActiveMaxAttempts` / `extensionActiveRetryDelay` constants and `waitForExtensionActive(dtc, sleeper)` in `pkg/installer/azure/install.go`.
+- [x] 2.5 Update `runInstallSteps` in `pkg/installer/azure/install.go`: capture `freshlyInstalled` from `installExtension()`; if true, print wait message, call `waitForExtensionActive`, print `"✓ Extension is active"` on success.
+- [x] 2.6 Update `pkg/installer/azure/update.go`: discard the bool (`_, err`).
+- [x] 2.7 Update `fakeDTClient` and `noopDTClient` in `pkg/installer/azure/helpers_test.go` for new signatures. `fakeDTClient.installExtension()` returns `(false, err)` (no wait in tests); `isExtensionActive()` returns `(true, nil)`.
+- [x] 2.8 `go test ./pkg/installer/azure/...` passes.
+
+## GCP
+
+- [x] 3.1 Change `dtclient.installExtension()` signature in `pkg/installer/gcp/dtapi.go` to `(bool, error)`. Add `isExtensionActive() (bool, error)` to the interface.
+- [x] 3.2 Update `sdkDTClient.installExtension()` and add `sdkDTClient.isExtensionActive()` (same pattern as Azure).
+- [x] 3.3 Add `extensionActiveMaxAttempts` / `extensionActiveRetryDelay` constants and `waitForExtensionActive(dtc, sleeper)` in `pkg/installer/gcp/install.go`.
+- [x] 3.4 Update `runInstallSteps` in `pkg/installer/gcp/install.go` with the same fresh-install wait pattern.
+- [x] 3.5 Update `pkg/installer/gcp/update.go`: discard the bool (`_, err`).
+- [x] 3.6 Update `fakeDTClient` and `noopDTClient` in `pkg/installer/gcp/helpers_test.go` for new signatures.
+- [x] 3.7 `go test ./pkg/installer/gcp/...` passes.

--- a/pkg/installer/azure/dtapi.go
+++ b/pkg/installer/azure/dtapi.go
@@ -30,7 +30,12 @@ type connRef struct {
 }
 
 type dtclient interface {
-	installExtension() error
+	// installExtension ensures the extension is installed. Returns true if it was freshly
+	// installed (202 Accepted from hub), false if it was already present.
+	installExtension() (bool, error)
+	// isExtensionActive reports whether the extension has an Active version. Use after a
+	// fresh install to poll until the async hub activation completes.
+	isExtensionActive() (bool, error)
 	createConnection(name string) (objectID string, err error)
 	updateConnection(objectID, name, tenantID, clientID string) error
 	createMonitoring(configName, connectionObjectID, clientID, subscriptionID string) error
@@ -54,12 +59,19 @@ func newSDKDTClient(envURL, platformToken string) (*sdkDTClient, error) {
 	return &sdkDTClient{ExtensionClient: ec}, nil
 }
 
-func (d *sdkDTClient) installExtension() error {
+func (d *sdkDTClient) installExtension() (bool, error) {
 	if _, err := d.LatestExtensionVersion(extensionName); err == nil {
 		logger.Debug("extension already installed", "extension", extensionName)
-		return nil
+		return false, nil
 	}
-	return d.InstallExtension(extensionName, "")
+	if err := d.InstallExtension(extensionName, ""); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *sdkDTClient) isExtensionActive() (bool, error) {
+	return d.IsExtensionActive(extensionName)
 }
 
 func (d *sdkDTClient) createConnection(name string) (string, error) {

--- a/pkg/installer/azure/dtapi_test.go
+++ b/pkg/installer/azure/dtapi_test.go
@@ -694,3 +694,89 @@ func TestSDKDeleteMonitoring_ServerError(t *testing.T) {
 		t.Fatal("expected error for 500, got nil")
 	}
 }
+
+// ─── installExtension ────────────────────────────────────────────────────────
+
+func TestSDKInstallExtension_AlreadyInstalled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == extensionAPI {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0"}]}`))
+			return
+		}
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	fresh, err := newTestSDKClient(t, srv.URL).installExtension()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fresh {
+		t.Error("expected fresh=false for already-installed extension")
+	}
+}
+
+func TestSDKInstallExtension_FreshInstall(t *testing.T) {
+	installCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == extensionAPI:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"Extension not found"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == extensionAPI:
+			installCalled = true
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"extensionName":"com.dynatrace.extension.da-azure","version":"1.2.0"}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	fresh, err := newTestSDKClient(t, srv.URL).installExtension()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fresh {
+		t.Error("expected fresh=true after hub install")
+	}
+	if !installCalled {
+		t.Error("expected InstallFromHub to be called")
+	}
+}
+
+// ─── isExtensionActive ───────────────────────────────────────────────────────
+
+func TestSDKIsExtensionActive_Active(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0","active":true}]}`))
+	}))
+	defer srv.Close()
+
+	active, err := newTestSDKClient(t, srv.URL).isExtensionActive()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("expected active=true when extension version has active:true")
+	}
+}
+
+func TestSDKIsExtensionActive_NotActive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0"}]}`))
+	}))
+	defer srv.Close()
+
+	active, err := newTestSDKClient(t, srv.URL).isExtensionActive()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Error("expected active=false when active field is absent")
+	}
+}

--- a/pkg/installer/azure/helpers_test.go
+++ b/pkg/installer/azure/helpers_test.go
@@ -72,8 +72,11 @@ func stubExecLookPath(t *testing.T) func() {
 // noopDTClient is used in tests that never reach the DT API calls.
 type noopDTClient struct{}
 
-func (noopDTClient) installExtension() error {
-	return fmt.Errorf("unexpected installExtension call")
+func (noopDTClient) installExtension() (bool, error) {
+	return false, fmt.Errorf("unexpected installExtension call")
+}
+func (noopDTClient) isExtensionActive() (bool, error) {
+	return false, fmt.Errorf("unexpected isExtensionActive call")
 }
 func (noopDTClient) createConnection(string) (string, error) {
 	return "", fmt.Errorf("unexpected createConnection call")
@@ -135,9 +138,13 @@ func happyUninstallFakeDTClient() *fakeDTClient {
 	}
 }
 
-func (f *fakeDTClient) installExtension() error {
+func (f *fakeDTClient) installExtension() (bool, error) {
 	f.callSeq = append(f.callSeq, "installExtension")
-	return f.installExtErr
+	return false, f.installExtErr // false = already installed; no wait loop in tests
+}
+
+func (f *fakeDTClient) isExtensionActive() (bool, error) {
+	return true, nil
 }
 
 func (f *fakeDTClient) createConnection(string) (string, error) {

--- a/pkg/installer/azure/helpers_test.go
+++ b/pkg/installer/azure/helpers_test.go
@@ -97,16 +97,16 @@ func (noopDTClient) deleteMonitoring(string) error                     { return 
 
 // fakeDTClient records calls for assertion.
 type fakeDTClient struct {
-	connObjectID      string
-	connErr           error
-	createConnCalled  bool
-	installExtErr     error
-	installExtFresh   bool // when true, installExtension() signals a fresh hub install
-	extNotActive      bool // when true, isExtensionActive() always returns false
-	isExtActiveCalls  int
-	callSeq           []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
-	updateErr         error
-	monErr            error
+	connObjectID     string
+	connErr          error
+	createConnCalled bool
+	installExtErr    error
+	installExtFresh  bool // when true, installExtension() signals a fresh hub install
+	extNotActive     bool // when true, isExtensionActive() always returns false
+	isExtActiveCalls int
+	callSeq          []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
+	updateErr        error
+	monErr           error
 
 	// uninstall
 	findConnObjectID string

--- a/pkg/installer/azure/helpers_test.go
+++ b/pkg/installer/azure/helpers_test.go
@@ -97,13 +97,16 @@ func (noopDTClient) deleteMonitoring(string) error                     { return 
 
 // fakeDTClient records calls for assertion.
 type fakeDTClient struct {
-	connObjectID     string
-	connErr          error
-	createConnCalled bool
-	installExtErr    error
-	callSeq          []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
-	updateErr        error
-	monErr           error
+	connObjectID      string
+	connErr           error
+	createConnCalled  bool
+	installExtErr     error
+	installExtFresh   bool // when true, installExtension() signals a fresh hub install
+	extNotActive      bool // when true, isExtensionActive() always returns false
+	isExtActiveCalls  int
+	callSeq           []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
+	updateErr         error
+	monErr            error
 
 	// uninstall
 	findConnObjectID string
@@ -140,11 +143,12 @@ func happyUninstallFakeDTClient() *fakeDTClient {
 
 func (f *fakeDTClient) installExtension() (bool, error) {
 	f.callSeq = append(f.callSeq, "installExtension")
-	return false, f.installExtErr // false = already installed; no wait loop in tests
+	return f.installExtFresh, f.installExtErr
 }
 
 func (f *fakeDTClient) isExtensionActive() (bool, error) {
-	return true, nil
+	f.isExtActiveCalls++
+	return !f.extNotActive, nil
 }
 
 func (f *fakeDTClient) createConnection(string) (string, error) {

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -264,15 +264,25 @@ func runInstallSteps(cfg azureConfig, runner cmdRunner, sleeper func(time.Durati
 	}
 	display.ColorOK.Println("  ✓ Connection updated")
 
-	if err := dtc.installExtension(); err != nil {
+	freshlyInstalled, err := dtc.installExtension()
+	if err != nil {
 		azurePartialFailureHint(cfg, completed)
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
+	}
+	if freshlyInstalled {
+		logger.Debug("extension freshly installed (async), waiting for it to become active")
+		fmt.Println("  Extension freshly installed — waiting for it to become active...")
+		if waitErr := waitForExtensionActive(dtc, sleeper); waitErr != nil {
+			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
+		} else {
+			display.ColorOK.Println("  ✓ Extension is active")
+		}
 	}
 
 	fmt.Printf("  Step 7/%d: Create Azure monitoring configuration...\n", total)
 	if err := dtc.createMonitoring(cfg.ConfigurationName, connObjectID, cfg.ClientID, cfg.SubscriptionID); err != nil {
 		azurePartialFailureHint(cfg, completed)
-		return fmt.Errorf("step 7: %w", err)
+		return fmt.Errorf("step 7: failed to create monitoring configuration: %w", err)
 	}
 	display.ColorOK.Println("  ✓ Monitoring configuration created")
 
@@ -313,6 +323,11 @@ func createOrReplaceFedCred(runner cmdRunner, clientID, fedJSON string) error {
 const (
 	updateConnectionMaxAttempts = 10
 	updateConnectionRetryDelay  = 5 * time.Second
+
+	// extensionActiveMaxAttempts x extensionActiveRetryDelay bounds how long dtwiz polls for a
+	// freshly hub-installed extension to become active (hub install is 202 Accepted = async).
+	extensionActiveMaxAttempts = 12
+	extensionActiveRetryDelay  = 5 * time.Second
 )
 
 // updateConnectionWithRetry retries DT connection finalization because Entra can take several seconds
@@ -329,5 +344,26 @@ func updateConnectionWithRetry(dtc dtclient, connObjectID, connName, tenantID, c
 		},
 	}, func() error {
 		return dtc.updateConnection(connObjectID, connName, tenantID, clientID)
+	})
+}
+
+// waitForExtensionActive polls until the extension reports Active == true.
+// Hub installs are async (202 Accepted); Active flipping to true is the readiness signal.
+func waitForExtensionActive(dtc dtclient, sleeper func(time.Duration)) error {
+	return installer.Retry(sleeper, installer.RetryConfig{
+		MaxAttempts: extensionActiveMaxAttempts,
+		Delay:       func(int) time.Duration { return extensionActiveRetryDelay },
+		OnRetry: func(attempt int, _ time.Duration, _ error) {
+			logger.Debug("extension not yet active, polling", "attempt", attempt)
+		},
+	}, func() error {
+		active, err := dtc.isExtensionActive()
+		if err != nil {
+			return err
+		}
+		if !active {
+			return fmt.Errorf("extension not yet active")
+		}
+		return nil
 	})
 }

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -144,7 +144,7 @@ func installAzureWithRunner(
 		// Complete connection found: reconcile monitoring config in place; don't recreate the SP (Entra "Constraints violated" hazard).
 		if _, err := selectUpdatableConnection(existing, name); err == nil {
 			fmt.Println("\n  Note: prerequisites already exist — running update instead of a fresh install.")
-			return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, runner, dtc)
+			return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, runner, sleeper, dtc)
 		}
 		return fmt.Errorf("azure connection '%s' already exists but is incomplete or duplicated: run `dtwiz uninstall azure` then `dtwiz install azure` for a clean setup", name)
 	}

--- a/pkg/installer/azure/install.go
+++ b/pkg/installer/azure/install.go
@@ -323,11 +323,6 @@ func createOrReplaceFedCred(runner cmdRunner, clientID, fedJSON string) error {
 const (
 	updateConnectionMaxAttempts = 10
 	updateConnectionRetryDelay  = 5 * time.Second
-
-	// extensionActiveMaxAttempts x extensionActiveRetryDelay bounds how long dtwiz polls for a
-	// freshly hub-installed extension to become active (hub install is 202 Accepted = async).
-	extensionActiveMaxAttempts = 12
-	extensionActiveRetryDelay  = 5 * time.Second
 )
 
 // updateConnectionWithRetry retries DT connection finalization because Entra can take several seconds
@@ -347,23 +342,6 @@ func updateConnectionWithRetry(dtc dtclient, connObjectID, connName, tenantID, c
 	})
 }
 
-// waitForExtensionActive polls until the extension reports Active == true.
-// Hub installs are async (202 Accepted); Active flipping to true is the readiness signal.
 func waitForExtensionActive(dtc dtclient, sleeper func(time.Duration)) error {
-	return installer.Retry(sleeper, installer.RetryConfig{
-		MaxAttempts: extensionActiveMaxAttempts,
-		Delay:       func(int) time.Duration { return extensionActiveRetryDelay },
-		OnRetry: func(attempt int, _ time.Duration, _ error) {
-			logger.Debug("extension not yet active, polling", "attempt", attempt)
-		},
-	}, func() error {
-		active, err := dtc.isExtensionActive()
-		if err != nil {
-			return err
-		}
-		if !active {
-			return fmt.Errorf("extension not yet active")
-		}
-		return nil
-	})
+	return installer.WaitForExtensionActive(dtc.isExtensionActive, sleeper)
 }

--- a/pkg/installer/azure/install_test.go
+++ b/pkg/installer/azure/install_test.go
@@ -106,6 +106,52 @@ func TestAzureInstallExtensionFailureStopsBeforeMonitoringConfig(t *testing.T) {
 	}
 }
 
+func TestAzureFreshExtensionInstall_WaitsForActiveThenCreatesMonitoring(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := happyFakeDTClient()
+	dtc.installExtFresh = true // simulate 202 Accepted from hub
+	fr := buildHappyPathAzRunner(t)
+
+	err := captureStdoutErr(func() error {
+		return installAzureWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, fr.run, noSleep, dtc)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dtc.isExtActiveCalls == 0 {
+		t.Error("expected isExtensionActive to be polled after fresh install")
+	}
+	if dtc.monCalledWith.connObjectID == "" {
+		t.Error("expected createMonitoring to be called after extension became active")
+	}
+}
+
+func TestAzureFreshExtensionInstall_PollTimeoutProceeds(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := happyFakeDTClient()
+	dtc.installExtFresh = true
+	dtc.extNotActive = true // isExtensionActive always returns false; poll exhausts
+	fr := buildHappyPathAzRunner(t)
+
+	err := captureStdoutErr(func() error {
+		return installAzureWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, fr.run, noSleep, dtc)
+	})
+	if err != nil {
+		t.Fatalf("flow must continue past poll timeout: %v", err)
+	}
+	if dtc.monCalledWith.connObjectID == "" {
+		t.Error("createMonitoring must be called even when extension poll times out")
+	}
+}
+
 func TestAzureDryRun(t *testing.T) {
 	old := installer.AutoConfirm
 	installer.AutoConfirm = true

--- a/pkg/installer/azure/update.go
+++ b/pkg/installer/azure/update.go
@@ -19,7 +19,7 @@ func UpdateAzure(envURL, platformToken string, dryRun bool, startTime time.Time)
 	if err := requireSupportedAzVersion(); err != nil {
 		return err
 	}
-	return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, realRunner, dtc)
+	return updateAzureWithRunner(envURL, platformToken, dryRun, startTime, realRunner, time.Sleep, dtc)
 }
 
 func updateAzureWithRunner(
@@ -27,6 +27,7 @@ func updateAzureWithRunner(
 	dryRun bool,
 	startTime time.Time,
 	runner cmdRunner,
+	sleeper func(time.Duration),
 	dtc dtclient,
 ) error {
 	subscriptionID, tenantID, err := azureAccountInfo(runner)
@@ -74,7 +75,7 @@ func updateAzureWithRunner(
 	if freshlyInstalled {
 		logger.Debug("extension freshly installed (async), waiting for it to become active")
 		fmt.Println("  Extension freshly installed — waiting for it to become active...")
-		if waitErr := waitForExtensionActive(dtc, time.Sleep); waitErr != nil {
+		if waitErr := waitForExtensionActive(dtc, sleeper); waitErr != nil {
 			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
 		} else {
 			display.ColorOK.Println("  ✓ Extension is active")

--- a/pkg/installer/azure/update.go
+++ b/pkg/installer/azure/update.go
@@ -67,7 +67,7 @@ func updateAzureWithRunner(
 		return err
 	}
 
-	if err := dtc.installExtension(); err != nil {
+	if _, err := dtc.installExtension(); err != nil {
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
 	}
 

--- a/pkg/installer/azure/update.go
+++ b/pkg/installer/azure/update.go
@@ -67,8 +67,18 @@ func updateAzureWithRunner(
 		return err
 	}
 
-	if _, err := dtc.installExtension(); err != nil {
+	freshlyInstalled, err := dtc.installExtension()
+	if err != nil {
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
+	}
+	if freshlyInstalled {
+		logger.Debug("extension freshly installed (async), waiting for it to become active")
+		fmt.Println("  Extension freshly installed — waiting for it to become active...")
+		if waitErr := waitForExtensionActive(dtc, time.Sleep); waitErr != nil {
+			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
+		} else {
+			display.ColorOK.Println("  ✓ Extension is active")
+		}
 	}
 
 	if err := reconcileMonitoring(cfg, monConfigIDs, dtc); err != nil {

--- a/pkg/installer/azure/update_test.go
+++ b/pkg/installer/azure/update_test.go
@@ -31,7 +31,7 @@ func TestUpdateAzureHappyPath_UpdatesInPlace(t *testing.T) {
 	dtc := happyUninstallFakeDTClient() // conn with clientID + one monitoring config
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -68,7 +68,7 @@ func TestUpdateAzureCreatesConfigWhenMissing(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -91,7 +91,7 @@ func TestUpdateAzureExtensionFailureStopsBeforeMonitoringConfig(t *testing.T) {
 	dtc.installExtErr = fmt.Errorf("extension install failed")
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected extension install error, got nil")
@@ -114,7 +114,7 @@ func TestUpdateAzureReconcilesAllDuplicateConfigs(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -133,7 +133,7 @@ func TestUpdateAzureDryRun(t *testing.T) {
 	dtc := happyUninstallFakeDTClient()
 
 	out := captureStdout(t, func() {
-		if err := updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), dtc); err != nil {
+		if err := updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), noSleep, dtc); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -151,7 +151,7 @@ func TestUpdateAzurePreviewLeavesAuthUnchanged(t *testing.T) {
 
 	dtc := happyUninstallFakeDTClient()
 	out := captureStdout(t, func() {
-		_ = updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), dtc)
+		_ = updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 
 	if !strings.Contains(out, "update Azure monitoring configuration") {
@@ -167,7 +167,7 @@ func TestUpdateAzureCancelled(t *testing.T) {
 
 	dtc := happyUninstallFakeDTClient()
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if !isErrInstallCancelled(err) {
 		t.Errorf("expected ErrInstallCancelled, got: %v", err)
@@ -205,7 +205,7 @@ func TestUpdateAzureNoUsableConnection(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error when no complete connection exists, got nil")
@@ -230,7 +230,7 @@ func TestUpdateAzureMultipleConnections(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error for ambiguous multiple connections, got nil")
@@ -245,7 +245,7 @@ func TestUpdateAzureFindMonitoringError(t *testing.T) {
 
 	dtc := &fakeDTClient{findMonErr: fmt.Errorf("monitoring API error")}
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error from findMonitoringConfig failure, got nil")
@@ -257,7 +257,7 @@ func TestUpdateAzureFindConnectionError(t *testing.T) {
 
 	dtc := &fakeDTClient{findConnErr: fmt.Errorf("connection API error")}
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error from findConnection failure, got nil")
@@ -275,7 +275,7 @@ func TestUpdateAzureAccountInfoFails(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, runner, happyUninstallFakeDTClient())
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, runner, noSleep, happyUninstallFakeDTClient())
 	})
 	if err == nil {
 		t.Fatal("expected error from account lookup failure, got nil")
@@ -295,7 +295,7 @@ func TestUpdateAzureMonitoringUpdateFails(t *testing.T) {
 	dtc.updateMonErr = fmt.Errorf("update monitoring: API error")
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error from monitoring update failure, got nil")
@@ -319,7 +319,7 @@ func TestUpdateAzureMonitoringCreateFails(t *testing.T) {
 	}
 
 	err := captureStdoutErr(func() error {
-		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), dtc)
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error from createMonitoring failure, got nil")
@@ -341,7 +341,7 @@ func TestUpdateAzurePreviewShowsCreateStep(t *testing.T) {
 		findConnClientID: "client-id-000",
 	}
 	out := captureStdout(t, func() {
-		_ = updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), dtc)
+		_ = updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, updateAzRunner(t), noSleep, dtc)
 	})
 
 	if !strings.Contains(out, "create Azure monitoring configuration") {
@@ -357,6 +357,37 @@ func TestUpdateAzureEntryPoint_ClientInitError(t *testing.T) {
 	err := UpdateAzure("", "dt0s16.fake.token", false, time.Time{})
 	if err == nil {
 		t.Fatal("expected error for empty envURL, got nil")
+	}
+}
+
+func TestUpdateAzureFreshExtensionInstallWaitsBeforeReconcile(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := happyUninstallFakeDTClient()
+	dtc.installExtFresh = true // simulate 202 Accepted fresh install
+	dtc.extNotActive = true    // force retries so the sleeper is called
+
+	slept := false
+	sleeper := func(time.Duration) { slept = true }
+
+	err := captureStdoutErr(func() error {
+		return updateAzureWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, updateAzRunner(t), sleeper, dtc)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slept {
+		t.Error("expected injected sleeper to be called while polling for extension active")
+	}
+	if dtc.isExtActiveCalls == 0 {
+		t.Error("expected waitForExtensionActive to poll isExtensionActive")
+	}
+	// update proceeds even when extension did not become active in time
+	if len(dtc.updateMonConfigIDs) != 1 {
+		t.Errorf("expected monitoring config reconciled, got %v", dtc.updateMonConfigIDs)
 	}
 }
 

--- a/pkg/installer/extension_client.go
+++ b/pkg/installer/extension_client.go
@@ -191,6 +191,21 @@ func (e *ExtensionClient) FetchExtensionSchema(extensionName, version string) (*
 	return &schema, nil
 }
 
+// IsExtensionActive reports whether any installed version of extensionName has Active == true.
+// The DT hub install is asynchronous (202 Accepted); this is the readiness signal.
+func (e *ExtensionClient) IsExtensionActive(extensionName string) (bool, error) {
+	versionList, err := e.Extension.Get(context.Background(), extensionName)
+	if err != nil {
+		return false, fmt.Errorf("get extension versions: %w", err)
+	}
+	for _, item := range versionList.Items {
+		if item.Active {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // LatestExtensionVersion returns the highest semver version installed for extensionName.
 func (e *ExtensionClient) LatestExtensionVersion(extensionName string) (string, error) {
 	versionList, err := e.Extension.Get(context.Background(), extensionName)

--- a/pkg/installer/gcp/dtapi.go
+++ b/pkg/installer/gcp/dtapi.go
@@ -92,7 +92,12 @@ func splitConnectionsByCompleteness(conns []connRef) (complete, incomplete []con
 }
 
 type dtclient interface {
-	installExtension() error
+	// installExtension ensures the extension is installed. Returns true if it was freshly
+	// installed (202 Accepted from hub), false if it was already present.
+	installExtension() (bool, error)
+	// isExtensionActive reports whether the extension has an Active version. Use after a
+	// fresh install to poll until the async hub activation completes.
+	isExtensionActive() (bool, error)
 	createConnection(name string) (objectID string, err error)
 	// dtServiceAccount returns the Dynatrace principal granted impersonation rights.
 	dtServiceAccount() (email string, err error)
@@ -118,12 +123,19 @@ func newSDKDTClient(envURL, platformToken string) (*sdkDTClient, error) {
 	return &sdkDTClient{ExtensionClient: ec}, nil
 }
 
-func (d *sdkDTClient) installExtension() error {
+func (d *sdkDTClient) installExtension() (bool, error) {
 	if _, err := d.LatestExtensionVersion(extensionName); err == nil {
 		logger.Debug("extension already installed", "extension", extensionName)
-		return nil
+		return false, nil
 	}
-	return d.InstallExtension(extensionName, "")
+	if err := d.InstallExtension(extensionName, ""); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *sdkDTClient) isExtensionActive() (bool, error) {
+	return d.IsExtensionActive(extensionName)
 }
 
 func (d *sdkDTClient) createConnection(name string) (string, error) {

--- a/pkg/installer/gcp/dtapi_test.go
+++ b/pkg/installer/gcp/dtapi_test.go
@@ -476,3 +476,89 @@ func TestSDKDeleteMonitoring_HappyPath(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// ─── installExtension ────────────────────────────────────────────────────────
+
+func TestSDKInstallExtension_AlreadyInstalled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == extensionAPI {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0"}]}`))
+			return
+		}
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	fresh, err := newTestSDKClient(t, srv.URL).installExtension()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fresh {
+		t.Error("expected fresh=false for already-installed extension")
+	}
+}
+
+func TestSDKInstallExtension_FreshInstall(t *testing.T) {
+	installCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == extensionAPI:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"Extension not found"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == extensionAPI:
+			installCalled = true
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"extensionName":"com.dynatrace.extension.da-gcp","version":"1.2.0"}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	fresh, err := newTestSDKClient(t, srv.URL).installExtension()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fresh {
+		t.Error("expected fresh=true after hub install")
+	}
+	if !installCalled {
+		t.Error("expected InstallFromHub to be called")
+	}
+}
+
+// ─── isExtensionActive ───────────────────────────────────────────────────────
+
+func TestSDKIsExtensionActive_Active(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0","active":true}]}`))
+	}))
+	defer srv.Close()
+
+	active, err := newTestSDKClient(t, srv.URL).isExtensionActive()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("expected active=true when extension version has active:true")
+	}
+}
+
+func TestSDKIsExtensionActive_NotActive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"version":"1.2.0"}]}`))
+	}))
+	defer srv.Close()
+
+	active, err := newTestSDKClient(t, srv.URL).isExtensionActive()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Error("expected active=false when active field is absent")
+	}
+}

--- a/pkg/installer/gcp/helpers_test.go
+++ b/pkg/installer/gcp/helpers_test.go
@@ -92,14 +92,17 @@ func (noopDTClient) deleteMonitoring(string) error                     { return 
 
 // fakeDTClient records calls for assertion.
 type fakeDTClient struct {
-	connObjectID  string
-	connErr       error
-	dtSAEmail     string
-	dtSAErr       error
-	installExtErr error
-	callSeq       []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
-	updateErr     error
-	monErr        error
+	connObjectID     string
+	connErr          error
+	dtSAEmail        string
+	dtSAErr          error
+	installExtErr    error
+	installExtFresh  bool // when true, installExtension() signals a fresh hub install
+	extNotActive     bool // when true, isExtensionActive() always returns false
+	isExtActiveCalls int
+	callSeq          []string // ordered record of installExtension / createMonitoring / updateMonitoring calls
+	updateErr        error
+	monErr           error
 
 	// uninstall
 	findConnObjectID string
@@ -140,11 +143,12 @@ func happyUninstallFakeDTClient() *fakeDTClient {
 
 func (f *fakeDTClient) installExtension() (bool, error) {
 	f.callSeq = append(f.callSeq, "installExtension")
-	return false, f.installExtErr // false = already installed; no wait loop in tests
+	return f.installExtFresh, f.installExtErr
 }
 
 func (f *fakeDTClient) isExtensionActive() (bool, error) {
-	return true, nil
+	f.isExtActiveCalls++
+	return !f.extNotActive, nil
 }
 
 func (f *fakeDTClient) createConnection(string) (string, error) {

--- a/pkg/installer/gcp/helpers_test.go
+++ b/pkg/installer/gcp/helpers_test.go
@@ -64,8 +64,11 @@ func stubExecLookPath(t *testing.T) func() {
 // noopDTClient is used in tests that never reach the DT API calls.
 type noopDTClient struct{}
 
-func (noopDTClient) installExtension() error {
-	return fmt.Errorf("unexpected installExtension call")
+func (noopDTClient) installExtension() (bool, error) {
+	return false, fmt.Errorf("unexpected installExtension call")
+}
+func (noopDTClient) isExtensionActive() (bool, error) {
+	return false, fmt.Errorf("unexpected isExtensionActive call")
 }
 func (noopDTClient) createConnection(string) (string, error) {
 	return "", fmt.Errorf("unexpected createConnection call")
@@ -135,9 +138,13 @@ func happyUninstallFakeDTClient() *fakeDTClient {
 	}
 }
 
-func (f *fakeDTClient) installExtension() error {
+func (f *fakeDTClient) installExtension() (bool, error) {
 	f.callSeq = append(f.callSeq, "installExtension")
-	return f.installExtErr
+	return false, f.installExtErr // false = already installed; no wait loop in tests
+}
+
+func (f *fakeDTClient) isExtensionActive() (bool, error) {
+	return true, nil
 }
 
 func (f *fakeDTClient) createConnection(string) (string, error) {

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -309,9 +309,19 @@ func runInstallSteps(cfg gcpConfig, runner cmdRunner, sleeper func(time.Duration
 	}
 	display.ColorOK.Println("  ✓ Connection updated")
 
-	if err := dtc.installExtension(); err != nil {
+	freshlyInstalled, err := dtc.installExtension()
+	if err != nil {
 		gcpPartialFailureHint(cfg, completed)
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
+	}
+	if freshlyInstalled {
+		logger.Debug("extension freshly installed (async), waiting for it to become active")
+		fmt.Println("  Extension freshly installed — waiting for it to become active...")
+		if waitErr := waitForExtensionActive(dtc, sleeper); waitErr != nil {
+			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
+		} else {
+			display.ColorOK.Println("  ✓ Extension is active")
+		}
 	}
 
 	fmt.Printf("  Step 7/%d: Create GCP monitoring configuration...\n", total)
@@ -352,6 +362,11 @@ const (
 	updateConnectionInitialDelay = 30 * time.Second
 	updateConnectionMaxAttempts  = 30
 	updateConnectionRetryDelay   = 5 * time.Second
+
+	// extensionActiveMaxAttempts x extensionActiveRetryDelay bounds how long dtwiz polls for a
+	// freshly hub-installed extension to become active (hub install is 202 Accepted = async).
+	extensionActiveMaxAttempts = 12
+	extensionActiveRetryDelay  = 5 * time.Second
 )
 
 // updateConnectionRetryable reports whether err is worth retrying. The live impersonation
@@ -405,4 +420,25 @@ func updateConnectionWithRetry(dtc dtclient, connObjectID, connName, serviceAcco
 			"the GCP resources and connection were already created — wait a moment and re-run to finish linking", lastErr)
 	}
 	return lastErr
+}
+
+// waitForExtensionActive polls until the extension reports Active == true.
+// Hub installs are async (202 Accepted); Active flipping to true is the readiness signal.
+func waitForExtensionActive(dtc dtclient, sleeper func(time.Duration)) error {
+	return installer.Retry(sleeper, installer.RetryConfig{
+		MaxAttempts: extensionActiveMaxAttempts,
+		Delay:       func(int) time.Duration { return extensionActiveRetryDelay },
+		OnRetry: func(attempt int, _ time.Duration, _ error) {
+			logger.Debug("extension not yet active, polling", "attempt", attempt)
+		},
+	}, func() error {
+		active, err := dtc.isExtensionActive()
+		if err != nil {
+			return err
+		}
+		if !active {
+			return fmt.Errorf("extension not yet active")
+		}
+		return nil
+	})
 }

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -196,7 +196,7 @@ func installGCPWithRunner(
 	// Complete connection found: reconcile monitoring config in place; don't recreate the SA/bindings.
 	if _, err := selectUpdatableConnection(existing, name); err == nil {
 		fmt.Println("\n  Note: prerequisites already exist — running update instead of a fresh install.")
-		return updateGCPWithRunner(envURL, platformToken, dryRun, startTime, runner, dtc)
+		return updateGCPWithRunner(envURL, platformToken, dryRun, startTime, runner, sleeper, dtc)
 	}
 	resumeConnID, err := gcpResumableConnection(existing, name)
 	if err != nil {

--- a/pkg/installer/gcp/install.go
+++ b/pkg/installer/gcp/install.go
@@ -362,11 +362,6 @@ const (
 	updateConnectionInitialDelay = 30 * time.Second
 	updateConnectionMaxAttempts  = 30
 	updateConnectionRetryDelay   = 5 * time.Second
-
-	// extensionActiveMaxAttempts x extensionActiveRetryDelay bounds how long dtwiz polls for a
-	// freshly hub-installed extension to become active (hub install is 202 Accepted = async).
-	extensionActiveMaxAttempts = 12
-	extensionActiveRetryDelay  = 5 * time.Second
 )
 
 // updateConnectionRetryable reports whether err is worth retrying. The live impersonation
@@ -422,23 +417,6 @@ func updateConnectionWithRetry(dtc dtclient, connObjectID, connName, serviceAcco
 	return lastErr
 }
 
-// waitForExtensionActive polls until the extension reports Active == true.
-// Hub installs are async (202 Accepted); Active flipping to true is the readiness signal.
 func waitForExtensionActive(dtc dtclient, sleeper func(time.Duration)) error {
-	return installer.Retry(sleeper, installer.RetryConfig{
-		MaxAttempts: extensionActiveMaxAttempts,
-		Delay:       func(int) time.Duration { return extensionActiveRetryDelay },
-		OnRetry: func(attempt int, _ time.Duration, _ error) {
-			logger.Debug("extension not yet active, polling", "attempt", attempt)
-		},
-	}, func() error {
-		active, err := dtc.isExtensionActive()
-		if err != nil {
-			return err
-		}
-		if !active {
-			return fmt.Errorf("extension not yet active")
-		}
-		return nil
-	})
+	return installer.WaitForExtensionActive(dtc.isExtensionActive, sleeper)
 }

--- a/pkg/installer/gcp/install_test.go
+++ b/pkg/installer/gcp/install_test.go
@@ -97,6 +97,50 @@ func TestGCPInstallExtensionFailureStopsBeforeMonitoringConfig(t *testing.T) {
 	}
 }
 
+func TestGCPFreshExtensionInstall_WaitsForActiveThenCreatesMonitoring(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := happyFakeDTClient()
+	dtc.installExtFresh = true // simulate 202 Accepted from hub
+
+	err := captureStdoutErr(func() error {
+		return installGCPWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, happyGcloudRunner(nil), noSleep, dtc)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dtc.isExtActiveCalls == 0 {
+		t.Error("expected isExtensionActive to be polled after fresh install")
+	}
+	if dtc.monCalledWith.connObjectID == "" {
+		t.Error("expected createMonitoring to be called after extension became active")
+	}
+}
+
+func TestGCPFreshExtensionInstall_PollTimeoutProceeds(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := happyFakeDTClient()
+	dtc.installExtFresh = true
+	dtc.extNotActive = true // isExtensionActive always returns false; poll exhausts
+
+	err := captureStdoutErr(func() error {
+		return installGCPWithRunner("https://abc.live.dynatrace.com", "dt0s16.fake.token", false, time.Time{}, happyGcloudRunner(nil), noSleep, dtc)
+	})
+	if err != nil {
+		t.Fatalf("flow must continue past poll timeout: %v", err)
+	}
+	if dtc.monCalledWith.connObjectID == "" {
+		t.Error("createMonitoring must be called even when extension poll times out")
+	}
+}
+
 func TestGCPDryRun(t *testing.T) {
 	old := installer.AutoConfirm
 	installer.AutoConfirm = true

--- a/pkg/installer/gcp/update.go
+++ b/pkg/installer/gcp/update.go
@@ -62,7 +62,7 @@ func updateGCPWithRunner(
 		return err
 	}
 
-	if err := dtc.installExtension(); err != nil {
+	if _, err := dtc.installExtension(); err != nil {
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
 	}
 

--- a/pkg/installer/gcp/update.go
+++ b/pkg/installer/gcp/update.go
@@ -16,7 +16,7 @@ func UpdateGCP(envURL, platformToken string, dryRun bool, startTime time.Time) e
 	if err != nil {
 		return err
 	}
-	return updateGCPWithRunner(envURL, platformToken, dryRun, startTime, realRunner, dtc)
+	return updateGCPWithRunner(envURL, platformToken, dryRun, startTime, realRunner, time.Sleep, dtc)
 }
 
 func updateGCPWithRunner(
@@ -24,6 +24,7 @@ func updateGCPWithRunner(
 	dryRun bool,
 	startTime time.Time,
 	runner cmdRunner,
+	sleeper func(time.Duration),
 	dtc dtclient,
 ) error {
 	name := integrationNameForEnv(envURL)
@@ -69,7 +70,7 @@ func updateGCPWithRunner(
 	if freshlyInstalled {
 		logger.Debug("extension freshly installed (async), waiting for it to become active")
 		fmt.Println("  Extension freshly installed — waiting for it to become active...")
-		if waitErr := waitForExtensionActive(dtc, time.Sleep); waitErr != nil {
+		if waitErr := waitForExtensionActive(dtc, sleeper); waitErr != nil {
 			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
 		} else {
 			display.ColorOK.Println("  ✓ Extension is active")

--- a/pkg/installer/gcp/update.go
+++ b/pkg/installer/gcp/update.go
@@ -62,8 +62,18 @@ func updateGCPWithRunner(
 		return err
 	}
 
-	if _, err := dtc.installExtension(); err != nil {
+	freshlyInstalled, err := dtc.installExtension()
+	if err != nil {
 		return fmt.Errorf("installing extension %s: %w", extensionName, err)
+	}
+	if freshlyInstalled {
+		logger.Debug("extension freshly installed (async), waiting for it to become active")
+		fmt.Println("  Extension freshly installed — waiting for it to become active...")
+		if waitErr := waitForExtensionActive(dtc, time.Sleep); waitErr != nil {
+			logger.Debug("extension did not become active in time, proceeding anyway", "error", waitErr)
+		} else {
+			display.ColorOK.Println("  ✓ Extension is active")
+		}
 	}
 
 	if err := reconcileMonitoring(cfg, monConfigIDs, dtc); err != nil {

--- a/pkg/installer/gcp/update_test.go
+++ b/pkg/installer/gcp/update_test.go
@@ -20,7 +20,7 @@ func TestGCPUpdateExistingConfig(t *testing.T) {
 		findMonConfigID: "mon-1",
 	}
 	err := captureStdoutErr(func() error {
-		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), dtc)
+		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), noSleep, dtc)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -45,7 +45,7 @@ func TestGCPUpdateCreatesWhenNoConfig(t *testing.T) {
 		// no monitoring config present
 	}
 	err := captureStdoutErr(func() error {
-		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), dtc)
+		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), noSleep, dtc)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -67,7 +67,7 @@ func TestGCPUpdateExtensionFailureStopsBeforeMonitoringConfig(t *testing.T) {
 		installExtErr:   fmt.Errorf("extension install failed"),
 	}
 	err := captureStdoutErr(func() error {
-		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), dtc)
+		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected extension install error, got nil")
@@ -85,7 +85,7 @@ func TestGCPUpdateRejectsPartialConnection(t *testing.T) {
 		findConnRefs: []connRef{{objectID: "conn-1", serviceAccountEmail: ""}},
 	}
 	err := captureStdoutErr(func() error {
-		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), dtc)
+		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), noSleep, dtc)
 	})
 	if err == nil {
 		t.Fatal("expected error for partial connection, got nil")
@@ -103,12 +103,46 @@ func TestGCPUpdateDryRun(t *testing.T) {
 		findMonConfigID: "mon-1",
 	}
 	out := captureStdout(t, func() {
-		_ = updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, uninstallGcloudRunner("my-project"), dtc)
+		_ = updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", true, time.Time{}, uninstallGcloudRunner("my-project"), noSleep, dtc)
 	})
 	if len(dtc.updateMonConfigIDs) != 0 || dtc.createMonCalled {
 		t.Error("dry-run must not change any monitoring config")
 	}
 	if !strings.Contains(out, "[dry-run]") {
 		t.Errorf("expected [dry-run] marker; got:\n%s", out)
+	}
+}
+
+func TestUpdateGCPFreshExtensionInstallWaitsBeforeReconcile(t *testing.T) {
+	old := installer.AutoConfirm
+	installer.AutoConfirm = true
+	defer func() { installer.AutoConfirm = old }()
+	defer stubExecLookPath(t)()
+
+	dtc := &fakeDTClient{
+		findConnRefs:    []connRef{{objectID: "conn-1", serviceAccountEmail: "dtwiz-gcp@my-project.iam.gserviceaccount.com"}},
+		findMonConfigID: "mon-1",
+		installExtFresh: true, // simulate 202 Accepted fresh install
+		extNotActive:    true, // force retries so the sleeper is called
+	}
+
+	slept := false
+	sleeper := func(time.Duration) { slept = true }
+
+	err := captureStdoutErr(func() error {
+		return updateGCPWithRunner("https://abc.live.dynatrace.com", "tok", false, time.Time{}, uninstallGcloudRunner("my-project"), sleeper, dtc)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slept {
+		t.Error("expected injected sleeper to be called while polling for extension active")
+	}
+	if dtc.isExtActiveCalls == 0 {
+		t.Error("expected waitForExtensionActive to poll isExtensionActive")
+	}
+	// update proceeds even when extension did not become active in time
+	if len(dtc.updateMonConfigIDs) != 1 {
+		t.Errorf("expected monitoring config reconciled, got %v", dtc.updateMonConfigIDs)
 	}
 }

--- a/pkg/installer/retry.go
+++ b/pkg/installer/retry.go
@@ -1,9 +1,40 @@
 package installer
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
+
+const (
+	// ExtensionActiveMaxAttempts x ExtensionActiveRetryDelay bounds how long dtwiz polls for a
+	// freshly hub-installed extension to become active (hub install is 202 Accepted = async).
+	ExtensionActiveMaxAttempts = 12
+	ExtensionActiveRetryDelay  = 5 * time.Second
+)
+
+// WaitForExtensionActive polls isActive until it returns true, using sleeper between attempts.
+// Hub installs are async (202 Accepted); Active flipping to true is the readiness signal.
+func WaitForExtensionActive(isActive func() (bool, error), sleeper func(time.Duration)) error {
+	return Retry(sleeper, RetryConfig{
+		MaxAttempts: ExtensionActiveMaxAttempts,
+		Delay:       func(int) time.Duration { return ExtensionActiveRetryDelay },
+		OnRetry: func(attempt int, _ time.Duration, _ error) {
+			logger.Debug("extension not yet active, polling", "attempt", attempt)
+		},
+	}, func() error {
+		active, err := isActive()
+		if err != nil {
+			return err
+		}
+		if !active {
+			return fmt.Errorf("extension not yet active")
+		}
+		return nil
+	})
+}
 
 // RetryConfig parameterizes Retry: how many times to try, how long to wait
 // between attempts, and which errors are worth retrying at all.


### PR DESCRIPTION
## Description

- [x] Bug fix

`dtwiz install azure` and failed at step 7 on tenants where the
extension had never been installed before. The Dynatrace Hub install endpoint returns
202 Accepted (async), so the extension was not yet active when the monitoring
configuration creation was attempted, causing a 400 validation error.

## How to test

1. Find a Dynatrace tenant where `com.dynatrace.extension.da-azure` is
   not installed. (or remove it as described - contact me for guidance)
2. Run `dtwiz install azure`.
3. Confirm the install completes without error and the connection logs in Dynatrace
   show healthy ingestion.
4. On a tenant where the extension is already installed, confirm the install and update
   flows behave as before with no added wait.

## Which other features are affected?

1. `dtwiz update azure` -- the same wait is applied if the
   extension is missing and re-installed during an update (e.g. after a manual deletion).

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
