### PR TITLE
chore: fix 'lint' and 'fmt' targets and run 'fmt' on whole project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,109 +1,15 @@
 #!/bin/sh
-# commit-msg hook — validates commit messages follow Conventional Commits format.
-# Rules mirror @commitlint/config-conventional. Ticket numbers are banned from commit subjects.
+# commit-msg hook — warns if commit message doesn't follow Conventional Commits format.
+# Non-blocking: the commit proceeds regardless. Hard enforcement happens in pre-push.
 #
 # Install: make setup
 
-COMMIT_MSG_FILE="$1"
+HOOK_DIR="$(dirname "$0")"
 
-# Strip comment lines (git inserts them after the message)
-MSG=$(grep -v '^#' "$COMMIT_MSG_FILE")
-
-# Skip empty commits
-if [ -z "$(printf '%s' "$MSG" | tr -d '[:space:]')" ]; then
-  exit 0
-fi
-
-# First line is the header
-HEADER=$(printf '%s\n' "$MSG" | head -n 1)
-
-# Skip release commits produced by release tooling: chore(release): ...
-case "$HEADER" in
-  "chore(release):"*) exit 0 ;;
-esac
-
-# ── helpers ────────────────────────────────────────────────────────────────────
-red()  { printf '\033[31m%s\033[0m\n' "$*" >&2; }
-hint() { printf '  %s\n' "$*" >&2; }
-
-ERRORS=0
-fail() { red "✗ $*"; ERRORS=$((ERRORS + 1)); }
-
-# ── rule: header-max-length (100) ─────────────────────────────────────────────
-HEADER_LEN=$(printf '%s' "$HEADER" | wc -c | tr -d ' ')
-if [ "$HEADER_LEN" -gt 100 ]; then
-  fail "header exceeds 100 characters (current length: $HEADER_LEN)"
-fi
-
-# ── rule: header must match <type>(<scope>): <subject> ────────────────────────
-if ! printf '%s' "$HEADER" | grep -qE '^[a-z]+(\([^)]+\))?: .+'; then
-  fail "commit message must follow format: <type>(<scope>): <subject>"
-  hint "examples:"
-  hint "  feat: add new feature"
-  hint "  fix(auth): correct token validation"
-  hint "  docs(readme): update installation steps"
-else
-  # Extract type (everything before an optional '(scope)' and ':')
-  TYPE=$(printf '%s' "$HEADER" | sed -E 's/^([a-z]+).*/\1/')
-
-  # ── rule: type-enum ──────────────────────────────────────────────────────────
-  case "$TYPE" in
-    feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert) ;;
-    *)
-      fail "type '$TYPE' is not allowed"
-      hint "allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
-      ;;
-  esac
-
-  # Extract subject (everything after the first ': ')
-  SUBJECT=$(printf '%s' "$HEADER" | sed -E 's/^[^:]+: //')
-
-  # ── rule: subject-empty ──────────────────────────────────────────────────────
-  if [ -z "$(printf '%s' "$SUBJECT" | tr -d '[:space:]')" ]; then
-    fail "subject may not be empty"
-  else
-    # ── rule: subject-case — must not start with an upper-case letter ──────────
-    FIRST_CHAR=$(printf '%s' "$SUBJECT" | cut -c1)
-    case "$FIRST_CHAR" in
-      [[:upper:]]) fail "subject '$SUBJECT' must not start with an upper-case letter" ;;
-    esac
-
-    # ── rule: subject-full-stop — must not end with '.' ───────────────────────
-    LAST_CHAR=$(printf '%s' "$SUBJECT" | rev | cut -c1)
-    if [ "$LAST_CHAR" = "." ]; then
-      fail "subject '$SUBJECT' must not end with a period"
-    fi
-  fi
-fi
-
-# ── rule: no ticket numbers (e.g. ABC-1234) anywhere in the header ────────────
-if printf '%s' "$HEADER" | grep -qE '[A-Z]{2,10}-[0-9]+'; then
-  fail "commit message must not contain ticket numbers (e.g. ABC-1234)"
-  hint "keep commit messages free of ticket numbers"
-fi
-
-# ── rule: body-max-line-length (100) — lines 3+ ───────────────────────────────
-LINE_NUM=0
-while IFS= read -r line; do
-  LINE_NUM=$((LINE_NUM + 1))
-  # Skip header and the mandatory blank separator line
-  [ "$LINE_NUM" -le 2 ] && continue
-  # Skip comment lines that git may have left in
-  case "$line" in \#*) continue ;; esac
-  LINE_LEN=$(printf '%s' "$line" | wc -c | tr -d ' ')
-  if [ "$LINE_LEN" -gt 100 ]; then
-    fail "body line $LINE_NUM exceeds 100 characters (current length: $LINE_LEN)"
-  fi
-done < "$COMMIT_MSG_FILE"
-
-# ── summary ───────────────────────────────────────────────────────────────────
-if [ "$ERRORS" -gt 0 ]; then
+if ! output=$("$HOOK_DIR/validate-msg" "$1" 2>&1); then
+  printf '\033[33m⚠ Warning: commit message issues (push will be blocked if not fixed):\033[0m\n' >&2
+  printf '%s\n' "$output" >&2
   printf '\n' >&2
-  red "Commit message validation failed ($ERRORS error(s))."
-  hint "Follow Conventional Commits: https://www.conventionalcommits.org"
-  hint "Format: <type>(<scope>): <subject>"
-  hint "Types:  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
-  exit 1
 fi
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,14 @@
 # pre-commit hook — blocks commits if code is not formatted.
 # Fix with: make fmt
 
+# Expand PATH for non-interactive shells (Homebrew, Go-installed tools)
+export PATH="$(go env GOPATH)/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+if ! command -v golangci-lint > /dev/null 2>&1; then
+  printf '\033[31m✗ golangci-lint not found. Install it: https://golangci-lint.run/welcome/install/\033[0m\n' >&2
+  exit 1
+fi
+
 diff=$(golangci-lint fmt --diff ./... 2>&1)
 if [ -n "$diff" ]; then
   printf '\033[31m✗ Code is not formatted. Run: make fmt\033[0m\n' >&2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# pre-commit hook — blocks commits if code is not formatted.
+# Fix with: make fmt
+
+diff=$(golangci-lint fmt --diff ./... 2>&1)
+if [ -n "$diff" ]; then
+  printf '\033[31m✗ Code is not formatted. Run: make fmt\033[0m\n' >&2
+  printf '%s\n' "$diff" >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -40,4 +40,11 @@ if [ "$ERRORS" -gt 0 ]; then
   exit 1
 fi
 
+# ── lint ──────────────────────────────────────────────────────────────────────
+printf 'Running make lint...\n' >&2
+if ! make lint >&2; then
+  printf '\033[31mPush rejected: lint failed. Fix the issues above and try again.\033[0m\n' >&2
+  exit 1
+fi
+
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,43 @@
+#!/bin/sh
+# pre-push hook — hard-blocks pushes containing commits with invalid messages.
+# Validates all commits being pushed that are not yet on the remote.
+#
+# Install: make setup
+
+HOOK_DIR="$(dirname "$0")"
+ERRORS=0
+
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  # Skip branch deletions
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue
+  fi
+
+  # Determine the commit range to validate
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # New branch: validate commits not yet on any remote
+    commits=$(git log "$local_sha" --not --remotes --format="%H")
+  else
+    commits=$(git log "$remote_sha..$local_sha" --format="%H")
+  fi
+
+  for commit in $commits; do
+    tmp=$(mktemp)
+    git log --format="%B" -n 1 "$commit" > "$tmp"
+    short=$(printf '%s' "$commit" | cut -c1-7)
+    if ! output=$("$HOOK_DIR/validate-msg" "$tmp" 2>&1); then
+      printf '\033[31m✗ %s — invalid commit message:\033[0m\n' "$short" >&2
+      printf '%s\n' "$output" >&2
+      printf '\n' >&2
+      ERRORS=$((ERRORS + 1))
+    fi
+    rm -f "$tmp"
+  done
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+  printf '\033[31mPush rejected: %d commit(s) with invalid message(s). Fix with: git rebase -i\033[0m\n' "$ERRORS" >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/validate-msg
+++ b/.githooks/validate-msg
@@ -1,0 +1,114 @@
+#!/bin/sh
+# validate-msg — validates a commit message file follows Conventional Commits format.
+# Rules mirror @commitlint/config-conventional. Ticket numbers are banned from commit subjects.
+#
+# Usage: validate-msg <commit-msg-file>
+
+COMMIT_MSG_FILE="$1"
+
+# Strip comment lines (git inserts them after the message)
+MSG=$(grep -v '^#' "$COMMIT_MSG_FILE")
+
+# Skip empty commits
+if [ -z "$(printf '%s' "$MSG" | tr -d '[:space:]')" ]; then
+  exit 0
+fi
+
+# First line is the header
+HEADER=$(printf '%s\n' "$MSG" | head -n 1)
+
+# Skip release commits produced by release tooling: chore(release): ...
+case "$HEADER" in
+  "chore(release):"*) exit 0 ;;
+esac
+
+# Skip fixup/squash/amend commits — these are rebased away before merging
+case "$HEADER" in
+  "fixup! "*|"squash! "*|"amend! "*) exit 0 ;;
+esac
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+red()  { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+hint() { printf '  %s\n' "$*" >&2; }
+
+ERRORS=0
+fail() { red "✗ $*"; ERRORS=$((ERRORS + 1)); }
+
+# ── rule: header-max-length (100) ─────────────────────────────────────────────
+HEADER_LEN=$(printf '%s' "$HEADER" | wc -c | tr -d ' ')
+if [ "$HEADER_LEN" -gt 100 ]; then
+  fail "header exceeds 100 characters (current length: $HEADER_LEN)"
+fi
+
+# ── rule: header must match <type>(<scope>): <subject> ────────────────────────
+if ! printf '%s' "$HEADER" | grep -qE '^[a-z]+(\([^)]+\))?: .+'; then
+  fail "commit message must follow format: <type>(<scope>): <subject>"
+  hint "examples:"
+  hint "  feat: add new feature"
+  hint "  fix(auth): correct token validation"
+  hint "  docs(readme): update installation steps"
+else
+  # Extract type (everything before an optional '(scope)' and ':')
+  TYPE=$(printf '%s' "$HEADER" | sed -E 's/^([a-z]+).*/\1/')
+
+  # ── rule: type-enum ──────────────────────────────────────────────────────────
+  case "$TYPE" in
+    feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert) ;;
+    *)
+      fail "type '$TYPE' is not allowed"
+      hint "allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+      ;;
+  esac
+
+  # Extract subject (everything after the first ': ')
+  SUBJECT=$(printf '%s' "$HEADER" | sed -E 's/^[^:]+: //')
+
+  # ── rule: subject-empty ──────────────────────────────────────────────────────
+  if [ -z "$(printf '%s' "$SUBJECT" | tr -d '[:space:]')" ]; then
+    fail "subject may not be empty"
+  else
+    # ── rule: subject-case — must not start with an upper-case letter ──────────
+    FIRST_CHAR=$(printf '%s' "$SUBJECT" | cut -c1)
+    case "$FIRST_CHAR" in
+      [[:upper:]]) fail "subject '$SUBJECT' must not start with an upper-case letter" ;;
+    esac
+
+    # ── rule: subject-full-stop — must not end with '.' ───────────────────────
+    LAST_CHAR=$(printf '%s' "$SUBJECT" | rev | cut -c1)
+    if [ "$LAST_CHAR" = "." ]; then
+      fail "subject '$SUBJECT' must not end with a period"
+    fi
+  fi
+fi
+
+# ── rule: no ticket numbers (e.g. ABC-1234) anywhere in the header ────────────
+if printf '%s' "$HEADER" | grep -qE '[A-Z]{2,10}-[0-9]+'; then
+  fail "commit message must not contain ticket numbers (e.g. ABC-1234)"
+  hint "keep commit messages free of ticket numbers"
+fi
+
+# ── rule: body-max-line-length (100) — lines 3+ ───────────────────────────────
+LINE_NUM=0
+while IFS= read -r line; do
+  LINE_NUM=$((LINE_NUM + 1))
+  # Skip header and the mandatory blank separator line
+  [ "$LINE_NUM" -le 2 ] && continue
+  # Skip comment lines that git may have left in
+  case "$line" in \#*) continue ;; esac
+  LINE_LEN=$(printf '%s' "$line" | wc -c | tr -d ' ')
+  if [ "$LINE_LEN" -gt 100 ]; then
+    fail "body line $LINE_NUM exceeds 100 characters (current length: $LINE_LEN)"
+  fi
+done < "$COMMIT_MSG_FILE"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+if [ "$ERRORS" -gt 0 ]; then
+  printf '\n' >&2
+  red "Commit message validation failed ($ERRORS error(s))."
+  hint "Follow Conventional Commits: https://www.conventionalcommits.org"
+  hint "Format: <type>(<scope>): <subject>"
+  hint "Types:  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+  exit 1
+fi
+
+exit 0

--- a/pkg/installer/oneagent/install_agent_windows.go
+++ b/pkg/installer/oneagent/install_agent_windows.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"unsafe"
 
+	"golang.org/x/sys/windows"
+
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
-	"golang.org/x/sys/windows"
 )
 
 var (

--- a/pkg/installer/otel/process_windows.go
+++ b/pkg/installer/otel/process_windows.go
@@ -7,8 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"golang.org/x/sys/windows"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // pythonLeafPID finds the leaf python process matching the given entrypoint.

--- a/pkg/installer/path_windows.go
+++ b/pkg/installer/path_windows.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 // RefreshWindowsPath appends any user registry PATH entries missing from the

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -30,7 +30,6 @@ func countDynakubes(t *testing.T) int {
 	return len(strings.Split(trimmed, "\n"))
 }
 
-
 // TestKubernetesLifecycle exercises the full Dynatrace Operator lifecycle
 // against a real Kubernetes cluster and a real Dynatrace tenant: install
 // (Helm chart + DynaKube CR, wait for pods to become ready) → uninstall

--- a/test/e2e/oneagent_test.go
+++ b/test/e2e/oneagent_test.go
@@ -115,4 +115,3 @@ func TestOneAgentLifecycle(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe):

* runs `make fmt` on the whole project
* allows non-conventional commits before pushing, only emitting a warning so fixup commits work again
  * introduces another git-hook that enforces the conventional commits before pushing 
* enforces `make lint` in pre-push hook 


## How to test

### Git Hooks - Conventional Commits
* Check out this branch
* Execute `make setup`
* Add a testfile or some change to the repo
* Commit using any commit message, ensuring that it DOES NOT follow "conventional commit" practices, this should succeed
* Try to push the new commit, this should fail

### Git Hooks - Formatting and Linting
* Check out this branch
* Change any file to not conform to formatting rules
* Try to commit the change
* Committing should fail, as formatting is not correct

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
