### PR TITLE
feat: propose 'include-home-directory-in-scan' change

### DIFF
--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/.openspec.yaml
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/design.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/design.md
@@ -1,0 +1,81 @@
+# Design
+
+## Context
+
+`scanProjectDirs` (`pkg/installer/otel/runtime_scan.go`) is the shared filesystem scanner for the OTel install flow. Today it hard-codes its roots: it calls `os.Getwd()` and walks the working directory downward, plus always walks `~/.dtwiz/examples/`. It deliberately never traverses ancestors of the working directory.
+
+The scanner is invoked once per enabled runtime (Python, Java, Node.js, Go). `detectAllProjects` (`otel.go:90`) fans those runtimes out into **parallel goroutines**, so `scanProjectDirs` runs up to four times concurrently. Any user prompt placed inside `scanProjectDirs` would therefore race across goroutines for stdin/stdout. This is the central constraint the design works around.
+
+The install entry point is `InstallOtelCollectorWithProject` (`otel.go:253`). When called with an explicit `--project` path it builds a plan directly and never scans. Otherwise it calls `detectAllProjects` (`otel.go:313`) and already has an established cancellation path via `installer.ErrInstallCancelled` (`otel.go:321`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let a user running `install otel` from a directory that does not cover home opt into also scanning their home directory, via a single interactive prompt.
+- Make the prompt fire exactly once per invocation, before any parallel scanning.
+- Keep the working-directory-only behavior available (`c`) and give a clean full-command abort (`n`).
+- Preserve the always-on `~/.dtwiz/examples/` scan unchanged.
+- Choose scan roots explicitly and pass them down, rather than deriving them deep inside the scanner.
+
+**Non-Goals:**
+
+- Optimizing the redundant walk when `cwd` is under `home` and the user picks `Y` (the `home` walk re-descends into the `cwd` subtree). Dedup already prevents duplicate results; the extra walk is accepted.
+- Adding a persistent flag or env var to preselect the choice. Only the interactive prompt plus the existing `AutoConfirm`/TTY signals drive the default.
+- Changing scan behavior for the explicit `--project` path (no scan, no prompt).
+- Changing uninstall-side scanning.
+
+## Decisions
+
+### Decision: Select scan roots once, above the parallel fan-out
+
+Root selection (and the prompt) lives in `InstallOtelCollectorWithProject`, in the `else` branch (`projectPath == ""`), immediately before `detectAllProjects`. This guarantees a single prompt and lets the `n` case `return installer.ErrInstallCancelled` before any work begins, reusing the existing cancellation pattern.
+
+**Alternative considered:** prompt inside `scanProjectDirs`. Rejected: it runs up to 4× concurrently, so the prompt would race and repeat.
+
+### Decision: Explicit threading of `roots []string`
+
+The chosen roots are passed as a parameter down the call chain rather than stored in package-level state:
+
+```text
+InstallOtelCollectorWithProject
+  → roots := selectScanRoots(...)          // prompt / decision, once
+  → detectAllProjects(runtimes, roots)
+      → rt.detect(roots)                    // runtimeInfo.detect signature grows
+          → detect{Python,Java,Node,Go}Projects(roots)
+              → scanJavaProjects(roots) (Java)
+              → scanProjectDirs(markers, excludeNames, roots)
+```
+
+`scanProjectDirs` stops calling `os.Getwd()` itself; it iterates the supplied `roots`, walking each via `walkCandidateDirs`, and then appends the always-on `~/.dtwiz/examples/` walk exactly as today. Progress/relative-path bookkeeping that currently keys off `workingDir` keys off the first root (the working directory).
+
+**Alternative considered:** a package-level `scanRoots` set before the fan-out (precedent: `AutoConfirm`, `globalScanCount`). Rejected: shared mutable state is easy to get wrong with concurrent scans and harder to test; the existing `TestScanProjectDirs_*` tests construct scans directly and benefit from an explicit parameter.
+
+### Decision: When to prompt vs. skip
+
+Compute `cwd = os.Getwd()` and `home = os.UserHomeDir()` once.
+
+- `cwd == home` → **no prompt**, `roots = [cwd]` (home is already the working dir).
+- `home` is a descendant of `cwd` (i.e. `cwd` is an ancestor of `home`) → **no prompt**, `roots = [cwd]` (the working-dir walk already covers home).
+- otherwise (`cwd` under `home`, or an unrelated tree) → **prompt** `Y/c/n`.
+
+Ancestor detection uses cleaned, symlink-resolved absolute paths and a path-segment comparison (not raw string prefix, to avoid `/home/foobar` matching `/home/foo`).
+
+### Decision: Prompt outcomes and non-interactive default
+
+- `Y` (default, Enter) → `roots = [cwd, home]`
+- `c` → `roots = [cwd]`
+- `n` → abort: `return installer.ErrInstallCancelled`
+
+When `installer.AutoConfirm` is set, or stdin is not a TTY, the prompt is not shown and `Y` is assumed (`roots = [cwd, home]`). This matches the proposal's "zero-config, widen by default" intent while never blocking an unattended run.
+
+### Decision: Bundled examples stay orthogonal
+
+`~/.dtwiz/examples/` remains an unconditional extra walk inside `scanProjectDirs`, independent of `roots` and of the prompt outcome (including `c`). No behavior change; the existing dedup handles overlap when `home` is also a root.
+
+## Risks / Trade-offs
+
+- **Redundant walk when `cwd` is under `home` and user picks `Y`** → the `home` walk re-descends into the `cwd` subtree. Mitigation: existing `matchedProjects` dedup keeps results correct; extra walk time accepted as out of scope.
+- **Scanning a large home directory is slow/noisy** → mitigation: the existing large-scan progress notice (`largeScanThreshold`) and the macOS/Windows system-dir excludes already apply to every root, including `home`.
+- **Non-interactive default `Y` walks all of home in CI/pipelines** → mitigation: this only affects `install otel` without `--project`; automated flows that target a specific project should pass `--project`, which skips scanning entirely.
+- **Relaxing the "never traverse ancestors" guarantee** → this is an intentional spec change (see spec delta); it only happens on explicit opt-in (or the documented non-interactive default), never silently mid-scan.

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/design.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/design.md
@@ -12,7 +12,7 @@ The install entry point is `InstallOtelCollectorWithProject` (`otel.go:253`). Wh
 
 **Goals:**
 
-- Let a user running `install otel` from a directory that does not cover home opt into also scanning their home directory, via a single interactive prompt.
+- Let a user running `install otel` from a directory outside the home tree opt into also scanning their home directory, via a single interactive prompt.
 - Make the prompt fire exactly once per invocation, before any parallel scanning.
 - Keep the working-directory-only behavior available (`c`) and give a clean full-command abort (`n`).
 - Preserve the always-on `~/.dtwiz/examples/` scan unchanged.
@@ -20,7 +20,7 @@ The install entry point is `InstallOtelCollectorWithProject` (`otel.go:253`). Wh
 
 **Non-Goals:**
 
-- Optimizing the redundant walk when `cwd` is under `home` and the user picks `Y` (the `home` walk re-descends into the `cwd` subtree). Dedup already prevents duplicate results; the extra walk is accepted.
+- Prompting or adding home when `cwd` is already within the home tree. If the user is somewhere under `~`, we scan the working directory only and never add home as a second root.
 - Adding a persistent flag or env var to preselect the choice. Only the interactive prompt plus the existing `AutoConfirm`/TTY signals drive the default.
 - Changing scan behavior for the explicit `--project` path (no scan, no prompt).
 - Changing uninstall-side scanning.
@@ -55,11 +55,14 @@ InstallOtelCollectorWithProject
 
 Compute `cwd = os.Getwd()` and `home = os.UserHomeDir()` once.
 
+The prompt fires only when `cwd` and `home` are in **disjoint trees**. If either is an ancestor of the other (inclusive), the working-directory walk is sufficient and there is nothing to add:
+
 - `cwd == home` → **no prompt**, `roots = [cwd]` (home is already the working dir).
 - `home` is a descendant of `cwd` (i.e. `cwd` is an ancestor of `home`) → **no prompt**, `roots = [cwd]` (the working-dir walk already covers home).
-- otherwise (`cwd` under `home`, or an unrelated tree) → **prompt** `Y/c/n`.
+- `cwd` is a descendant of `home` (`cwd` is within the home tree, e.g. `~/projects/foo`) → **no prompt**, `roots = [cwd]`. We do **not** add home as a second root, since the user is already working inside their home tree.
+- otherwise (disjoint trees, e.g. `/opt/app`, `/tmp/work`) → **prompt** `Y/c/n`.
 
-Ancestor detection uses cleaned, symlink-resolved absolute paths and a path-segment comparison (not raw string prefix, to avoid `/home/foobar` matching `/home/foo`).
+Ancestor/descendant detection uses cleaned, symlink-resolved absolute paths and a path-segment comparison (not raw string prefix, to avoid `/home/foobar` matching `/home/foo`).
 
 ### Decision: Prompt outcomes and non-interactive default
 
@@ -75,7 +78,7 @@ When `installer.AutoConfirm` is set, or stdin is not a TTY, the prompt is not sh
 
 ## Risks / Trade-offs
 
-- **Redundant walk when `cwd` is under `home` and user picks `Y`** → the `home` walk re-descends into the `cwd` subtree. Mitigation: existing `matchedProjects` dedup keeps results correct; extra walk time accepted as out of scope.
+- **Roots overlap only via bundled examples** → since home is added only when disjoint from `cwd`, the two roots never overlap; the sole residual overlap is the always-on `~/.dtwiz/examples/` root (under home). Mitigation: existing `matchedProjects` dedup keeps results correct.
 - **Scanning a large home directory is slow/noisy** → mitigation: the existing large-scan progress notice (`largeScanThreshold`) and the macOS/Windows system-dir excludes already apply to every root, including `home`.
-- **Non-interactive default `Y` walks all of home in CI/pipelines** → mitigation: this only affects `install otel` without `--project`; automated flows that target a specific project should pass `--project`, which skips scanning entirely.
-- **Relaxing the "never traverse ancestors" guarantee** → this is an intentional spec change (see spec delta); it only happens on explicit opt-in (or the documented non-interactive default), never silently mid-scan.
+- **Non-interactive default `Y` walks all of home in CI/pipelines** → mitigation: this only affects `install otel` run from outside the home tree without `--project`; automated flows that target a specific project should pass `--project`, which skips scanning entirely.
+- **Adding home as a separate root expands scan scope** → the working directory's ancestors are still never traversed; home is a disjoint additional root, scanned only on explicit opt-in (or the documented non-interactive default), never silently mid-scan.

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/proposal.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/proposal.md
@@ -6,15 +6,15 @@ When a user runs `dtwiz install otel` from a working directory that does not con
 
 ## What Changes
 
-- When `dtwiz install otel` runs **without** an explicit `--project` path, and the working directory does not already cover the home directory, prompt the user once (before the parallel runtime scan begins) with a three-way choice:
+- When `dtwiz install otel` runs **without** an explicit `--project` path, and the working directory lies **outside the home-directory tree** (neither contains home nor is contained by it), prompt the user once (before the parallel runtime scan begins) with a three-way choice:
   - `Y` (default): scan the working directory **and** the home directory
   - `c`: scan the working directory only
   - `n`: abort the whole `install otel` command
-- The prompt is skipped (no change from today, working-directory scan only) when `cwd == home` or when `home` is a descendant of `cwd`, because the working-directory walk already covers home in those cases.
-- In non-interactive contexts (`--yes`/`AutoConfirm`, or stdin is not a TTY) the default `Y` is assumed: scan working directory + home.
+- The prompt is skipped (no change from today, working-directory scan only) whenever the working directory is in the same lineage as home: `cwd == home`, or `home` is a descendant of `cwd` (the working-directory walk already covers home), or `cwd` is within home (`cwd` is a descendant of home). In the last case we do **not** add home as a second root.
+- In non-interactive contexts (`--yes`/`AutoConfirm`, or stdin is not a TTY) the default `Y` is assumed when the working directory is outside the home tree: scan working directory + home.
 - The scanner accepts an explicit set of scan roots instead of hard-coding the working directory. Roots are chosen once, before the parallel fan-out, and threaded down into every per-runtime scan.
 - The `~/.dtwiz/examples/` bundled-examples scan stays always-on and unchanged, independent of the prompt outcome.
-- **BREAKING** (spec-level only): the scanner may now traverse an ancestor of the working directory (the home directory) when the user opts in. This relaxes the current "SHALL NOT traverse any ancestor directories" guarantee.
+- Because home is only added when it is disjoint from the working directory, the scanner still never traverses an ancestor of the working directory; it may scan an additional, separate root (home). No change to the explicit-`--project` path (no scan, no prompt).
 
 ## Capabilities
 
@@ -24,12 +24,12 @@ _None._
 
 ### Modified Capabilities
 
-- `otel-project-scan`: The "scan scope limited to working directory" requirement is relaxed. The scanner now selects scan roots via an interactive three-way prompt (working directory only, working directory + home, or abort) when run from a directory that does not already cover home. Non-interactive default is working directory + home. The bundled-examples requirement is unchanged.
+- `otel-project-scan`: The "scan scope limited to working directory" requirement is extended. The scanner now selects scan roots via an interactive three-way prompt (working directory only, working directory + home, or abort) when run from a directory outside the home tree. Non-interactive default is working directory + home. The bundled-examples requirement is unchanged.
 
 ## Impact
 
 - **Code:** `pkg/installer/otel/otel.go` (`InstallOtelCollectorWithProject` gains the root-selection prompt before `detectAllProjects`; `detectAllProjects` and `runtimeInfo.detect` gain a `roots []string` parameter), `pkg/installer/otel/runtime_scan.go` (`scanProjectDirs` accepts and iterates `roots` instead of calling `os.Getwd()` internally), and the per-runtime detectors (`detectPythonProjects`, `detectJavaProjects`/`scanJavaProjects`, `detectNodeProjects`, `detectGoProjects`) which thread `roots` through.
 - **UX:** one new interactive prompt in the otel install flow; abort reuses the existing `installer.ErrInstallCancelled` cancellation path.
 - **Tests:** `runtime_scan_test.go` scan helpers now pass explicit roots; new coverage for the prompt decision logic (prompt-vs-skip conditions, three-way outcomes, non-interactive default).
-- **Accepted trade-off:** in the common case where `cwd` is under `home`, choosing `Y` re-walks the `cwd` subtree while walking `home`; the existing `matchedProjects` dedup prevents duplicate projects, and the redundant walk is accepted (not optimized in this change).
+- **Overlap handling:** home is only added when disjoint from the working directory, so the two roots never overlap. The only residual overlap is the always-on `~/.dtwiz/examples/` root (which lives under home); the existing `matchedProjects` dedup already prevents duplicate projects there.
 - No dependency, API, or auth changes. No feature flag.

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/proposal.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/proposal.md
@@ -1,0 +1,35 @@
+# Proposal
+
+## Why
+
+When a user runs `dtwiz install otel` from a working directory that does not contain their code, the scanner finds nothing and the flow dead-ends, even though the user's projects usually live somewhere under their home directory. Today the scanner is deliberately limited to the working directory and never traverses ancestors, so there is no way to widen the search without `cd`-ing elsewhere and re-running. We want to offer that wider search interactively, without silently walking the user's entire home directory when they did not ask for it.
+
+## What Changes
+
+- When `dtwiz install otel` runs **without** an explicit `--project` path, and the working directory does not already cover the home directory, prompt the user once (before the parallel runtime scan begins) with a three-way choice:
+  - `Y` (default): scan the working directory **and** the home directory
+  - `c`: scan the working directory only
+  - `n`: abort the whole `install otel` command
+- The prompt is skipped (no change from today, working-directory scan only) when `cwd == home` or when `home` is a descendant of `cwd`, because the working-directory walk already covers home in those cases.
+- In non-interactive contexts (`--yes`/`AutoConfirm`, or stdin is not a TTY) the default `Y` is assumed: scan working directory + home.
+- The scanner accepts an explicit set of scan roots instead of hard-coding the working directory. Roots are chosen once, before the parallel fan-out, and threaded down into every per-runtime scan.
+- The `~/.dtwiz/examples/` bundled-examples scan stays always-on and unchanged, independent of the prompt outcome.
+- **BREAKING** (spec-level only): the scanner may now traverse an ancestor of the working directory (the home directory) when the user opts in. This relaxes the current "SHALL NOT traverse any ancestor directories" guarantee.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `otel-project-scan`: The "scan scope limited to working directory" requirement is relaxed. The scanner now selects scan roots via an interactive three-way prompt (working directory only, working directory + home, or abort) when run from a directory that does not already cover home. Non-interactive default is working directory + home. The bundled-examples requirement is unchanged.
+
+## Impact
+
+- **Code:** `pkg/installer/otel/otel.go` (`InstallOtelCollectorWithProject` gains the root-selection prompt before `detectAllProjects`; `detectAllProjects` and `runtimeInfo.detect` gain a `roots []string` parameter), `pkg/installer/otel/runtime_scan.go` (`scanProjectDirs` accepts and iterates `roots` instead of calling `os.Getwd()` internally), and the per-runtime detectors (`detectPythonProjects`, `detectJavaProjects`/`scanJavaProjects`, `detectNodeProjects`, `detectGoProjects`) which thread `roots` through.
+- **UX:** one new interactive prompt in the otel install flow; abort reuses the existing `installer.ErrInstallCancelled` cancellation path.
+- **Tests:** `runtime_scan_test.go` scan helpers now pass explicit roots; new coverage for the prompt decision logic (prompt-vs-skip conditions, three-way outcomes, non-interactive default).
+- **Accepted trade-off:** in the common case where `cwd` is under `home`, choosing `Y` re-walks the `cwd` subtree while walking `home`; the existing `matchedProjects` dedup prevents duplicate projects, and the redundant walk is accepted (not optimized in this change).
+- No dependency, API, or auth changes. No feature flag.

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/specs/otel-project-scan/spec.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/specs/otel-project-scan/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Scan scope limited to working directory
 
- The scanner SHALL search the working directory and its subdirectories for OTel project markers by default. It SHALL NOT traverse any ancestor directories of the working directory **unless** (a) the user selects an option that includes the home directory at the interactive prompt (see "Interactive home-directory scan choice"), or (b) the command is running non-interactively (e.g., `--yes`/`AutoConfirm`, or stdin is not a TTY), in which case scanning the home directory is the default. When home scanning is enabled, the home directory and its subdirectories are also searched.
+The scanner SHALL search the working directory and its subdirectories for OTel project markers. It SHALL NOT traverse any ancestor directories of the working directory. When the working directory lies outside the home-directory tree, the scanner MAY additionally search the home directory and its subdirectories as a separate scan root, either because the user opted in at the interactive prompt or because the command is running non-interactively (see "Interactive home-directory scan choice"). Home is never an ancestor of the working directory in this case, so the no-ancestor-traversal guarantee is preserved.
 
 #### Scenario: Project in working directory is found
 
@@ -18,11 +18,11 @@
 - **WHEN** the user runs a dtwiz OTel install command from that parent directory
 - **THEN** all matching subdirectory projects are detected
 
-#### Scenario: Parent directory is not scanned when user does not opt in
+#### Scenario: Parent directory is not scanned
 
-- **GIVEN** the user runs a dtwiz OTel install command from a subdirectory of their project root (e.g. `my-project/src/`)
-- **WHEN** the user chooses to scan the working directory only
-- **THEN** the parent directory (`my-project/`) is NOT scanned and projects there are NOT detected
+- **GIVEN** the working directory is a subdirectory of a project root within the home tree (e.g. `~/my-project/src/`)
+- **WHEN** the user runs a dtwiz OTel install command from there (no prompt is shown, since the working directory is within home)
+- **THEN** the parent directory (`~/my-project/`) is NOT scanned and projects there are NOT detected
 
 #### Scenario: Parent directory is not scanned during uninstall
 
@@ -36,13 +36,17 @@
 
 ### Requirement: Interactive home-directory scan choice
 
-When `dtwiz install otel` runs WITHOUT an explicit `--project` path, and the working directory does NOT already cover the home directory, the scanner SHALL prompt the user exactly once, before any project scanning begins, with a three-way choice:
+When `dtwiz install otel` runs WITHOUT an explicit `--project` path, and the working directory lies OUTSIDE the home-directory tree (the working directory and the home directory are in disjoint trees, with neither an ancestor of the other), the scanner SHALL prompt the user exactly once, before any project scanning begins, with a three-way choice:
 
 - `Y` (default): scan the working directory AND the home directory
 - `c`: scan the working directory only
 - `n`: abort the entire `install otel` command
 
-The working directory "already covers" the home directory when the working directory IS the home directory, or when the home directory is a descendant of the working directory. In those cases the scanner SHALL NOT prompt and SHALL scan the working directory only (the home directory is already within the working-directory walk).
+The scanner SHALL NOT prompt, and SHALL scan the working directory only, whenever the working directory is in the same lineage as the home directory:
+
+- the working directory IS the home directory, or
+- the home directory is a descendant of the working directory (the working-directory walk already covers home), or
+- the working directory is a descendant of the home directory (the user is already working inside their home tree); the scanner SHALL NOT add the home directory as a second root in this case.
 
 The prompt SHALL be presented before the per-runtime scans fan out, so that it is shown at most once per invocation regardless of how many runtimes are scanned.
 
@@ -50,9 +54,9 @@ The `~/.dtwiz/examples/` bundled-examples scan SHALL remain always-on regardless
 
 When an explicit `--project` path is provided, the scanner SHALL NOT prompt and SHALL NOT perform a directory scan.
 
-#### Scenario: Prompt offered from a directory that does not cover home
+#### Scenario: Prompt offered from a directory outside the home tree
 
-- **GIVEN** the working directory is neither the home directory nor an ancestor of it (e.g. `~/projects/foo` or `/tmp/work`)
+- **GIVEN** the working directory is in a disjoint tree from the home directory (e.g. `/opt/app`, `/tmp/work`, or `D:\projects` on Windows)
 - **WHEN** the user runs `dtwiz install otel` without `--project`
 - **THEN** the scanner SHALL present the three-way `Y/c/n` prompt before scanning begins
 
@@ -74,6 +78,13 @@ When an explicit `--project` path is provided, the scanner SHALL NOT prompt and 
 - **WHEN** the user selects `n`
 - **THEN** the entire `dtwiz install otel` command SHALL be cancelled and SHALL NOT proceed to scanning or installation
 
+#### Scenario: Prompt skipped when working directory is within the home directory
+
+- **GIVEN** the working directory is a descendant of the home directory (e.g. `~/projects/foo`)
+- **WHEN** the user runs `dtwiz install otel` without `--project`
+- **THEN** the scanner SHALL NOT prompt and SHALL scan the working directory tree only
+- **AND** the scanner SHALL NOT add the home directory as a second root
+
 #### Scenario: Prompt skipped when working directory is the home directory
 
 - **GIVEN** the working directory is the home directory
@@ -89,7 +100,7 @@ When an explicit `--project` path is provided, the scanner SHALL NOT prompt and 
 #### Scenario: Non-interactive default includes home
 
 - **GIVEN** the command is run with `--yes`/`AutoConfirm`, or stdin is not a TTY
-- **WHEN** the working directory does not cover the home directory
+- **WHEN** the working directory lies outside the home tree (disjoint from home)
 - **THEN** the scanner SHALL NOT block on a prompt and SHALL default to scanning the working directory AND the home directory
 
 #### Scenario: Explicit project path skips prompt and scan

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/specs/otel-project-scan/spec.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/specs/otel-project-scan/spec.md
@@ -1,0 +1,99 @@
+# Spec: OTel Project Scan
+
+## MODIFIED Requirements
+
+### Requirement: Scan scope limited to working directory
+
+ The scanner SHALL search the working directory and its subdirectories for OTel project markers by default. It SHALL NOT traverse any ancestor directories of the working directory **unless** (a) the user selects an option that includes the home directory at the interactive prompt (see "Interactive home-directory scan choice"), or (b) the command is running non-interactively (e.g., `--yes`/`AutoConfirm`, or stdin is not a TTY), in which case scanning the home directory is the default. When home scanning is enabled, the home directory and its subdirectories are also searched.
+
+#### Scenario: Project in working directory is found
+
+- **GIVEN** the working directory contains a project marker (e.g. `requirements.txt`, `package.json`)
+- **WHEN** the user runs a dtwiz OTel install command from that directory
+- **THEN** the project is detected and instrumentation proceeds
+
+#### Scenario: Project in subdirectory is found
+
+- **GIVEN** the working directory has subdirectories that contain project markers
+- **WHEN** the user runs a dtwiz OTel install command from that parent directory
+- **THEN** all matching subdirectory projects are detected
+
+#### Scenario: Parent directory is not scanned when user does not opt in
+
+- **GIVEN** the user runs a dtwiz OTel install command from a subdirectory of their project root (e.g. `my-project/src/`)
+- **WHEN** the user chooses to scan the working directory only
+- **THEN** the parent directory (`my-project/`) is NOT scanned and projects there are NOT detected
+
+#### Scenario: Parent directory is not scanned during uninstall
+
+- **GIVEN** the working directory is a subdirectory of a project root
+- **WHEN** the user runs a dtwiz OTel uninstall command from that subdirectory
+- **THEN** `.otel/` directories in parent directories are NOT found and NOT removed; only `.otel/` directories within the working directory tree are considered
+
+---
+
+## ADDED Requirements
+
+### Requirement: Interactive home-directory scan choice
+
+When `dtwiz install otel` runs WITHOUT an explicit `--project` path, and the working directory does NOT already cover the home directory, the scanner SHALL prompt the user exactly once, before any project scanning begins, with a three-way choice:
+
+- `Y` (default): scan the working directory AND the home directory
+- `c`: scan the working directory only
+- `n`: abort the entire `install otel` command
+
+The working directory "already covers" the home directory when the working directory IS the home directory, or when the home directory is a descendant of the working directory. In those cases the scanner SHALL NOT prompt and SHALL scan the working directory only (the home directory is already within the working-directory walk).
+
+The prompt SHALL be presented before the per-runtime scans fan out, so that it is shown at most once per invocation regardless of how many runtimes are scanned.
+
+The `~/.dtwiz/examples/` bundled-examples scan SHALL remain always-on regardless of the choice, including when the user selects `c`.
+
+When an explicit `--project` path is provided, the scanner SHALL NOT prompt and SHALL NOT perform a directory scan.
+
+#### Scenario: Prompt offered from a directory that does not cover home
+
+- **GIVEN** the working directory is neither the home directory nor an ancestor of it (e.g. `~/projects/foo` or `/tmp/work`)
+- **WHEN** the user runs `dtwiz install otel` without `--project`
+- **THEN** the scanner SHALL present the three-way `Y/c/n` prompt before scanning begins
+
+#### Scenario: Choosing Y scans working directory and home
+
+- **GIVEN** the three-way prompt is shown
+- **WHEN** the user selects `Y` (or presses Enter)
+- **THEN** the scanner SHALL search both the working directory tree and the home directory tree for project markers
+
+#### Scenario: Choosing c scans working directory only
+
+- **GIVEN** the three-way prompt is shown
+- **WHEN** the user selects `c`
+- **THEN** the scanner SHALL search only the working directory tree (plus the always-on bundled examples) and SHALL NOT traverse the home directory
+
+#### Scenario: Choosing n aborts the install command
+
+- **GIVEN** the three-way prompt is shown
+- **WHEN** the user selects `n`
+- **THEN** the entire `dtwiz install otel` command SHALL be cancelled and SHALL NOT proceed to scanning or installation
+
+#### Scenario: Prompt skipped when working directory is the home directory
+
+- **GIVEN** the working directory is the home directory
+- **WHEN** the user runs `dtwiz install otel` without `--project`
+- **THEN** the scanner SHALL NOT prompt and SHALL scan the working directory (home) tree
+
+#### Scenario: Prompt skipped when home is a descendant of the working directory
+
+- **GIVEN** the working directory is an ancestor of the home directory (e.g. `/Users` on macOS, `/home` on Linux)
+- **WHEN** the user runs `dtwiz install otel` without `--project`
+- **THEN** the scanner SHALL NOT prompt and SHALL scan the working directory tree, which already includes the home directory
+
+#### Scenario: Non-interactive default includes home
+
+- **GIVEN** the command is run with `--yes`/`AutoConfirm`, or stdin is not a TTY
+- **WHEN** the working directory does not cover the home directory
+- **THEN** the scanner SHALL NOT block on a prompt and SHALL default to scanning the working directory AND the home directory
+
+#### Scenario: Explicit project path skips prompt and scan
+
+- **GIVEN** an explicit `--project <path>` is provided
+- **WHEN** the user runs `dtwiz install otel --project <path>`
+- **THEN** the scanner SHALL NOT present the prompt and SHALL NOT perform a directory scan

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/tasks.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## 1. Thread scan roots through the scanner
+
+- [ ] 1.1 Change `scanProjectDirs` (`pkg/installer/otel/runtime_scan.go`) to accept `roots []string`; iterate the supplied roots via `walkCandidateDirs` instead of calling `os.Getwd()` internally, keeping the always-on `~/.dtwiz/examples/` walk
+- [ ] 1.2 Base the progress notice and relative-path/subtree bookkeeping on the first root (the working directory) instead of the removed `workingDir` local
+- [ ] 1.3 Update per-runtime detectors to accept and forward `roots`: `detectPythonProjects`, `detectJavaProjects` + `scanJavaProjects`, `detectNodeProjects`, `detectGoProjects`
+- [ ] 1.4 Add `roots` to the `runtimeInfo.detect` signature and to `detectAllProjects(runtimes, roots)`; pass `roots` from each parallel `rt.detect(roots)` call
+
+## 2. Root selection and prompt
+
+- [ ] 2.1 Add a helper (e.g. `selectScanRoots`) that computes `cwd = os.Getwd()` and `home = os.UserHomeDir()`, using cleaned, symlink-resolved absolute paths and segment-wise ancestor comparison
+- [ ] 2.2 Skip the prompt and return `[cwd]` when `cwd == home` or when `home` is a descendant of `cwd`
+- [ ] 2.3 Otherwise present the three-way `Y/c/n` prompt (default `Y`): `Y` → `[cwd, home]`, `c` → `[cwd]`, `n` → signal abort
+- [ ] 2.4 In non-interactive contexts (`installer.AutoConfirm`, or stdin is not a TTY) skip the prompt and default to `[cwd, home]`
+- [ ] 2.5 Map the `n` outcome to `installer.ErrInstallCancelled` returned from the caller
+
+## 3. Wire into the install flow
+
+- [ ] 3.1 In `InstallOtelCollectorWithProject` (`pkg/installer/otel/otel.go`), inside the `projectPath == ""` branch and before `detectAllProjects`, call the root-selection helper and return `installer.ErrInstallCancelled` on `n`
+- [ ] 3.2 Pass the selected `roots` into `detectAllProjects(runtimes, roots)`
+- [ ] 3.3 Confirm the explicit `--project` path branch neither prompts nor scans (no change needed beyond not invoking the helper there)
+
+## 4. Tests
+
+- [ ] 4.1 Update existing `TestScanProjectDirs_*` (`runtime_scan_test.go`) to pass explicit `roots`
+- [ ] 4.2 Add tests for the decision logic: prompt-vs-skip when `cwd == home`, when `home` is a descendant of `cwd`, and when it is not
+- [ ] 4.3 Add tests for the three outcomes (`Y`/`c`/`n`) and the non-interactive default (`AutoConfirm`/non-TTY → `[cwd, home]`)
+- [ ] 4.4 Add a test that scanning multiple roots dedups a project reachable from both `cwd` and `home` (common dev case)
+
+## 5. Verify
+
+- [ ] 5.1 `make test` passes
+- [ ] 5.2 `make lint` shows no new issues
+- [ ] 5.3 Manual smoke: run `dtwiz install otel --dry-run` from `~/some/project` (CWD under home → prompt appears), from `$HOME` (CWD == home → no prompt), and with `--project <path>` (no scan, no prompt)
+- [ ] 5.4 Update `CHANGELOG.md` `[Unreleased]` with the new home-directory scan choice

--- a/openspec/changes/bizobs-1811-include-home-directory-in-scan/tasks.md
+++ b/openspec/changes/bizobs-1811-include-home-directory-in-scan/tasks.md
@@ -9,9 +9,9 @@
 
 ## 2. Root selection and prompt
 
-- [ ] 2.1 Add a helper (e.g. `selectScanRoots`) that computes `cwd = os.Getwd()` and `home = os.UserHomeDir()`, using cleaned, symlink-resolved absolute paths and segment-wise ancestor comparison
-- [ ] 2.2 Skip the prompt and return `[cwd]` when `cwd == home` or when `home` is a descendant of `cwd`
-- [ ] 2.3 Otherwise present the three-way `Y/c/n` prompt (default `Y`): `Y` → `[cwd, home]`, `c` → `[cwd]`, `n` → signal abort
+- [ ] 2.1 Add a helper (e.g. `selectScanRoots`) that computes `cwd = os.Getwd()` and `home = os.UserHomeDir()`, using cleaned, symlink-resolved absolute paths and segment-wise ancestor/descendant comparison
+- [ ] 2.2 Skip the prompt and return `[cwd]` in all same-lineage cases: `cwd == home`, `home` is a descendant of `cwd`, or `cwd` is a descendant of `home` (within the home tree). Only prompt when `cwd` and `home` are disjoint trees
+- [ ] 2.3 Otherwise (disjoint) present the three-way `Y/c/n` prompt (default `Y`): `Y` → `[cwd, home]`, `c` → `[cwd]`, `n` → signal abort
 - [ ] 2.4 In non-interactive contexts (`installer.AutoConfirm`, or stdin is not a TTY) skip the prompt and default to `[cwd, home]`
 - [ ] 2.5 Map the `n` outcome to `installer.ErrInstallCancelled` returned from the caller
 
@@ -24,13 +24,13 @@
 ## 4. Tests
 
 - [ ] 4.1 Update existing `TestScanProjectDirs_*` (`runtime_scan_test.go`) to pass explicit `roots`
-- [ ] 4.2 Add tests for the decision logic: prompt-vs-skip when `cwd == home`, when `home` is a descendant of `cwd`, and when it is not
-- [ ] 4.3 Add tests for the three outcomes (`Y`/`c`/`n`) and the non-interactive default (`AutoConfirm`/non-TTY → `[cwd, home]`)
-- [ ] 4.4 Add a test that scanning multiple roots dedups a project reachable from both `cwd` and `home` (common dev case)
+- [ ] 4.2 Add tests for the decision logic: skip (no prompt) when `cwd == home`, when `home` is a descendant of `cwd`, and when `cwd` is a descendant of `home`; prompt only when `cwd` and `home` are disjoint
+- [ ] 4.3 Add tests for the three outcomes (`Y`/`c`/`n`) and the non-interactive default (`AutoConfirm`/non-TTY, disjoint cwd → `[cwd, home]`)
+- [ ] 4.4 Add a test that scanning `[cwd, home]` dedups a project reachable via both the home root and the always-on `~/.dtwiz/examples/` root (or via a symlink), since the two primary roots are disjoint
 
 ## 5. Verify
 
 - [ ] 5.1 `make test` passes
 - [ ] 5.2 `make lint` shows no new issues
-- [ ] 5.3 Manual smoke: run `dtwiz install otel --dry-run` from `~/some/project` (CWD under home → prompt appears), from `$HOME` (CWD == home → no prompt), and with `--project <path>` (no scan, no prompt)
+- [ ] 5.3 Manual smoke: run `dtwiz install otel --dry-run` from a directory outside home like `/tmp/project` (disjoint → prompt appears), from `~/some/project` (within home → no prompt), from `$HOME` (CWD == home → no prompt), and with `--project <path>` (no scan, no prompt)
 - [ ] 5.4 Update `CHANGELOG.md` `[Unreleased]` with the new home-directory scan choice


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

This PR adds the OpenSpec artifacts for "asking the user to also scan home directory" feature. If `dtwiz` is run outside the user's own home directory, the user is asked if they want to include their home directory as well or stay just within the current working directory.

## How to test
- N/A

## Which other features are affected?
- This touches the `otel-project-scanner` capability

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
