### PR TITLE
feat: remove dynatrace operator version von k8s

### DIFF
--- a/pkg/installer/kubernetes/helm_install.go
+++ b/pkg/installer/kubernetes/helm_install.go
@@ -100,7 +100,6 @@ func helmOperatorArgs(helmMajor int, disableCSI bool) []string {
 	args := []string{
 		"install", "dynatrace-operator",
 		dynatraceOperatorOCI,
-		"--version", dynatraceOperatorVersion,
 		"--create-namespace",
 		"--namespace", "dynatrace",
 		rollbackFlag,
@@ -123,7 +122,6 @@ func helmOperatorUpgradeArgs(helmMajor int, disableCSI bool) []string {
 	args := []string{
 		"upgrade", "dynatrace-operator",
 		dynatraceOperatorOCI,
-		"--version", dynatraceOperatorVersion,
 		"--namespace", "dynatrace",
 		rollbackFlag,
 		"--timeout", "10m",

--- a/pkg/installer/kubernetes/install.go
+++ b/pkg/installer/kubernetes/install.go
@@ -27,8 +27,6 @@ const (
 	dynakubeEECTag           = "1.337.60.20260603-063549"
 	dynakubeCodeModulesImage = "public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.60.20260603-063549"
 
-	// dynatraceOperatorVersion is the operator chart version pinned by dtwiz.
-	dynatraceOperatorVersion = "1.10.0-rc.0"
 	// dynatraceOperatorOCI is the OCI chart reference hosted on public.ecr.aws.
 	dynatraceOperatorOCI = "oci://public.ecr.aws/dynatrace/dynatrace-operator"
 )


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. Run `dtwiz setup`, select option  `[2]  Kubernetes cluster`
2. Make sure in Steps, Step 1 doesn't contain `-- version` flag and no version is specified
3. Make sure installation was successful
4. Check installed dynatrace operator version by running `helm list -n dynatrace`, command
5. Make sure last dynatrace operator version is installed

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
