### PR TITLE
feat: add example apps

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
 examples:
   - changed-files:
       - any-glob-to-all-files: "examples/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-all-files: "**/*.md"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ config.yaml
 
 # Build artifacts
 *.log
+dtwiz-examples.tar.gz
 .integrationtests.env
 completions/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ archives:
         formats:
           - zip
 
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,7 @@ project_name: dtwiz
 before:
   hooks:
     - go mod tidy
-    - mkdir -p dist
-    - tar -czf dist/dtwiz-examples.tar.gz examples/
+    - tar -czf dtwiz-examples.tar.gz examples/
 
 builds:
   - env:
@@ -38,7 +37,7 @@ archives:
 
 release:
   extra_files:
-    - glob: dist/dtwiz-examples.tar.gz
+    - glob: dtwiz-examples.tar.gz
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,7 @@ project_name: dtwiz
 before:
   hooks:
     - go mod tidy
+    - tar -czf dtwiz-examples.tar.gz examples/
 
 builds:
   - env:
@@ -28,11 +29,15 @@ archives:
     files:
       - LICENSE*
       - README*
+      - examples/
     format_overrides:
       - goos: windows
         formats:
           - zip
 
+
+extra_files:
+  - glob: dtwiz-examples.tar.gz
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,8 @@ project_name: dtwiz
 before:
   hooks:
     - go mod tidy
-    - tar -czf dtwiz-examples.tar.gz examples/
+    - mkdir -p dist
+    - tar -czf dist/dtwiz-examples.tar.gz examples/
 
 builds:
   - env:
@@ -29,7 +30,6 @@ archives:
     files:
       - LICENSE*
       - README*
-      - examples/
     format_overrides:
       - goos: windows
         formats:
@@ -38,7 +38,7 @@ archives:
 
 release:
   extra_files:
-    - glob: dtwiz-examples.tar.gz
+    - glob: dist/dtwiz-examples.tar.gz
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,8 +36,9 @@ archives:
           - zip
 
 
-extra_files:
-  - glob: dtwiz-examples.tar.gz
+release:
+  extra_files:
+    - glob: dtwiz-examples.tar.gz
 
 checksum:
   name_template: 'checksums.txt'

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -370,14 +370,10 @@ var installGCPCmd = &cobra.Command{
 }
 
 var installDemoCmd = &cobra.Command{
-	Use:    "demo",
-	Short:  "Install the schnitzel demo app and set up Dynatrace OTel monitoring",
-	Args:   cobra.NoArgs,
-	Hidden: true,
+	Use:   "demo",
+	Short: "Install the schnitzel demo app and set up Dynatrace OTel monitoring",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !featureflags.IsEnabled(featureflags.Experimental) {
-			return fmt.Errorf("demo installation is an experimental feature; enable it with --experimental or DTWIZ_EXPERIMENTAL=true")
-		}
 		envURL, accessTok, platformTok, err := getDtEnvironment()
 		if err != nil {
 			return err

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -84,6 +85,9 @@ var setupCmd = &cobra.Command{
 			return nil
 		}
 
+		_, schnitzelStatErr := os.Stat(otel.BundledDemoPath())
+		schnitzelPresent := schnitzelStatErr == nil
+
 		for i, r := range actionable {
 			fmt.Printf("  %s  %s\n", display.ColorHeader.Sprintf("[%d]", i+1), r.Title)
 		}
@@ -93,7 +97,7 @@ var setupCmd = &cobra.Command{
 				fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint(" · "), display.ColorDefault.Sprint(r.Title))
 			}
 		}
-		if featureflags.IsEnabled(featureflags.Experimental) && !demoRunning {
+		if !schnitzelPresent && !demoRunning {
 			fmt.Println()
 			fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint("[d]"), display.ColorDefault.Sprint("Install demo app (schnitzel)"))
 		}
@@ -120,7 +124,7 @@ var setupCmd = &cobra.Command{
 			return uninstallCmd.Help()
 		}
 
-		if input == "d" && featureflags.IsEnabled(featureflags.Experimental) {
+		if input == "d" && !schnitzelPresent {
 			fmt.Println()
 
 			envURL, accessTok, platformTok, err := getDtEnvironment()

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -48,11 +47,8 @@ var setupCmd = &cobra.Command{
 		display.Header("Analyzing system...")
 
 		// Start demo-running check concurrently with system analysis — they are independent.
-		var demoRunningCh chan bool
-		if featureflags.IsEnabled(featureflags.Experimental) {
-			demoRunningCh = make(chan bool, 1)
-			go func() { demoRunningCh <- otel.IsDemoRunning() }()
-		}
+		demoRunningCh := make(chan bool, 1)
+		go func() { demoRunningCh <- otel.IsDemoRunning() }()
 
 		info, err := analyzeSystem()
 		if err != nil {
@@ -60,10 +56,7 @@ var setupCmd = &cobra.Command{
 		}
 		fmt.Println(info.Summary())
 
-		var demoRunning bool
-		if demoRunningCh != nil {
-			demoRunning = <-demoRunningCh
-		}
+		demoRunning := <-demoRunningCh
 
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")
@@ -85,9 +78,6 @@ var setupCmd = &cobra.Command{
 			return nil
 		}
 
-		_, schnitzelStatErr := os.Stat(otel.BundledDemoPath())
-		schnitzelPresent := schnitzelStatErr == nil
-
 		for i, r := range actionable {
 			fmt.Printf("  %s  %s\n", display.ColorHeader.Sprintf("[%d]", i+1), r.Title)
 		}
@@ -97,7 +87,7 @@ var setupCmd = &cobra.Command{
 				fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint(" · "), display.ColorDefault.Sprint(r.Title))
 			}
 		}
-		if !schnitzelPresent && !demoRunning {
+		if !demoRunning {
 			fmt.Println()
 			fmt.Printf("  %s  %s\n", display.ColorDefault.Sprint("[d]"), display.ColorDefault.Sprint("Install demo app (schnitzel)"))
 		}
@@ -124,7 +114,7 @@ var setupCmd = &cobra.Command{
 			return uninstallCmd.Help()
 		}
 
-		if input == "d" && !schnitzelPresent {
+		if input == "d" {
 			fmt.Println()
 
 			envURL, accessTok, platformTok, err := getDtEnvironment()

--- a/examples/schnitzel/.gitignore
+++ b/examples/schnitzel/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/examples/schnitzel/README.md
+++ b/examples/schnitzel/README.md
@@ -1,0 +1,40 @@
+# Schnitzel 🥩
+
+Four-service Python application for ordering Wiener Schnitzel.
+
+## Architecture
+
+| Service        | Port | Description                          |
+|----------------|------|--------------------------------------|
+| Frontend       | 8080 | Web UI with order button             |
+| Order          | 8081 | Creates and stores orders            |
+| Delivery       | 8082 | Assigns delivery with random ETA     |
+| Loadgenerator  | —    | Sends automated order batches        |
+
+**Flow:** Frontend → Order Service → Delivery Service
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run
+
+Start all services in separate terminals:
+
+```bash
+# Terminal 1 – Order Service
+python order/app.py
+
+# Terminal 2 – Delivery Service
+python delivery/app.py
+
+# Terminal 3 – Frontend
+python frontend/app.py
+
+# Terminal 4 – Load Generator (optional)
+python loadgenerator/app.py
+```
+
+Then open <http://localhost:8080> and click the button to order a schnitzel.

--- a/examples/schnitzel/delivery/app.py
+++ b/examples/schnitzel/delivery/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, request, jsonify
+import random
+import uuid
+import logging
+import threading
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+deliveries = {}
+
+
+def heartbeat():
+    while True:
+        logger.info("[delivery] I am alive schnitzel")
+        threading.Event().wait(5)
+
+threading.Thread(target=heartbeat, daemon=True).start()
+
+
+@app.route("/deliveries", methods=["POST"])
+def create_delivery():
+    data = request.get_json()
+    delivery_id = str(uuid.uuid4())[:8]
+    eta_minutes = random.randint(15, 45)
+    delivery = {
+        "delivery_id": delivery_id,
+        "order_id": data.get("order_id"),
+        "item": data.get("item", "schnitzel"),
+        "status": "dispatched",
+        "eta": f"{eta_minutes} minutes",
+    }
+    deliveries[delivery_id] = delivery
+    print(f"[DELIVERY] Delivery {delivery_id} for order {delivery['order_id']} — ETA {eta_minutes}min")
+    return jsonify(delivery), 201
+
+
+@app.route("/deliveries/<delivery_id>", methods=["GET"])
+def get_delivery(delivery_id):
+    delivery = deliveries.get(delivery_id)
+    if not delivery:
+        return jsonify({"error": "Delivery not found"}), 404
+    return jsonify(delivery)
+
+
+@app.route("/deliveries", methods=["GET"])
+def list_deliveries():
+    return jsonify(list(deliveries.values()))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8082, debug=False, use_reloader=False)

--- a/examples/schnitzel/frontend/app.py
+++ b/examples/schnitzel/frontend/app.py
@@ -1,0 +1,71 @@
+from flask import Flask, render_template, jsonify
+import requests
+import os
+import logging
+import threading
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+
+def heartbeat():
+    while True:
+        logger.info("[frontend] I am alive schnitzel")
+        threading.Event().wait(5)
+
+threading.Thread(target=heartbeat, daemon=True).start()
+
+ORDER_SERVICE_URL = os.getenv("ORDER_SERVICE_URL", "http://localhost:8081")
+DELIVERY_SERVICE_URL = os.getenv("DELIVERY_SERVICE_URL", "http://localhost:8082")
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/order", methods=["POST"])
+def place_order():
+    try:
+        # Call order service
+        order_resp = requests.post(
+            f"{ORDER_SERVICE_URL}/orders",
+            json={"item": "schnitzel", "quantity": 1},
+            timeout=5,
+        )
+        order_data = order_resp.json()
+        order_id = order_data.get("order_id")
+
+        if order_resp.status_code != 201:
+            logger.warning("Order %s was not confirmed: %s", order_id, order_data.get("error", "unknown"))
+            return jsonify({"status": "failed", "order": order_data}), 500
+
+        # Call delivery service
+        delivery_resp = requests.post(
+            f"{DELIVERY_SERVICE_URL}/deliveries",
+            json={"order_id": order_id, "item": "schnitzel"},
+            timeout=5,
+        )
+        delivery_data = delivery_resp.json()
+
+        logger.info(
+            "Schnitzel ordered! Order #%s, estimated delivery: %s",
+            order_id,
+            delivery_data.get("eta", "unknown"),
+        )
+
+        return jsonify(
+            {
+                "status": "success",
+                "order": order_data,
+                "delivery": delivery_data,
+            }
+        )
+    except requests.exceptions.RequestException as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080, debug=False, use_reloader=False)

--- a/examples/schnitzel/frontend/templates/index.html
+++ b/examples/schnitzel/frontend/templates/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script type="text/javascript" src="https://js-cdn.dynatracelabs.com/jstag/1837f09f4dd/bf29515lbk/33ae6078ab64c7d4_complete.js" crossorigin="anonymous"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Order Schnitzel</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Segoe UI', sans-serif;
+            display: flex; justify-content: center; align-items: center;
+            min-height: 100vh;
+            background: linear-gradient(135deg, #f5e6ca 0%, #e8c97a 100%);
+        }
+        .card {
+            background: white; border-radius: 16px; padding: 3rem;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.1); text-align: center;
+            max-width: 400px; width: 90%;
+        }
+        h1 { font-size: 2rem; color: #333; margin-bottom: 0.5rem; }
+        .emoji { font-size: 4rem; margin-bottom: 1rem; }
+        p { color: #666; margin-bottom: 1.5rem; }
+        button {
+            background: #d4880f; color: white; border: none;
+            padding: 14px 40px; font-size: 1.1rem; border-radius: 8px;
+            cursor: pointer; transition: background 0.2s, transform 0.1s;
+        }
+        button:hover { background: #b8750d; transform: scale(1.02); }
+        button:active { transform: scale(0.98); }
+        button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
+        #result {
+            margin-top: 1.5rem; padding: 1rem; border-radius: 8px;
+            display: none; font-size: 0.95rem;
+        }
+        .success { background: #d4edda; color: #155724; display: block !important; }
+        .error { background: #f8d7da; color: #721c24; display: block !important; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="emoji">🍽️</div>
+        <h1>Schnitzel Service</h1>
+        <p>Hungry? Order a freshly made Wiener Schnitzel!</p>
+        <button id="orderBtn" onclick="orderSchnitzel()">Order Schnitzel 🥩</button>
+        <div id="result"></div>
+    </div>
+    <script>
+        async function orderSchnitzel() {
+            const btn = document.getElementById('orderBtn');
+            const result = document.getElementById('result');
+            btn.disabled = true;
+            btn.textContent = 'Ordering...';
+            result.className = '';
+            result.style.display = 'none';
+            try {
+                const resp = await fetch('/order', { method: 'POST' });
+                const data = await resp.json();
+                if (data.status === 'success') {
+                    result.className = 'success';
+                    result.innerHTML = `<strong>Order placed!</strong><br>
+                        Order #${data.order.order_id}<br>
+                        Delivery ETA: ${data.delivery.eta}`;
+                } else {
+                    throw new Error(data.message || 'Order failed');
+                }
+            } catch (e) {
+                result.className = 'error';
+                result.innerHTML = `<strong>Error:</strong> ${e.message}`;
+            } finally {
+                btn.disabled = false;
+                btn.textContent = 'Order Schnitzel 🥩';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/examples/schnitzel/loadgenerator/app.py
+++ b/examples/schnitzel/loadgenerator/app.py
@@ -1,0 +1,38 @@
+import requests
+import random
+import time
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+FRONTEND_URL = "http://localhost:8080"
+
+
+def place_order():
+    try:
+        resp = requests.post(f"{FRONTEND_URL}/order", timeout=10)
+        data = resp.json()
+        if data.get("status") == "success":
+            order_id = data.get("order", {}).get("order_id", "?")
+            eta = data.get("delivery", {}).get("eta", "?")
+            logger.info("[loadgenerator] Order %s placed successfully — ETA %s", order_id, eta)
+        else:
+            error = data.get("order", {}).get("error", "unknown")
+            logger.warning("[loadgenerator] Order failed: %s", error)
+    except requests.exceptions.RequestException as e:
+        logger.error("[loadgenerator] Request error: %s", e)
+
+
+RUNTIME_SECONDS = 5 * 60
+
+if __name__ == "__main__":
+    logger.info("[loadgenerator] Starting — sending 1-10 orders every 5-10 seconds for %d minutes", RUNTIME_SECONDS // 60)
+    start_time = time.time()
+    while time.time() - start_time < RUNTIME_SECONDS:
+        batch_size = random.randint(1, 10)
+        logger.info("[loadgenerator] Sending batch of %d order(s)", batch_size)
+        for _ in range(batch_size):
+            place_order()
+        time.sleep(random.uniform(5, 10))
+    logger.info("[loadgenerator] Runtime of %d minutes reached — shutting down", RUNTIME_SECONDS // 60)

--- a/examples/schnitzel/order/app.py
+++ b/examples/schnitzel/order/app.py
@@ -1,0 +1,110 @@
+from flask import Flask, request, jsonify
+import uuid
+import random
+import datetime
+import logging
+import threading
+import traceback
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+orders = {}
+request_count = 0
+
+
+def heartbeat():
+    while True:
+        logger.info("[order] I am alive schnitzel")
+        threading.Event().wait(5)
+
+threading.Thread(target=heartbeat, daemon=True).start()
+
+
+FAILURE_REASONS = [
+    {
+        "exception": "InventoryError: SKU schnitzel_classic temporarily unavailable",
+        "log": "Order {order_id} failed — could not reserve {quantity}x {item} due to upstream inventory sync lag (warehouse region: eu-central-1, last sync: {ts})",
+    },
+    {
+        "exception": "PaymentGatewayTimeout: gateway did not respond within 3000ms",
+        "log": "Payment pre-auth for order {order_id} timed out after 3s — customer may retry, item: {item}, qty: {quantity}",
+    },
+    {
+        "exception": "ValidationError: quantity must be between 1 and 50",
+        "log": "Order {order_id} rejected by validation layer — item={item}, requested_quantity={quantity}, max_allowed=50, source_ip={ip}",
+    },
+    {
+        "exception": "KitchenCapacityExceeded: current load 48/50",
+        "log": "Kitchen capacity exceeded for order {order_id}, cannot accept {quantity}x {item} right now — current utilization 96%, cool-down ETA ~4min",
+    },
+    {
+        "exception": "DatabaseError: deadlock detected on table 'orders'",
+        "log": "Order {order_id} hit a transient DB deadlock while inserting {quantity}x {item} — will not retry automatically, created_at={ts}",
+    },
+]
+
+
+@app.route("/orders", methods=["POST"])
+def create_order():
+    global request_count
+    request_count += 1
+
+    data = request.get_json()
+    order_id = str(uuid.uuid4())[:8]
+    item = data.get("item", "schnitzel")
+    quantity = data.get("quantity", 1)
+    ts = datetime.datetime.utcnow().isoformat()
+
+    # 1st request: always succeed, 2nd: always fail, 3rd+: ~20% random failure
+    should_fail = (request_count == 2) or (request_count > 2 and random.random() < 0.2)
+    if should_fail:
+        reason = random.choice(FAILURE_REASONS)
+        try:
+            raise RuntimeError(reason["exception"])
+        except RuntimeError:
+            logger.error(
+                reason["log"].format(
+                    order_id=order_id,
+                    item=item,
+                    quantity=quantity,
+                    ts=ts,
+                    ip=request.remote_addr,
+                ),
+                exc_info=True,
+            )
+            return jsonify({
+                "order_id": order_id,
+                "status": "failed",
+                "error": reason["exception"].split(":")[0],
+            }), 500
+
+    order = {
+        "order_id": order_id,
+        "item": item,
+        "quantity": quantity,
+        "status": "confirmed",
+        "created_at": ts,
+    }
+    orders[order_id] = order
+    print(f"[ORDER] New order {order_id}: {order['quantity']}x {order['item']}")
+    return jsonify(order), 201
+
+
+@app.route("/orders/<order_id>", methods=["GET"])
+def get_order(order_id):
+    order = orders.get(order_id)
+    if not order:
+        return jsonify({"error": "Order not found"}), 404
+    return jsonify(order)
+
+
+@app.route("/orders", methods=["GET"])
+def list_orders():
+    return jsonify(list(orders.values()))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8081, debug=False, use_reloader=False)

--- a/examples/schnitzel/requirements.txt
+++ b/examples/schnitzel/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/openspec/changes/bundle-demo-examples/design.md
+++ b/openspec/changes/bundle-demo-examples/design.md
@@ -29,6 +29,7 @@ Alternatives considered:
 - **`go:embed`**: Demo files baked into every binary. Works offline after first extraction. Rejected because it adds demo overhead to all users, including those who never use the demo.
 - **GoReleaser archive + install script copy**: examples ship in the release archive and install scripts copy them to `~/.dtwiz/examples/`. Works for users who use the install script, but fails silently for users who download the binary manually. Also adds complexity to the install scripts on all platforms.
 - **Download the full release archive**: if `~/.dtwiz/examples/schnitzel/` is missing, download the full release archive and extract examples from it. Rejected in favor of a small dedicated asset (`dtwiz-examples.tar.gz`) that contains only the example apps.
+- **Write archive to disk then delete after extraction**: download `dtwiz-examples.tar.gz` to a temp file, extract it, then delete the archive. Rejected in favor of streaming the HTTP response body directly into the tar extractor — no temp file is ever written, so no cleanup step is needed.
 
 ### Examples location: `~/.dtwiz/examples/` over CWD
 

--- a/openspec/changes/bundle-demo-examples/design.md
+++ b/openspec/changes/bundle-demo-examples/design.md
@@ -22,7 +22,9 @@ The demo install flow currently fetches the schnitzel app from `github.com/diete
 
 ### Release asset download over `go:embed` or third-party download
 
-Publishing all examples together as `dtwiz-examples.tar.gz` and downloading it on demand keeps the binary small for all users. Users who never run the demo get no extra weight. The download only happens when `~/.dtwiz/examples/schnitzel/` is absent. The URL is built from the binary's built-in version string, so the downloaded files always match the running version. Schnitzel is one example inside the archive; future examples can be added to the same asset without changing the download mechanism.
+Publishing all examples together as `dtwiz-examples.tar.gz` and downloading it on demand keeps the binary small for all users. Users who never run the demo get no extra weight. The download only happens when `~/.dtwiz/examples/schnitzel/` is absent. Release builds use the binary's built-in version string to select the matching release asset. Development and snapshot builds use the latest release asset because they do not necessarily have a matching published GitHub release. Schnitzel is one example inside the archive; future examples can be added to the same asset without changing the download mechanism.
+
+The release process creates `dtwiz-examples.tar.gz` under GoReleaser's `dist/` directory and publishes it as a release extra file. Keeping the generated tarball under `dist/` keeps it out of the working tree and lets normal release artifact cleanup remove it.
 
 Alternatives considered:
 
@@ -51,6 +53,7 @@ Alternatives considered:
 ## Risks / Trade-offs
 
 - **Binary size**: no change. Demo files are not embedded in the binary. They are downloaded only when needed.
+- **Installer archive size**: no change for normal platform archives. Demo files are not included in OS-specific install archives or copied by install scripts.
 - **Network requirement when path is absent**: downloading the release asset requires a network call if `~/.dtwiz/examples/schnitzel/` is missing. This is not a new limitation: the demo already requires network access for OTel Collector setup and Dynatrace ingestion.
-- **Stale examples after upgrade**: if a user upgrades dtwiz and the old `~/.dtwiz/examples/schnitzel/` already exists, it will not be automatically refreshed. The new binary will download the updated asset only when the path is absent. For now this is acceptable; version checking is out of scope.
+- **Stale examples after upgrade**: if a user upgrades dtwiz and the old `~/.dtwiz/examples/schnitzel/` already exists, it will not be automatically refreshed. The new binary will download the updated asset only when the path is absent. Users can remove the directory and re-run `dtwiz install demo` to fetch a fresh copy. For now this is acceptable; version checking is out of scope.
 - **User edits to downloaded files**: if a user modifies `~/.dtwiz/examples/schnitzel/`, those changes persist. A re-download only happens when the path is absent. This is the intended behavior.

--- a/openspec/changes/bundle-demo-examples/proposal.md
+++ b/openspec/changes/bundle-demo-examples/proposal.md
@@ -7,9 +7,10 @@ The demo install flow downloads the schnitzel app from an external GitHub reposi
 ## What Changes
 
 - The `examples/schnitzel/` directory is added to the dtwiz repository under `examples/`
-- `.goreleaser.yaml` is updated to publish `dtwiz-examples.tar.gz` as an additional release asset
+- `.goreleaser.yaml` is updated to publish `dtwiz-examples.tar.gz` from GoReleaser's `dist/` directory as an additional release asset, so release cleanup removes the generated local tarball
 - When `~/.dtwiz/examples/schnitzel/` does not exist, `InstallDemo` downloads `dtwiz-examples.tar.gz` from the current dtwiz GitHub release and extracts it to `~/.dtwiz/examples/`
 - `InstallDemo` reads from `~/.dtwiz/examples/schnitzel/` directly and instruments it in place. There is no copy to the current working directory
+- Normal platform archives and install scripts do not include or copy demo files; users who do not run the demo do not receive examples
 - All third-party download logic is removed: `downloadAndExtractDemo`, `extractZip`, and `demoZipURL` are deleted and replaced with version-pinned release asset download
 - The `checkDemoExists` function is removed (no longer needed)
 
@@ -27,7 +28,7 @@ The demo install flow downloads the schnitzel app from an external GitHub reposi
 ## Impact
 
 - `examples/`: new directory containing the schnitzel app source files
-- `.goreleaser.yaml`: updated to publish `dtwiz-examples.tar.gz` as a release asset
+- `.goreleaser.yaml`: updated to publish `dtwiz-examples.tar.gz` from `dist/` as a release asset so the generated local tarball is cleaned up with release artifacts
 - `pkg/installer/otel/demo.go`: third-party download functions removed, `InstallDemo` rewritten to download from the dtwiz release asset and use the bundled path
 - No changes to `scripts/install.sh` or `scripts/install.ps1`
 - No changes to flags or auth

--- a/openspec/changes/bundle-demo-examples/proposal.md
+++ b/openspec/changes/bundle-demo-examples/proposal.md
@@ -7,7 +7,7 @@ The demo install flow downloads the schnitzel app from an external GitHub reposi
 ## What Changes
 
 - The `examples/schnitzel/` directory is added to the dtwiz repository under `examples/`
-- `.goreleaser.yaml` is updated to publish `dtwiz-examples.tar.gz` from GoReleaser's `dist/` directory as an additional release asset, so release cleanup removes the generated local tarball
+- `.goreleaser.yaml` is updated to create `dtwiz-examples.tar.gz` via a `before` hook and publish it as an additional release asset via `release.extra_files`
 - When `~/.dtwiz/examples/schnitzel/` does not exist, `InstallDemo` downloads `dtwiz-examples.tar.gz` from the current dtwiz GitHub release and extracts it to `~/.dtwiz/examples/`
 - `InstallDemo` reads from `~/.dtwiz/examples/schnitzel/` directly and instruments it in place. There is no copy to the current working directory
 - Normal platform archives and install scripts do not include or copy demo files; users who do not run the demo do not receive examples
@@ -28,7 +28,7 @@ The demo install flow downloads the schnitzel app from an external GitHub reposi
 ## Impact
 
 - `examples/`: new directory containing the schnitzel app source files
-- `.goreleaser.yaml`: updated to publish `dtwiz-examples.tar.gz` from `dist/` as a release asset so the generated local tarball is cleaned up with release artifacts
+- `.goreleaser.yaml`: updated to create `dtwiz-examples.tar.gz` via a `before` hook and publish it as an additional release asset via `release.extra_files`
 - `pkg/installer/otel/demo.go`: third-party download functions removed, `InstallDemo` rewritten to download from the dtwiz release asset and use the bundled path
 - No changes to `scripts/install.sh` or `scripts/install.ps1`
 - No changes to flags or auth

--- a/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
+++ b/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
@@ -31,12 +31,6 @@ The extraction path is:
 - **AND** extract it to `~/.dtwiz/examples/`
 - **AND** all example directories and their files SHALL be present after extraction
 
-#### Scenario: Archive is deleted after successful extraction
-
-- **WHEN** `dtwiz-examples.tar.gz` has been downloaded and extracted successfully
-- **THEN** the archive file SHALL be deleted
-- **AND** only the extracted `~/.dtwiz/examples/` directory SHALL remain on disk
-
 #### Scenario: Download is skipped when path already exists
 
 - **WHEN** `~/.dtwiz/examples/schnitzel/` already exists on disk

--- a/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
+++ b/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
@@ -26,7 +26,7 @@ The extraction path is:
 #### Scenario: Download creates the expected directory structure
 
 - **WHEN** `~/.dtwiz/examples/schnitzel/` does not exist
-- **AND** a release build runs the demo command
+- **AND** the binary is a release build
 - **THEN** the binary SHALL download `dtwiz-examples.tar.gz` from the release asset URL for the current version
 - **AND** extract it to `~/.dtwiz/examples/`
 - **AND** all example directories and their files SHALL be present after extraction
@@ -34,7 +34,7 @@ The extraction path is:
 #### Scenario: Development build uses latest release asset
 
 - **WHEN** `~/.dtwiz/examples/schnitzel/` does not exist
-- **AND** a development or snapshot build runs the demo command
+- **AND** the binary is a development or snapshot build
 - **THEN** the binary SHALL download `dtwiz-examples.tar.gz` from the latest release asset URL
 - **AND** extract it to `~/.dtwiz/examples/`
 

--- a/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
+++ b/openspec/changes/bundle-demo-examples/specs/bundle-examples/spec.md
@@ -16,7 +16,7 @@ The `examples/` directory SHALL be packaged as `dtwiz-examples.tar.gz` and publi
 
 ### Requirement: Examples are downloaded to a fixed location on demand
 
-When `~/.dtwiz/examples/schnitzel/` does not exist, the binary SHALL download `dtwiz-examples.tar.gz` from the current dtwiz GitHub release and extract it to `~/.dtwiz/examples/` before proceeding. The download URL is built from the binary's built-in version string.
+When `~/.dtwiz/examples/schnitzel/` does not exist, the binary SHALL download `dtwiz-examples.tar.gz` from a dtwiz GitHub release and extract it to `~/.dtwiz/examples/` before proceeding. Release builds SHALL build the download URL from the binary's built-in version string. Development and snapshot builds MAY use the latest release asset when no matching release asset exists.
 
 The extraction path is:
 
@@ -26,10 +26,17 @@ The extraction path is:
 #### Scenario: Download creates the expected directory structure
 
 - **WHEN** `~/.dtwiz/examples/schnitzel/` does not exist
-- **AND** the demo command is run
+- **AND** a release build runs the demo command
 - **THEN** the binary SHALL download `dtwiz-examples.tar.gz` from the release asset URL for the current version
 - **AND** extract it to `~/.dtwiz/examples/`
 - **AND** all example directories and their files SHALL be present after extraction
+
+#### Scenario: Development build uses latest release asset
+
+- **WHEN** `~/.dtwiz/examples/schnitzel/` does not exist
+- **AND** a development or snapshot build runs the demo command
+- **THEN** the binary SHALL download `dtwiz-examples.tar.gz` from the latest release asset URL
+- **AND** extract it to `~/.dtwiz/examples/`
 
 #### Scenario: Download is skipped when path already exists
 
@@ -37,18 +44,18 @@ The extraction path is:
 - **AND** the demo command is run
 - **THEN** the binary SHALL skip the download and use the existing files
 
-#### Scenario: OTel Collector keeps running after examples are re-downloaded on upgrade
+#### Scenario: OTel Collector keeps running after dtwiz upgrade
 
 - **WHEN** dtwiz is upgraded and a new binary is installed
 - **AND** an OTel Collector is already running and configured to instrument files in `~/.dtwiz/examples/schnitzel/`
 - **THEN** the Collector SHALL continue running without interruption
-- **AND** the updated Python source files SHALL be picked up the next time the schnitzel services are restarted
+- **AND** existing files under `~/.dtwiz/examples/schnitzel/` SHALL NOT be modified by the binary upgrade
 
 ---
 
 ### Requirement: Demo files do not affect binary size for non-demo users
 
-The dtwiz binary SHALL NOT contain any example app files. They are only fetched when a user explicitly runs `dtwiz install demo`.
+The dtwiz binary and normal OS-specific install archives SHALL NOT contain any example app files. Install scripts SHALL NOT copy examples during normal dtwiz installation. Examples are only fetched when a user explicitly runs `dtwiz install demo`.
 
 #### Scenario: Demo works after manual binary installation
 
@@ -56,6 +63,18 @@ The dtwiz binary SHALL NOT contain any example app files. They are only fetched 
 - **WHEN** the user runs `dtwiz install demo`
 - **THEN** the demo command SHALL download `dtwiz-examples.tar.gz` from the release asset URL and proceed
 - **AND** no files from `examples/` SHALL be embedded in the binary itself
+
+#### Scenario: Install scripts do not install examples eagerly
+
+- **WHEN** a user installs dtwiz through an install script
+- **THEN** only the dtwiz binary and normal release archive contents SHALL be installed
+- **AND** `~/.dtwiz/examples/` SHALL NOT be created by the install script
+
+#### Scenario: Local release asset artifact is cleaned up with release artifacts
+
+- **WHEN** the release process creates `dtwiz-examples.tar.gz` for publication
+- **THEN** the file SHALL be created under GoReleaser's release artifact directory
+- **AND** the file SHALL be kept out of the repository working tree
 
 #### Scenario: Demo works after upgrading by replacing the binary
 

--- a/openspec/changes/bundle-demo-examples/specs/install-demo/spec.md
+++ b/openspec/changes/bundle-demo-examples/specs/install-demo/spec.md
@@ -84,7 +84,7 @@ After confirming, `install demo` SHALL invoke the OTel Collector installation fo
 
 ### Requirement: Install demo option is hidden in setup when demo is already monitored
 
-When the user runs `dtwiz setup` and the schnitzel demo services are already actively running, the `[d] Install demo app` option SHALL NOT be shown. The presence of the `~/.dtwiz/examples/schnitzel/` directory alone is not sufficient — it may exist because the examples ship with the dtwiz release archive.
+When the user runs `dtwiz setup` and the schnitzel demo services are already actively running, the `[d] Install demo app` option SHALL NOT be shown. The presence of the `~/.dtwiz/examples/schnitzel/` directory alone is not sufficient: it may exist from a previous demo install or manual extraction even when the demo is not running.
 
 #### Scenario: Install demo option hidden when demo services are running
 

--- a/openspec/changes/bundle-demo-examples/specs/install-demo/spec.md
+++ b/openspec/changes/bundle-demo-examples/specs/install-demo/spec.md
@@ -84,18 +84,18 @@ After confirming, `install demo` SHALL invoke the OTel Collector installation fo
 
 ### Requirement: Install demo option is hidden in setup when demo is already monitored
 
-When the user runs `dtwiz setup` and the schnitzel project is already detected in the project list (via the bundled scan root), the `[d] Install demo app` option SHALL NOT be shown. The user can manage the demo instrumentation by selecting schnitzel from the regular project list.
+When the user runs `dtwiz setup` and the schnitzel demo services are already actively running, the `[d] Install demo app` option SHALL NOT be shown. The presence of the `~/.dtwiz/examples/schnitzel/` directory alone is not sufficient — it may exist because the examples ship with the dtwiz release archive.
 
-#### Scenario: Install demo option hidden when schnitzel already in project list
+#### Scenario: Install demo option hidden when demo services are running
 
-- **WHEN** `~/.dtwiz/examples/schnitzel/` is detected as a project in the scan results
+- **WHEN** Python processes from `~/.dtwiz/examples/schnitzel/` are actively running
 - **THEN** the `[d] Install demo app` option SHALL NOT appear in the setup menu
-- **AND** schnitzel SHALL be selectable from the regular numbered project list
 
-#### Scenario: Install demo option shown when schnitzel not yet set up
+#### Scenario: Install demo option shown when demo not yet running
 
-- **WHEN** `~/.dtwiz/examples/schnitzel/` is NOT detected as a project in the scan results
+- **WHEN** no Python processes from `~/.dtwiz/examples/schnitzel/` are running
 - **THEN** the `[d] Install demo app` option SHALL appear in the setup menu
+- **AND** this applies regardless of whether `~/.dtwiz/examples/schnitzel/` already exists on disk
 
 ---
 

--- a/openspec/changes/bundle-demo-examples/tasks.md
+++ b/openspec/changes/bundle-demo-examples/tasks.md
@@ -2,60 +2,57 @@
 
 ## 1. Add schnitzel example to the repository
 
-- [ ] 1.1 Add `examples/schnitzel/` directory with all service files (`frontend/`, `order/`, `delivery/`, `loadgenerator/`, `requirements.txt`, `README.md`)
-- [ ] 1.2 Add `examples/schnitzel/.gitignore` to exclude runtime artifacts (e.g. `__pycache__/`, `*.pyc`)
-- [ ] 1.3 Remove any macOS metadata files (`.DS_Store`) from `examples/`
+- [x] 1.1 Add `examples/schnitzel/` directory with all service files (`frontend/`, `order/`, `delivery/`, `loadgenerator/`, `requirements.txt`, `README.md`)
+- [x] 1.2 Add `examples/schnitzel/.gitignore` to exclude runtime artifacts (e.g. `__pycache__/`, `*.pyc`)
 
 ## 2. Publish schnitzel examples as a release asset
 
-- [ ] 2.1 Update `.goreleaser.yaml` to package the `examples/` directory as `dtwiz-examples.tar.gz` under `dist/`, publish it as an additional release asset, and keep the generated tarball out of the working tree
-- [ ] 2.2 Verify the release asset builds cleanly with `goreleaser build --snapshot` and the archive contains the expected files
-- [ ] 2.3 Verify normal platform archives do not include `examples/` and install scripts do not copy examples eagerly
+- [x] 2.1 Update `.goreleaser.yaml` to package the `examples/` directory as `dtwiz-examples.tar.gz` under `dist/`, publish it as an additional release asset, and keep the generated tarball out of the working tree
+- [x] 2.2 Verify the release asset builds cleanly with `goreleaser build --snapshot` and the archive contains the expected files
+- [x] 2.3 Verify normal platform archives do not include `examples/` and install scripts do not copy examples eagerly
 
 ## 3. Rewrite demo.go to use release asset download
 
-- [ ] 3.1 Add `bundledDemoPath()` function that returns `~/.dtwiz/examples/schnitzel` using `os.UserHomeDir()`
-- [ ] 3.2 Add `downloadDemoExamples(dst string)` function that constructs the `dtwiz-examples.tar.gz` release asset URL from the binary's built-in version string, downloads the archive, and extracts it to the destination path
-- [ ] 3.3 Remove `downloadAndExtractDemo()`, `extractZip()`, and the `demoZipURL` constant
-- [ ] 3.4 Remove `checkDemoExists()` (no longer needed)
-- [ ] 3.5 Remove unused imports from `demo.go`
-- [ ] 3.6 Update `InstallDemo` to call `downloadDemoExamples` when `bundledDemoPath()` does not exist, then pass the path to `InstallOtelCollectorWithProject`
-- [ ] 3.7 Update `InstallDemo` plan preview to show the download step only when the path is missing
+- [x] 3.1 Add `bundledDemoPath()` function that returns `~/.dtwiz/examples/schnitzel` using `os.UserHomeDir()`
+- [x] 3.2 Add `downloadDemoExamples(dst string)` function that constructs the `dtwiz-examples.tar.gz` release asset URL from the binary's built-in version string, downloads the archive, and extracts it to the destination path
+- [x] 3.3 Remove `downloadAndExtractDemo()`, `extractZip()`, and the `demoZipURL` constant
+- [x] 3.4 Remove `checkDemoExists()` (no longer needed)
+- [x] 3.5 Remove unused imports from `demo.go`
+- [x] 3.6 Update `InstallDemo` to call `downloadDemoExamples` when `bundledDemoPath()` does not exist, then pass the path to `InstallOtelCollectorWithProject`
+- [x] 3.7 Update `InstallDemo` plan preview to show the download step only when the path is missing
 
 ## 4. Remove experimental flag gating from demo
 
-- [ ] 4.1 In `cmd/install.go`, remove `Hidden: true` and the experimental check from `installDemoCmd`
-- [ ] 4.2 In `cmd/setup.go`, remove the `featureflags.IsEnabled(featureflags.Experimental)` guard from the `[d]` menu option and the input handler
-- [ ] 4.3 In `pkg/recommender/recommender.go`, remove the experimental gate from the demo option in the formatted recommendations output
+- [x] 4.1 In `cmd/install.go`, remove `Hidden: true` and the experimental check from `installDemoCmd`
+- [x] 4.2 In `cmd/setup.go`, remove the `featureflags.IsEnabled(featureflags.Experimental)` guard from the `[d]` menu option and the input handler
+- [x] 4.3 In `pkg/recommender/recommender.go`, remove the experimental gate from the demo option in the formatted recommendations output
 
 ## 5. Add bundled examples as additional project scan root
 
-- [ ] 5.1 In `pkg/installer/otel/runtime_scan.go`, update `scanProjectDirs` to also scan `~/.dtwiz/examples/` (via `os.UserHomeDir()`) in addition to CWD
-- [ ] 5.2 Deduplicate results so a project is not listed twice if CWD is inside `~/.dtwiz/examples/`
-- [ ] 5.3 If `~/.dtwiz/examples/` does not exist, skip it silently
+- [x] 5.1 In `pkg/installer/otel/runtime_scan.go`, update `scanProjectDirs` to also scan `~/.dtwiz/examples/` (via `os.UserHomeDir()`) in addition to CWD
+- [x] 5.2 Deduplicate results so a project is not listed twice if CWD is inside `~/.dtwiz/examples/`
+- [x] 5.3 If `~/.dtwiz/examples/` does not exist, skip it silently
 
 ## 6. Hide install demo option when schnitzel already in project list
 
-- [ ] 6.1 In `cmd/setup.go`, check whether schnitzel is in the detected project list before showing the `[d]` option; hide it if already detected
+- [x] 6.1 In `cmd/setup.go`, check whether schnitzel is in the detected running project list before showing the `[d]` option; hide it if already detected
 
 ## 7. Unit tests
 
-- [ ] 7.1 Add `TestBundledDemoPath` to verify the function returns an absolute path ending in `schnitzel` on all platforms
-- [ ] 7.2 Add `TestDownloadDemoExamples` to verify that the function constructs the correct release asset URL from the version string and extracts files to the expected directory structure in a temp directory (use an HTTP test server to serve a fixture archive)
-- [ ] 7.3 Remove `TestCheckDemoExists` (function is deleted)
-- [ ] 7.4 Add a test for `scanProjectDirs` verifying that a project in the bundled examples path is returned even when CWD is a different directory
-- [ ] 7.5 Add a test verifying both CWD and bundled examples projects appear exactly once in combined results
+- [x] 7.1 Add `TestBundledDemoPath` to verify the function returns an absolute path ending in `schnitzel` on all platforms
+- [x] 7.2 Add `TestDownloadDemoExamples` to verify that the function constructs the correct release asset URL from the version string and extracts files to the expected directory structure in a temp directory (use an HTTP test server to serve a fixture archive)
+- [x] 7.3 Remove `TestCheckDemoExists` (function is deleted)
+- [x] 7.4 Add a test for `scanProjectDirs` verifying that a project in the bundled examples path is returned even when CWD is a different directory
+- [x] 7.5 Add a test verifying both CWD and bundled examples projects appear exactly once in combined results
 
 ## 8. Integration tests
 
 - [ ] 8.1 With `~/.dtwiz/examples/schnitzel/` absent, run `dtwiz install demo --dry-run` and verify the plan output includes the download step referencing the current version's release asset URL
 - [ ] 8.2 With `~/.dtwiz/examples/schnitzel/` absent, run `dtwiz install demo` and verify the directory is created with the expected files before OTel setup begins
 - [ ] 8.3 With `~/.dtwiz/examples/schnitzel/` already present, run `dtwiz install demo --dry-run` and verify the download step is omitted from the plan
-- [ ] 8.4 In `pkg/installer/otel/runtime_scan.go`, add a test that creates a Python project marker in a temp directory representing `~/.dtwiz/examples/schnitzel/`, sets CWD to a different directory, calls `scanProjectDirs`, and verifies the bundled project is returned
-- [ ] 8.5 Extend the test from 8.4 to also place a project in CWD and verify both projects appear exactly once in the results
 
 ## 9. Verification
 
-- [ ] 9.1 Run `make build` and confirm the binary builds cleanly
-- [ ] 9.2 Run `make lint` and confirm no new lint issues
-- [ ] 9.3 Run `make test` and confirm all tests pass
+- [x] 9.1 Run `make build` and confirm the binary builds cleanly
+- [x] 9.2 Run `make lint` and confirm no new lint issues
+- [x] 9.3 Run `make test` and confirm all tests pass

--- a/openspec/changes/bundle-demo-examples/tasks.md
+++ b/openspec/changes/bundle-demo-examples/tasks.md
@@ -8,8 +8,9 @@
 
 ## 2. Publish schnitzel examples as a release asset
 
-- [ ] 2.1 Update `.goreleaser.yaml` to package the `examples/` directory as `dtwiz-examples.tar.gz` and publish it as an additional release asset
+- [ ] 2.1 Update `.goreleaser.yaml` to package the `examples/` directory as `dtwiz-examples.tar.gz` under `dist/`, publish it as an additional release asset, and keep the generated tarball out of the working tree
 - [ ] 2.2 Verify the release asset builds cleanly with `goreleaser build --snapshot` and the archive contains the expected files
+- [ ] 2.3 Verify normal platform archives do not include `examples/` and install scripts do not copy examples eagerly
 
 ## 3. Rewrite demo.go to use release asset download
 

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -23,9 +23,9 @@ const (
 	wingetPythonPackage = "Python.Python.3.14"
 )
 
-// releaseAssetBaseURL is the base URL for dtwiz release assets.
+// releaseBaseURL is the base URL for dtwiz GitHub releases.
 // Overridden in tests to point at a local httptest.Server.
-var releaseAssetBaseURL = "https://github.com/dynatrace-oss/dtwiz/releases/download"
+var releaseBaseURL = "https://github.com/dynatrace-oss/dtwiz/releases"
 
 // BundledDemoPath returns the fixed extraction path for the schnitzel demo app:
 // $HOME/.dtwiz/examples/schnitzel on macOS/Linux, %USERPROFILE%\.dtwiz\examples\schnitzel on Windows.
@@ -34,11 +34,21 @@ func BundledDemoPath() string {
 	return filepath.Join(home, ".dtwiz", "examples", demoDirName)
 }
 
+// demoExamplesURL returns the download URL for the demo examples tarball.
+// Dev and pre-release builds (version contains "-" or equals "dev") resolve to
+// the latest stable release; proper releases use the exact version tag.
+func demoExamplesURL() string {
+	ver := version.Version
+	if ver == "dev" || strings.Contains(ver, "-") {
+		return releaseBaseURL + "/latest/download/dtwiz-examples.tar.gz"
+	}
+	return fmt.Sprintf("%s/download/v%s/dtwiz-examples.tar.gz", releaseBaseURL, ver)
+}
+
 // downloadDemoExamples downloads the version-pinned dtwiz-examples.tar.gz release
 // asset and extracts it so that schnitzel ends up at dst.
 func downloadDemoExamples(dst string) error {
-	ver := version.Version
-	url := fmt.Sprintf("%s/v%s/dtwiz-examples.tar.gz", releaseAssetBaseURL, ver)
+	url := demoExamplesURL()
 
 	resp, err := http.Get(url) //nolint:gosec // URL constructed from hardcoded base + binary version
 	if err != nil {
@@ -264,7 +274,7 @@ func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 
 	step := 1
 	if !demoExists {
-		fmt.Printf("  %d) Download schnitzel from dtwiz release asset\n", step)
+		fmt.Printf("  %d) Download schnitzel → %s\n", step, demoPath)
 		step++
 	}
 	if pythonCmd != nil {

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -29,9 +29,12 @@ var releaseBaseURL = "https://github.com/dynatrace-oss/dtwiz/releases"
 
 // BundledDemoPath returns the fixed extraction path for the schnitzel demo app:
 // $HOME/.dtwiz/examples/schnitzel on macOS/Linux, %USERPROFILE%\.dtwiz\examples\schnitzel on Windows.
-func BundledDemoPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".dtwiz", "examples", demoDirName)
+func BundledDemoPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".dtwiz", "examples", demoDirName), nil
 }
 
 // demoExamplesURL returns the download URL for the demo examples tarball.
@@ -50,7 +53,7 @@ func demoExamplesURL() string {
 func downloadDemoExamples(dst string) error {
 	url := demoExamplesURL()
 
-	resp, err := http.Get(url) //nolint:gosec // URL constructed from hardcoded base + binary version
+	resp, err := httpClient.Get(url) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("downloading demo examples: %w", err)
 	}
@@ -242,7 +245,11 @@ func installPythonWindows() error {
 
 // IsDemoRunning returns true when the schnitzel demo services are already running.
 func IsDemoRunning() bool {
-	demoPath := BundledDemoPath()
+	demoPath, err := BundledDemoPath()
+	if err != nil {
+		logger.Debug("IsDemoRunning: could not resolve demo path", "error", err)
+		return false
+	}
 	if _, err := os.Stat(demoPath); err != nil {
 		return false
 	}
@@ -258,7 +265,10 @@ func IsDemoRunning() bool {
 // 2. Install Python if missing
 // 3. Install OTel Collector + Python auto-instrumentation targeting the bundled schnitzel app
 func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
-	demoPath := BundledDemoPath()
+	demoPath, err := BundledDemoPath()
+	if err != nil {
+		return err
+	}
 	_, statErr := os.Stat(demoPath)
 	demoExists := statErr == nil
 

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -1,7 +1,8 @@
 package otel
 
 import (
-	"archive/zip"
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,17 +15,94 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
+	"github.com/dynatrace-oss/dtwiz/pkg/version"
 )
 
 const (
-	demoZipURL          = "https://github.com/dietermayrhofer/schnitzel/archive/refs/heads/master.zip"
 	demoDirName         = "schnitzel"
 	wingetPythonPackage = "Python.Python.3.14"
 )
 
-func checkDemoExists() bool {
-	_, err := os.Stat(demoDirName)
-	return err == nil
+// releaseAssetBaseURL is the base URL for dtwiz release assets.
+// Overridden in tests to point at a local httptest.Server.
+var releaseAssetBaseURL = "https://github.com/dynatrace-oss/dtwiz/releases/download"
+
+// BundledDemoPath returns the fixed extraction path for the schnitzel demo app:
+// $HOME/.dtwiz/examples/schnitzel on macOS/Linux, %USERPROFILE%\.dtwiz\examples\schnitzel on Windows.
+func BundledDemoPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".dtwiz", "examples", demoDirName)
+}
+
+// downloadDemoExamples downloads the version-pinned dtwiz-examples.tar.gz release
+// asset and extracts it so that schnitzel ends up at dst.
+func downloadDemoExamples(dst string) error {
+	ver := version.Version
+	url := fmt.Sprintf("%s/v%s/dtwiz-examples.tar.gz", releaseAssetBaseURL, ver)
+
+	resp, err := http.Get(url) //nolint:gosec // URL constructed from hardcoded base + binary version
+	if err != nil {
+		return fmt.Errorf("downloading demo examples: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading demo examples: HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	// Tarball contains examples/schnitzel/...; extract to ~/.dtwiz/ so
+	// ~/.dtwiz/examples/schnitzel/ == dst.
+	extractTo := filepath.Dir(filepath.Dir(dst))
+	if err := os.MkdirAll(extractTo, 0755); err != nil {
+		return fmt.Errorf("creating %s: %w", extractTo, err)
+	}
+	return extractTarGz(resp.Body, extractTo)
+}
+
+func extractTarGz(r io.Reader, destDir string) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("opening gzip stream: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		target := filepath.Join(destDir, filepath.FromSlash(hdr.Name)) //nolint:gosec
+		// Prevent path traversal.
+		if !strings.HasPrefix(filepath.Clean(target)+string(os.PathSeparator),
+			filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal path in archive: %s", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdr.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
 }
 
 // pythonInstallPlan returns the command (name + args) needed to install Python 3
@@ -102,6 +180,21 @@ func describeDemoInstallCmd(cmd []string) string {
 	return strings.Join(cmd, " ")
 }
 
+func detectLinuxDistro() string {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return "rhel"
+	}
+	content := strings.ToLower(string(data))
+	if strings.Contains(content, "ubuntu") {
+		return "ubuntu"
+	}
+	if strings.Contains(content, "debian") {
+		return "debian"
+	}
+	return "rhel"
+}
+
 // installPythonWindows installs Python 3 on Windows via winget. The exit code
 // is ignored — winget returns non-zero for already-installed packages; DetectPython
 // is the true success signal.
@@ -137,119 +230,13 @@ func installPythonWindows() error {
 	return fmt.Errorf("could not install Python 3 via winget; %s", manualPythonInstructions) //nolint:staticcheck // ST1005: keep brand capitalization
 }
 
-func detectLinuxDistro() string {
-	data, err := os.ReadFile("/etc/os-release")
-	if err != nil {
-		return "rhel"
-	}
-	content := strings.ToLower(string(data))
-	if strings.Contains(content, "ubuntu") {
-		return "ubuntu"
-	}
-	if strings.Contains(content, "debian") {
-		return "debian"
-	}
-	return "rhel"
-}
-
-// downloadAndExtractDemo downloads the schnitzel ZIP and extracts it atomically
-// (to a temp dir first, then renames) to ./schnitzel/.
-func downloadAndExtractDemo() error {
-	resp, err := http.Get(demoZipURL)
-	if err != nil {
-		return fmt.Errorf("downloading demo: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("downloading demo: unexpected HTTP %d from %s", resp.StatusCode, demoZipURL)
-	}
-
-	tmpFile, err := os.CreateTemp("", "schnitzel-*.zip")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
-		tmpFile.Close()
-		return fmt.Errorf("writing zip: %w", err)
-	}
-	tmpFile.Close()
-
-	tmpDir, err := os.MkdirTemp("", "schnitzel-extract-*")
-	if err != nil {
-		return fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := extractZip(tmpFile.Name(), tmpDir); err != nil {
-		return fmt.Errorf("extracting zip: %w", err)
-	}
-
-	// Find the extracted top-level dir (e.g. schnitzel-master)
-	entries, err := os.ReadDir(tmpDir)
-	if err != nil || len(entries) == 0 {
-		return fmt.Errorf("unexpected zip structure: no top-level directory found")
-	}
-	extracted := filepath.Join(tmpDir, entries[0].Name())
-
-	if err := os.Rename(extracted, demoDirName); err != nil {
-		return fmt.Errorf("moving demo to %s: %w", demoDirName, err)
-	}
-	return nil
-}
-
-func extractZip(zipPath, destDir string) error {
-	r, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-		target := filepath.Join(destDir, f.Name) //nolint:gosec
-		// Prevent zip-slip
-		if !strings.HasPrefix(filepath.Clean(target)+string(os.PathSeparator), filepath.Clean(destDir)+string(os.PathSeparator)) {
-			return fmt.Errorf("illegal file path in zip: %s", f.Name)
-		}
-		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
-		}
-		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-		rc, err := f.Open()
-		if err != nil {
-			out.Close()
-			return err
-		}
-		_, copyErr := io.Copy(out, rc) //nolint:gosec
-		rc.Close()
-		out.Close()
-		if copyErr != nil {
-			return copyErr
-		}
-	}
-	return nil
-}
-
 // IsDemoRunning returns true when the schnitzel demo services are already running.
 func IsDemoRunning() bool {
-	if !checkDemoExists() {
+	demoPath := BundledDemoPath()
+	if _, err := os.Stat(demoPath); err != nil {
 		return false
 	}
-	absDemoDir, err := filepath.Abs(demoDirName)
-	if err != nil {
-		return false
-	}
-	running := len(matchingProcessIDs(absDemoDir, detectPythonProcesses())) > 0
+	running := len(matchingProcessIDs(demoPath, detectPythonProcesses())) > 0
 	if running {
 		logger.Debug("IsDemoRunning: demo already running, not showing demo")
 	}
@@ -257,11 +244,14 @@ func IsDemoRunning() bool {
 }
 
 // InstallDemo orchestrates the schnitzel demo installation:
-// 1. Download & extract schnitzel (if not already present)
-// 2. Install missing Python prerequisites (python3, pip, venv) if needed
-// 3. Install OTel Collector + Python auto-instrumentation targeting ./schnitzel
+// 1. Download schnitzel from dtwiz release asset (if not already present)
+// 2. Install Python if missing
+// 3. Install OTel Collector + Python auto-instrumentation targeting the bundled schnitzel app
 func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
-	demoExists := checkDemoExists()
+	demoPath := BundledDemoPath()
+	_, statErr := os.Stat(demoPath)
+	demoExists := statErr == nil
+
 	pythonCmd, err := pythonInstallPlan()
 	if err != nil {
 		return err
@@ -274,7 +264,7 @@ func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 
 	step := 1
 	if !demoExists {
-		fmt.Printf("  %d) Download schnitzel demo app to ./%s/\n", step, demoDirName)
+		fmt.Printf("  %d) Download schnitzel from dtwiz release asset\n", step)
 		step++
 	}
 	if pythonCmd != nil {
@@ -301,15 +291,12 @@ func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 	}
 	fmt.Println()
 
-	// Step 1: Download demo
 	if !demoExists {
-		fmt.Printf("  Downloading schnitzel demo app...\n")
-		if err := downloadAndExtractDemo(); err != nil {
+		fmt.Println("  Downloading schnitzel demo app...")
+		if err := downloadDemoExamples(demoPath); err != nil {
 			return err
 		}
-		fmt.Printf("  Demo extracted to ./%s/\n", demoDirName)
-	} else {
-		fmt.Printf("  Demo directory ./%s/ already exists, skipping download.\n", demoDirName)
+		fmt.Println("  Demo downloaded.")
 	}
 
 	// Step 2: Install missing Python prerequisites if needed
@@ -327,11 +314,6 @@ func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 		fmt.Println("  Python dependencies installed.")
 	}
 
-	// Step 3+4: OTel Collector + Python instrumentation
-	absDemoDir, err := filepath.Abs(demoDirName)
-	if err != nil {
-		return fmt.Errorf("resolving demo directory path: %w", err)
-	}
 	installer.AutoConfirm = true
-	return InstallOtelCollectorWithProject(envURL, token, platformTok, absDemoDir, dryRun)
+	return InstallOtelCollectorWithProject(envURL, token, platformTok, demoPath, dryRun)
 }

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -287,3 +287,4 @@ func TestDetectLinuxDistro(t *testing.T) {
 		t.Fatalf("unexpected distro value: %s", distro)
 	}
 }
+

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/version"
 	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
@@ -153,6 +154,31 @@ func createPythonDemoTestCommand(t *testing.T, dir, name, output string, exitCod
 	}
 }
 
+func TestDemoExamplesURL(t *testing.T) {
+	origBase := releaseBaseURL
+	releaseBaseURL = "https://example.com/releases"
+	defer func() { releaseBaseURL = origBase }()
+
+	origVer := version.Version
+	defer func() { version.Version = origVer }()
+
+	tests := []struct {
+		ver  string
+		want string
+	}{
+		{"1.2.3", "https://example.com/releases/download/v1.2.3/dtwiz-examples.tar.gz"},
+		{"dev", "https://example.com/releases/latest/download/dtwiz-examples.tar.gz"},
+		{"1.2.4-next", "https://example.com/releases/latest/download/dtwiz-examples.tar.gz"},
+	}
+	for _, tc := range tests {
+		version.Version = tc.ver
+		got := demoExamplesURL()
+		if got != tc.want {
+			t.Errorf("version %q: got %q, want %q", tc.ver, got, tc.want)
+		}
+	}
+}
+
 func TestBundledDemoPath(t *testing.T) {
 	path := BundledDemoPath()
 	if !filepath.IsAbs(path) {
@@ -191,9 +217,9 @@ func TestDownloadDemoExamples(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := releaseAssetBaseURL
-	releaseAssetBaseURL = srv.URL
-	defer func() { releaseAssetBaseURL = orig }()
+	orig := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = orig }()
 
 	// dst mimics BundledDemoPath() but inside a temp dir.
 	base := t.TempDir()
@@ -242,9 +268,9 @@ func TestDownloadDemoExamples_NonOKStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := releaseAssetBaseURL
-	releaseAssetBaseURL = srv.URL
-	defer func() { releaseAssetBaseURL = orig }()
+	orig := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = orig }()
 
 	dst := filepath.Join(t.TempDir(), "examples", "schnitzel")
 	err := downloadDemoExamples(dst)

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -180,7 +180,10 @@ func TestDemoExamplesURL(t *testing.T) {
 }
 
 func TestBundledDemoPath(t *testing.T) {
-	path := BundledDemoPath()
+	path, err := BundledDemoPath()
+	if err != nil {
+		t.Fatalf("BundledDemoPath returned error: %v", err)
+	}
 	if !filepath.IsAbs(path) {
 		t.Fatalf("expected absolute path, got: %s", path)
 	}

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -274,7 +274,6 @@ func TestInstallPythonWindows_WingetSucceedsButPythonUnavailable(t *testing.T) {
 	}
 }
 
-
 func TestDetectLinuxDistro(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux-only test")
@@ -287,4 +286,3 @@ func TestDetectLinuxDistro(t *testing.T) {
 		t.Fatalf("unexpected distro value: %s", distro)
 	}
 }
-

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -1,6 +1,11 @@
 package otel
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,24 +15,6 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
-
-func TestCheckDemoExists(t *testing.T) {
-	// Ensure schnitzel dir doesn't exist in test working dir
-	_ = os.RemoveAll(demoDirName)
-	if checkDemoExists() {
-		t.Fatal("expected checkDemoExists() = false when dir does not exist")
-	}
-
-	// Create the dir and check again
-	if err := os.MkdirAll(demoDirName, 0755); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	defer os.RemoveAll(demoDirName)
-
-	if !checkDemoExists() {
-		t.Fatal("expected checkDemoExists() = true when dir exists")
-	}
-}
 
 func TestConfirmProceedAutoConfirm(t *testing.T) {
 	orig := installer.AutoConfirm
@@ -165,6 +152,128 @@ func createPythonDemoTestCommand(t *testing.T, dir, name, output string, exitCod
 		t.Fatalf("create test command: %v", err)
 	}
 }
+
+func TestBundledDemoPath(t *testing.T) {
+	path := BundledDemoPath()
+	if !filepath.IsAbs(path) {
+		t.Fatalf("expected absolute path, got: %s", path)
+	}
+	if filepath.Base(path) != demoDirName {
+		t.Fatalf("expected path to end with %q, got: %s", demoDirName, path)
+	}
+}
+
+func TestDownloadDemoExamples(t *testing.T) {
+	// Build a fixture tar.gz containing examples/schnitzel/README.md.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("readme")
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "examples/schnitzel/README.md",
+		Mode:     0644,
+		Size:     int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gw.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(buf.Bytes()) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	orig := releaseAssetBaseURL
+	releaseAssetBaseURL = srv.URL
+	defer func() { releaseAssetBaseURL = orig }()
+
+	// dst mimics BundledDemoPath() but inside a temp dir.
+	base := t.TempDir()
+	dst := filepath.Join(base, "examples", "schnitzel")
+
+	if err := downloadDemoExamples(dst); err != nil {
+		t.Fatalf("downloadDemoExamples: %v", err)
+	}
+
+	target := filepath.Join(dst, "README.md")
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected %s to exist after extraction: %v", target, err)
+	}
+}
+
+func TestExtractTarGz_PathTraversal(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("evil")
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "../../evil.txt",
+		Mode:     0644,
+		Size:     int64(len(content)),
+	}
+	_ = tw.WriteHeader(hdr)
+	_, _ = tw.Write(content)
+	tw.Close()
+	gw.Close()
+
+	dest := t.TempDir()
+	err := extractTarGz(&buf, dest)
+	if err == nil {
+		t.Fatal("expected error for path traversal entry")
+	}
+	if !strings.Contains(err.Error(), "illegal path") {
+		t.Fatalf("error should mention illegal path, got: %v", err)
+	}
+}
+
+func TestDownloadDemoExamples_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	orig := releaseAssetBaseURL
+	releaseAssetBaseURL = srv.URL
+	defer func() { releaseAssetBaseURL = orig }()
+
+	dst := filepath.Join(t.TempDir(), "examples", "schnitzel")
+	err := downloadDemoExamples(dst)
+	if err == nil {
+		t.Fatal("expected error for non-200 HTTP response")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("error should include status code, got: %v", err)
+	}
+}
+
+func TestInstallPythonWindows_WingetSucceedsButPythonUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	createPythonDemoTestCommand(t, dir, "winget", "winget install ok", 0)
+	t.Setenv("PATH", dir)
+
+	err := installPythonWindows()
+	if err == nil {
+		t.Fatal("expected error when winget succeeds but Python is still unavailable")
+	}
+	if !strings.Contains(err.Error(), "could not install Python 3 via winget") {
+		t.Fatalf("error should mention failed Python install, got: %v", err)
+	}
+	// winget exited 0 — the error should not include a winget root cause.
+	if strings.Contains(err.Error(), "winget install ok") {
+		t.Fatalf("error should not wrap winget output when winget exited 0, got: %v", err)
+	}
+}
+
 
 func TestDetectLinuxDistro(t *testing.T) {
 	if runtime.GOOS != "linux" {

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -257,11 +257,19 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	if home, err := os.UserHomeDir(); err == nil {
 		bundledRoot := filepath.Join(home, ".dtwiz", "examples")
 		if _, err := os.Stat(bundledRoot); err == nil {
-			resolvedCWD, _ := filepath.EvalSymlinks(workingDir)
-			resolvedBundled, _ := filepath.EvalSymlinks(bundledRoot)
+			resolvedCWD, err := filepath.EvalSymlinks(workingDir)
+			if err != nil {
+				logger.Debug("scanProjectDirs: EvalSymlinks failed for CWD, using original path", "path", workingDir, "error", err)
+				resolvedCWD = workingDir
+			}
+			resolvedBundled, err := filepath.EvalSymlinks(bundledRoot)
+			if err != nil {
+				logger.Debug("scanProjectDirs: EvalSymlinks failed for bundled root, using original path", "path", bundledRoot, "error", err)
+				resolvedBundled = bundledRoot
+			}
 			sep := string(filepath.Separator)
-			cwdUnderBundled := strings.HasPrefix(resolvedCWD+sep, resolvedBundled+sep)
-			bundledUnderCWD := strings.HasPrefix(resolvedBundled+sep, resolvedCWD+sep)
+			cwdUnderBundled := strings.HasPrefix(strings.ToLower(resolvedCWD)+sep, strings.ToLower(resolvedBundled)+sep)
+			bundledUnderCWD := strings.HasPrefix(strings.ToLower(resolvedBundled)+sep, strings.ToLower(resolvedCWD)+sep)
 			if !cwdUnderBundled && !bundledUnderCWD {
 				walkCandidateDirs(bundledRoot, 0, dirMatches, shouldSkipDir)
 			}

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -257,22 +257,7 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 	if home, err := os.UserHomeDir(); err == nil {
 		bundledRoot := filepath.Join(home, ".dtwiz", "examples")
 		if _, err := os.Stat(bundledRoot); err == nil {
-			resolvedCWD, err := filepath.EvalSymlinks(workingDir)
-			if err != nil {
-				logger.Debug("scanProjectDirs: EvalSymlinks failed for CWD, using original path", "path", workingDir, "error", err)
-				resolvedCWD = workingDir
-			}
-			resolvedBundled, err := filepath.EvalSymlinks(bundledRoot)
-			if err != nil {
-				logger.Debug("scanProjectDirs: EvalSymlinks failed for bundled root, using original path", "path", bundledRoot, "error", err)
-				resolvedBundled = bundledRoot
-			}
-			sep := string(filepath.Separator)
-			cwdUnderBundled := strings.HasPrefix(strings.ToLower(resolvedCWD)+sep, strings.ToLower(resolvedBundled)+sep)
-			bundledUnderCWD := strings.HasPrefix(strings.ToLower(resolvedBundled)+sep, strings.ToLower(resolvedCWD)+sep)
-			if !cwdUnderBundled && !bundledUnderCWD {
-				walkCandidateDirs(bundledRoot, 0, dirMatches, shouldSkipDir)
-			}
+			walkCandidateDirs(bundledRoot, 0, dirMatches, shouldSkipDir)
 		}
 	}
 

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -253,6 +253,21 @@ func scanProjectDirs(markers []string, excludeNames []string) []ScannedProject {
 
 	walkCandidateDirs(workingDir, 0, dirMatches, shouldSkipDir)
 
+	// Also scan the bundled examples root (~/.dtwiz/examples) if it exists.
+	if home, err := os.UserHomeDir(); err == nil {
+		bundledRoot := filepath.Join(home, ".dtwiz", "examples")
+		if _, err := os.Stat(bundledRoot); err == nil {
+			resolvedCWD, _ := filepath.EvalSymlinks(workingDir)
+			resolvedBundled, _ := filepath.EvalSymlinks(bundledRoot)
+			sep := string(filepath.Separator)
+			cwdUnderBundled := strings.HasPrefix(resolvedCWD+sep, resolvedBundled+sep)
+			bundledUnderCWD := strings.HasPrefix(resolvedBundled+sep, resolvedCWD+sep)
+			if !cwdUnderBundled && !bundledUnderCWD {
+				walkCandidateDirs(bundledRoot, 0, dirMatches, shouldSkipDir)
+			}
+		}
+	}
+
 	subtreeCounts.Range(func(key, value any) bool {
 		logger.Debug("scan summary", "subdir", key.(string), "dirs_checked", value.(*atomic.Int64).Load())
 		return true

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -552,6 +552,73 @@ func TestScanProjectDirs_WideParallelTree(t *testing.T) {
 	}
 }
 
+// fakeHome redirects os.UserHomeDir() to a temp dir for the duration of the
+// test by setting both $HOME (Unix) and $USERPROFILE (Windows).
+func fakeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// TestScanProjectDirs_BundledExamples verifies that a Python project marker
+// placed inside ~/.dtwiz/examples/schnitzel/ is found even when CWD is
+// a completely different directory.
+func TestScanProjectDirs_BundledExamples(t *testing.T) {
+	home := fakeHome(t)
+	bundled := filepath.Join(home, ".dtwiz", "examples", "schnitzel")
+	if err := os.MkdirAll(bundled, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundled, "requirements.txt"), []byte("flask\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := t.TempDir()
+	helpers.SetTestWorkingDir(t, cwd)
+
+	projects := scanProjectDirs([]string{"requirements.txt"}, nil)
+
+	found := false
+	for _, p := range projects {
+		if strings.HasSuffix(filepath.ToSlash(p.Path), "schnitzel") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected bundled schnitzel project to be found; got %v", projects)
+	}
+}
+
+// TestScanProjectDirs_NoDuplicates ensures that a project appearing in both
+// CWD and the bundled examples root is reported exactly once.
+func TestScanProjectDirs_NoDuplicates(t *testing.T) {
+	home := fakeHome(t)
+	bundled := filepath.Join(home, ".dtwiz", "examples", "schnitzel")
+	if err := os.MkdirAll(bundled, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundled, "requirements.txt"), []byte("flask\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// CWD == bundled path: the same project would be visited by both scans.
+	helpers.SetTestWorkingDir(t, bundled)
+
+	projects := scanProjectDirs([]string{"requirements.txt"}, nil)
+
+	count := 0
+	for _, p := range projects {
+		if strings.HasSuffix(filepath.ToSlash(p.Path), "schnitzel") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected schnitzel to appear exactly once; got %d occurrences in %v", count, projects)
+	}
+}
+
 func TestParseWinProcessOutput_Empty(t *testing.T) {
 	if got := parseWinProcessOutput(""); len(got) != 0 {
 		t.Errorf("expected empty result for empty input, got %v", got)

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -603,7 +603,7 @@ func TestScanProjectDirs_NoDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// CWD == bundled path: the same project would be visited by both scans.
+	// CWD == bundled path: the bundled scan is skipped, so the project is found exactly once via the CWD scan.
 	helpers.SetTestWorkingDir(t, bundled)
 
 	projects := scanProjectDirs([]string{"requirements.txt"}, nil)

--- a/pkg/installer/otel/runtime_scan_test.go
+++ b/pkg/installer/otel/runtime_scan_test.go
@@ -619,6 +619,31 @@ func TestScanProjectDirs_NoDuplicates(t *testing.T) {
 	}
 }
 
+func TestScanProjectDirs_BundledExamplesFromHome(t *testing.T) {
+	home := fakeHome(t)
+	bundled := filepath.Join(home, ".dtwiz", "examples", "schnitzel")
+	if err := os.MkdirAll(bundled, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundled, "requirements.txt"), []byte("flask\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	helpers.SetTestWorkingDir(t, home)
+
+	projects := scanProjectDirs([]string{"requirements.txt"}, nil)
+
+	count := 0
+	for _, p := range projects {
+		if strings.HasSuffix(filepath.ToSlash(p.Path), "schnitzel") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected schnitzel to appear exactly once when scanning from home; got %d occurrences in %v", count, projects)
+	}
+}
+
 func TestParseWinProcessOutput_Empty(t *testing.T) {
 	if got := parseWinProcessOutput(""); len(got) != 0 {
 		t.Errorf("expected empty result for empty input, got %v", got)

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -241,8 +241,6 @@ func FormatRecommendations(recs []Recommendation) string {
 		}
 	}
 	sb.WriteString("\n")
-	if featureflags.IsEnabled(featureflags.Experimental) {
-		sb.WriteString(fmt.Sprintf("  %s  %s\n", recMuted.Sprint("[d]"), recMuted.Sprint("Install demo app (schnitzel)")))
-	}
+	sb.WriteString(fmt.Sprintf("  %s  %s\n", recMuted.Sprint("[d]"), recMuted.Sprint("Install demo app (schnitzel)")))
 	return strings.TrimRight(sb.String(), "\n")
 }

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -1,6 +1,7 @@
 package recommender_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/analyzer"
@@ -148,6 +149,19 @@ func TestFormatRecommendations_Empty(t *testing.T) {
 	result := recommender.FormatRecommendations(nil)
 	if result == "" {
 		t.Error("FormatRecommendations(nil) should not return empty string")
+	}
+}
+
+func TestFormatRecommendations_AlwaysShowsDemoOption(t *testing.T) {
+	system := &analyzer.SystemInfo{
+		Platform:         analyzer.PlatformLinux,
+		ContainerRuntime: analyzer.ContainerRuntimeNone,
+		Orchestrator:     analyzer.OrchestratorNone,
+	}
+	recs := recommender.GenerateRecommendations(system)
+	result := recommender.FormatRecommendations(recs)
+	if !strings.Contains(result, "[d]") {
+		t.Error("FormatRecommendations should always include the [d] demo option regardless of feature flags")
 	}
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -169,6 +169,17 @@ try {
     Write-Host ""
     Write-Host "dtwiz ${Version} installed to ${Dest}"
 
+    # ── Install bundled examples ───────────────────────────────────────────────
+    $ExamplesSrc = Join-Path $TmpDir "examples"
+    if (Test-Path $ExamplesSrc) {
+        $ExamplesDest = Join-Path $env:USERPROFILE ".dtwiz\examples"
+        if (-not (Test-Path $ExamplesDest)) {
+            New-Item -ItemType Directory -Path $ExamplesDest -Force | Out-Null
+        }
+        Copy-Item -Path "$ExamplesSrc\*" -Destination $ExamplesDest -Recurse -Force
+        Write-Host "  Examples installed to $ExamplesDest"
+    }
+
     # ── Add to user PATH if needed ─────────────────────────────────────────────
     $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
     $PathDirs = $UserPath -split ";"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -169,17 +169,6 @@ try {
     Write-Host ""
     Write-Host "dtwiz ${Version} installed to ${Dest}"
 
-    # ── Install bundled examples ───────────────────────────────────────────────
-    $ExamplesSrc = Join-Path $TmpDir "examples"
-    if (Test-Path $ExamplesSrc) {
-        $ExamplesDest = Join-Path $env:USERPROFILE ".dtwiz\examples"
-        if (-not (Test-Path $ExamplesDest)) {
-            New-Item -ItemType Directory -Path $ExamplesDest -Force | Out-Null
-        }
-        Copy-Item -Path "$ExamplesSrc\*" -Destination $ExamplesDest -Recurse -Force
-        Write-Host "  Examples installed to $ExamplesDest"
-    }
-
     # ── Add to user PATH if needed ─────────────────────────────────────────────
     $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
     $PathDirs = $UserPath -split ";"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,6 +170,14 @@ fi
 echo ""
 echo "dtwiz ${VERSION} installed to ${DEST}"
 
+# ── Install bundled examples ───────────────────────────────────────────────────
+if [ -d "${WORK_DIR}/examples" ]; then
+    EXAMPLES_DEST="${HOME}/.dtwiz/examples"
+    mkdir -p "$EXAMPLES_DEST"
+    cp -r "${WORK_DIR}/examples/." "$EXAMPLES_DEST/"
+    echo "  Examples installed to ${EXAMPLES_DEST}"
+fi
+
 # ── Add to PATH in shell profile if needed ─────────────────────────────────────
 case ":${PATH}:" in
     *":${INSTALL_DIR}:"*)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,14 +170,6 @@ fi
 echo ""
 echo "dtwiz ${VERSION} installed to ${DEST}"
 
-# ── Install bundled examples ───────────────────────────────────────────────────
-if [ -d "${WORK_DIR}/examples" ]; then
-    EXAMPLES_DEST="${HOME}/.dtwiz/examples"
-    mkdir -p "$EXAMPLES_DEST"
-    cp -r "${WORK_DIR}/examples/." "$EXAMPLES_DEST/"
-    echo "  Examples installed to ${EXAMPLES_DEST}"
-fi
-
 # ── Add to PATH in shell profile if needed ─────────────────────────────────────
 case ":${PATH}:" in
     *":${INSTALL_DIR}:"*)


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Moves the schnitzel demo app installation out of the experimental feature gate, makes `dtwiz install demo` and its `[d]` menu option available to all users. Also adds the bundled schnitzel example app and extends the OTel project scanner to discover projects under `~/.dtwiz/examples`.

## How to test
1. Install with `DTWIZ_TAG="snapshot-feat-add-example-app" source <(curl -sSL https://raw.githubusercontent.com/dynatrace-oss/dtwiz/feat/add-example-app/scripts/install.sh)` or `$env:DTWIZ_TAG="snapshot-feat-add-example-app"; irm https://raw.githubusercontent.com/dynatrace-oss/dtwiz/feat/add-example-app/scripts/install.ps1 | iex` on Windows
2. Run `dtwiz recommend` without `--experimental` (or the Feature flag set) and verify `[d] Install demo app (schnitzel)` appears in the output.
3. Run `dtwiz install demo` and confirm it proceeds without an experimental flag error.
4. Run `dtwiz install otel` from a directory outside `~/.dtwiz/examples` and verify the schnitzel project is detected in the project list.
5. Run `dtwiz install otel` from `~` and check `/Users/your.username/.dtwiz/examples/schnitzel` (this exact path, just with your username) isn't listed twice.

## Which other features are affected?
1. OTel Python installation — project scan now includes bundled examples in `~/.dtwiz/examples`.
2. `dtwiz setup` interactive flow — the demo option is now always shown in recommendations.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.