### PR TITLE
fix(analyzer): false positive 'OneAgent: running' in Codespaces/devcontainers (systemctl shim exits 0)

### DIFF
--- a/pkg/analyzer/detect_oneagent.go
+++ b/pkg/analyzer/detect_oneagent.go
@@ -2,14 +2,28 @@
 
 package analyzer
 
+import "os"
+
+// systemdAvailable reports whether systemd is the running init system.
+// /run/systemd/system exists as a directory only when systemd is booted
+// (see sd_booted(3)). In containers such as GitHub Codespaces, systemctl
+// is a compatibility shim that exits 0 for any invocation, so its exit
+// code must not be trusted unless systemd is actually running.
+func systemdAvailable() bool {
+	fi, err := os.Stat("/run/systemd/system")
+	return err == nil && fi.IsDir()
+}
+
 // detectOneAgent checks for a running Dynatrace OneAgent on Unix systems.
 func detectOneAgent() bool {
 	// Check whether the oneagent service is active.
-	ok, _ := runCmd("systemctl", "is-active", "--quiet", "oneagent")
-	if ok {
-		return true
+	if systemdAvailable() {
+		ok, _ := runCmd("systemctl", "is-active", "--quiet", "oneagent")
+		if ok {
+			return true
+		}
 	}
 	// Check for oneagentctl in PATH.
-	ok, _ = runCmd("oneagentctl", "--version")
+	ok, _ := runCmd("oneagentctl", "--version")
 	return ok
 }


### PR DESCRIPTION
## Problem

`dtwiz status` reports `OneAgent: running` on hosts that have **no OneAgent installed**. Reproduced and verified in a GitHub Codespace — which is exactly the environment many dtwiz trainings run in, so learners see an agent that doesn't exist and go looking for it.

## Root cause

`detectOneAgent()` (pkg/analyzer/detect_oneagent.go) trusts the exit code of:

```
systemctl is-active --quiet oneagent
```

In GitHub Codespaces and most devcontainer images, `/usr/local/bin/systemctl` shadows the real systemctl with a compatibility shim that prints a warning and **exits 0 for any invocation** when systemd is not running:

```sh
#!/bin/sh
set -e
if [ -d "/run/systemd/system" ]; then
    exec /bin/systemctl "$@"
else
    # prints '"systemd" is not running in this container...' and exits 0
```

So check 1 always "succeeds" and every Codespace user gets a false `OneAgent: running`.

## Verified reproduction (GitHub Codespace, no OneAgent installed)

```bash
$ systemctl is-active --quiet oneagent; echo "exit=$?"

"systemd" is not running in this container due to its overhead.
Use the "service" command to start services instead. e.g.:

service --status-all
exit=0                                    # ← shim exits 0 for ANY invocation

$ command -v oneagentctl
# (nothing — not in PATH)

$ dtwiz status
...
OneAgent:          running                # ← false positive
```

## Fix

Only trust `systemctl` when systemd is actually the running init: `/run/systemd/system` exists as a directory (the `sd_booted(3)` convention). Notably this is the **same guard the shim itself uses** before delegating to the real systemctl — dtwiz just needs to apply it too.

- systemd hosts: behavior unchanged (systemctl check runs first, `oneagentctl` fallback intact)
- containers/Codespaces: systemctl check skipped, detection falls through to `oneagentctl --version`, which correctly reports absence

`go build ./...`, `go vet`, and `go test ./pkg/analyzer/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
