### PR TITLE
chore: extract environment related code to separate package

### DIFF
--- a/.e2e.env.example
+++ b/.e2e.env.example
@@ -2,5 +2,4 @@
 #   cp .e2e.env.example .e2e.env
 
 TEST_DT_ENVIRONMENT=https://<your-environment-id>.com
-TEST_DT_ACCESS_TOKEN=dt0c01.<your-access-token>
 TEST_DT_PLATFORM_TOKEN=dt0s16.<your-platform-token>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,6 @@
 - [ ] I have tested these changes locally.
 - [ ] I updated OpenSpec and other documentation where necessary.
 - [ ] I added or updated tests where appropriate.
+- [ ] I have run `make test-integration` locally.
+- [ ] I have updated the changelog if necessary.
 - [ ] I followed the existing code style and conventions.

--- a/pkg/installer/otel/environment/environment.go
+++ b/pkg/installer/otel/environment/environment.go
@@ -1,4 +1,4 @@
-package otel
+package environment
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 
 const otelExporterOTLPHeadersEnvVar = "OTEL_EXPORTER_OTLP_HEADERS"
 
-func generateBaseOtelEnvVars(collectorEndpoint, serviceName string) map[string]string {
+func GenerateBaseOtelEnvVars(collectorEndpoint, serviceName string) map[string]string {
 	return map[string]string{
 		"OTEL_SERVICE_NAME":                                 serviceName,
 		"OTEL_EXPORTER_OTLP_ENDPOINT":                       collectorEndpoint,
@@ -21,7 +21,7 @@ func generateBaseOtelEnvVars(collectorEndpoint, serviceName string) map[string]s
 	}
 }
 
-func projectServiceName(projectPath string) string {
+func ProjectServiceName(projectPath string) string {
 	baseName := filepath.Base(projectPath)
 	// filepath.Base("/") returns "/" on Unix and "\\" on Windows; treat either as root.
 	if baseName == "" || baseName == "." || strings.Trim(baseName, `/\`) == "" {
@@ -34,13 +34,13 @@ func projectServiceName(projectPath string) string {
 // separators, e.g. "ui/web" from a Maven nested module path) into a value that
 // is safe to use as an OTEL_SERVICE_NAME and as a filename fragment.
 // Forward-slash, back-slash, and colon characters are replaced with "-".
-func normalizeServiceName(name string) string {
+func NormalizeServiceName(name string) string {
 	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
 	return r.Replace(name)
 }
 
 func GenerateEnvExportScript(envVars map[string]string) string {
-	lines := formatEnvExportLines(envVars)
+	lines := FormatEnvExportLines(envVars)
 	if len(lines) == 0 {
 		return ""
 	}
@@ -48,7 +48,7 @@ func GenerateEnvExportScript(envVars map[string]string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func formatEnvExportLines(envVars map[string]string) []string {
+func FormatEnvExportLines(envVars map[string]string) []string {
 	keys := make([]string, 0, len(envVars))
 	for key := range envVars {
 		keys = append(keys, key)
@@ -63,7 +63,7 @@ func formatEnvExportLines(envVars map[string]string) []string {
 	return lines
 }
 
-func formatEnvVars(envVars map[string]string) []string {
+func FormatEnvVars(envVars map[string]string) []string {
 	keys := make([]string, 0, len(envVars))
 	for key := range envVars {
 		keys = append(keys, key)
@@ -77,7 +77,7 @@ func formatEnvVars(envVars map[string]string) []string {
 	return formatted
 }
 
-func formatPrintableEnvVars(envVars map[string]string) []string {
+func FormatPrintableEnvVars(envVars map[string]string) []string {
 	keys := make([]string, 0, len(envVars))
 	for key := range envVars {
 		keys = append(keys, key)

--- a/pkg/installer/otel/environment/environment_test.go
+++ b/pkg/installer/otel/environment/environment_test.go
@@ -1,4 +1,4 @@
-package otel
+package environment
 
 import (
 	"strings"
@@ -19,7 +19,7 @@ func TestProjectServiceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			got := projectServiceName(tt.path)
+			got := ProjectServiceName(tt.path)
 			if got != tt.want {
 				t.Errorf("projectServiceName(%q) = %q, want %q", tt.path, got, tt.want)
 			}
@@ -43,16 +43,16 @@ func TestNormalizeServiceName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalizeServiceName(tt.in)
+			got := NormalizeServiceName(tt.in)
 			if got != tt.want {
-				t.Errorf("normalizeServiceName(%q) = %q, want %q", tt.in, got, tt.want)
+				t.Errorf("NormalizeServiceName(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}
 }
 
 func TestGenerateBaseOtelEnvVars(t *testing.T) {
-	envVars := generateBaseOtelEnvVars("http://127.0.0.1:4318", "my-svc")
+	envVars := GenerateBaseOtelEnvVars("http://127.0.0.1:4318", "my-svc")
 
 	wantEndpoint := "http://127.0.0.1:4318"
 	if got := envVars["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != wantEndpoint {
@@ -83,7 +83,7 @@ func TestGenerateBaseOtelEnvVars(t *testing.T) {
 }
 
 func TestGenerateBaseOtelEnvVars_NonDefaultPort(t *testing.T) {
-	envVars := generateBaseOtelEnvVars("http://127.0.0.1:4320", "svc")
+	envVars := GenerateBaseOtelEnvVars("http://127.0.0.1:4320", "svc")
 	want := "http://127.0.0.1:4320"
 	if got := envVars["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != want {
 		t.Errorf("ENDPOINT = %q, want %q (non-default port should be preserved)", got, want)
@@ -95,7 +95,7 @@ func TestFormatEnvVars(t *testing.T) {
 		"FOO": "bar",
 		"BAZ": "qux",
 	}
-	got := formatEnvVars(m)
+	got := FormatEnvVars(m)
 	want := []string{"BAZ=qux", "FOO=bar"}
 	if len(got) != len(want) {
 		t.Fatalf("formatEnvVars length = %d, want %d", len(got), len(want))
@@ -108,7 +108,7 @@ func TestFormatEnvVars(t *testing.T) {
 }
 
 func TestFormatEnvVars_Empty(t *testing.T) {
-	got := formatEnvVars(map[string]string{})
+	got := FormatEnvVars(map[string]string{})
 	if len(got) != 0 {
 		t.Errorf("formatEnvVars(empty) = %v, want empty", got)
 	}
@@ -151,7 +151,7 @@ func TestFormatPrintableEnvVars(t *testing.T) {
 		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
 	}
 
-	got := formatPrintableEnvVars(envVars)
+	got := FormatPrintableEnvVars(envVars)
 	want := []string{
 		"OTEL_EXPORTER_OTLP_HEADERS=Authorization=Api-Token%20<redacted>",
 		"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",

--- a/pkg/installer/otel/golang.go
+++ b/pkg/installer/otel/golang.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -96,8 +97,8 @@ func DetectGoPlan(collectorEndpoint string) *GoInstrumentationPlan {
 		}
 	}
 
-	svcName := projectServiceName(sel.Path)
-	envVars := generateBaseOtelEnvVars(collectorEndpoint, svcName)
+	svcName := environment.ProjectServiceName(sel.Path)
+	envVars := environment.GenerateBaseOtelEnvVars(collectorEndpoint, svcName)
 
 	return &GoInstrumentationPlan{
 		Project: goProj,
@@ -127,7 +128,7 @@ func (p *GoInstrumentationPlan) Execute() error {
 	fmt.Println()
 	fmt.Println("  Set the following environment variables:")
 	fmt.Println()
-	for _, line := range formatEnvExportLines(p.EnvVars) {
+	for _, line := range environment.FormatEnvExportLines(p.EnvVars) {
 		fmt.Printf("    %s\n", line)
 	}
 	fmt.Println()

--- a/pkg/installer/otel/java.go
+++ b/pkg/installer/otel/java.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -132,13 +133,13 @@ func buildInstrumentedCmd(ep JavaEntrypoint, agentPath, projectPath string, envV
 			finalEnvVars[k] = v
 		}
 		finalEnvVars["JAVA_TOOL_OPTIONS"] = "-javaagent:" + agentPath
-		cmd.Env = append(os.Environ(), formatEnvVars(finalEnvVars)...)
+		cmd.Env = append(os.Environ(), environment.FormatEnvVars(finalEnvVars)...)
 		cmd.Dir = projectPath
 		return cmd
 	}
 
 	cmd.Dir = projectPath
-	cmd.Env = append(os.Environ(), formatEnvVars(envVars)...)
+	cmd.Env = append(os.Environ(), environment.FormatEnvVars(envVars)...)
 	return cmd
 }
 
@@ -202,7 +203,7 @@ func (p *JavaInstrumentationPlan) PrintPlanSteps() {
 		fmt.Printf("     Launch:     (entrypoint will be detected at execution time)\n")
 	}
 	fmt.Printf("     Agent JAR:  %s\n", otelJavaAgentURL)
-	for _, line := range formatPrintableEnvVars(p.EnvVars) {
+	for _, line := range environment.FormatPrintableEnvVars(p.EnvVars) {
 		fmt.Printf("     %s\n", line)
 	}
 }
@@ -211,8 +212,8 @@ func buildJavaInstrumentationPlan(proj detectedProject, collectorEndpoint, token
 	if mm := detectMultiModule(proj.Path); mm != nil {
 		return buildMultiModulePlan(mm, proj.ScannedProject, collectorEndpoint, token, envURL)
 	}
-	svcName := projectServiceName(proj.Path)
-	envVars := generateBaseOtelEnvVars(collectorEndpoint, svcName)
+	svcName := environment.ProjectServiceName(proj.Path)
+	envVars := environment.GenerateBaseOtelEnvVars(collectorEndpoint, svcName)
 	entrypoints := detectJavaEntrypoints(proj.Path)
 	var entrypointCmd string
 	if len(entrypoints) > 0 {
@@ -272,7 +273,7 @@ func (p *JavaInstrumentationPlan) Execute() error {
 		}
 	}
 
-	svcName := projectServiceName(p.Project.Path)
+	svcName := environment.ProjectServiceName(p.Project.Path)
 	displayCmd := displayInstrumentedCmd(*ep, agentPath)
 
 	logPath := filepath.Join(p.Project.Path, svcName+".log")
@@ -345,10 +346,10 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 	collectorEndpoint := fmt.Sprintf("http://127.0.0.1:%d", otlpHTTPPortFromConfig(findExistingCollectorConfig()))
 
 	if serviceName == "my-service" {
-		serviceName = projectServiceName(proj.Path)
+		serviceName = environment.ProjectServiceName(proj.Path)
 	}
 	logger.Debug("java instrumentation target", "project", proj.Path, "service", serviceName)
-	envVars = generateBaseOtelEnvVars(collectorEndpoint, serviceName)
+	envVars = environment.GenerateBaseOtelEnvVars(collectorEndpoint, serviceName)
 
 	if mm := detectMultiModule(proj.Path); mm != nil {
 		logger.Debug("multi-module project detected", "tool", mm.BuildTool)
@@ -431,7 +432,7 @@ func InstallOtelJava(envURL, token, serviceName, projectPath string, dryRun bool
 	fmt.Printf("  Agent JAR:  %s\n", otelJavaAgentURL)
 	fmt.Println()
 	fmt.Println("  Environment variables:")
-	for _, line := range formatPrintableEnvVars(envVars) {
+	for _, line := range environment.FormatPrintableEnvVars(envVars) {
 		fmt.Printf("    %s\n", line)
 	}
 	var pidStr string

--- a/pkg/installer/otel/java_multimodule.go
+++ b/pkg/installer/otel/java_multimodule.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -145,8 +146,8 @@ func buildMultiModulePlan(mm *MultiModuleProject, proj ScannedProject, collector
 
 	subs := make([]SubModulePlan, len(mm.Modules))
 	for i, mod := range mm.Modules {
-		svcName := normalizeServiceName(mod.Name)
-		envVars := generateBaseOtelEnvVars(collectorEndpoint, svcName)
+		svcName := environment.NormalizeServiceName(mod.Name)
+		envVars := environment.GenerateBaseOtelEnvVars(collectorEndpoint, svcName)
 
 		var launchCmd string
 		entrypoints := detectJavaEntrypoints(mod.Path)

--- a/pkg/installer/otel/nodejs.go
+++ b/pkg/installer/otel/nodejs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -41,7 +42,7 @@ func nodeServiceNameFromEntrypoint(projectPath, entrypoint string) string {
 
 // generateOtelNodeEnvVars extends base OTel env vars with Node.js-specific settings.
 func generateOtelNodeEnvVars(collectorEndpoint, serviceName string) map[string]string {
-	envVars := generateBaseOtelEnvVars(collectorEndpoint, serviceName)
+	envVars := environment.GenerateBaseOtelEnvVars(collectorEndpoint, serviceName)
 	envVars["OTEL_NODE_RESOURCE_DETECTORS"] = "all"
 	return envVars
 }
@@ -73,7 +74,7 @@ func buildNodeInstrumentationPlan(proj ScannedProject, collectorEndpoint string)
 		return nil
 	}
 
-	svcName := projectServiceName(proj.Path)
+	svcName := environment.ProjectServiceName(proj.Path)
 	envVars := generateOtelNodeEnvVars(collectorEndpoint, svcName)
 	pkgManager := detectNodePackageManager(proj.Path)
 	otelDir := filepath.Join(proj.Path, ".otel")
@@ -451,20 +452,20 @@ func (p *NodeInstrumentationPlan) Execute() error {
 
 	switch p.Framework {
 	case "next":
-		svcName := projectServiceName(proj.Path)
+		svcName := environment.ProjectServiceName(proj.Path)
 		epEnvVars := maps.Clone(p.EnvVars)
 		epEnvVars["OTEL_SERVICE_NAME"] = svcName
 
 		cmd := exec.Command("node", filepath.Join(".otel", "next-otel-bootstrap.js"), "start")
 		cmd.Dir = proj.Path
-		cmd.Env = append(os.Environ(), formatEnvVars(epEnvVars)...)
+		cmd.Env = append(os.Environ(), environment.FormatEnvVars(epEnvVars)...)
 
 		mp := launchEntrypoint(svcName, proj.Path, "next:start", cmd)
 		if mp != nil {
 			procs = append(procs, mp)
 		}
 	case "nuxt":
-		svcName := projectServiceName(proj.Path)
+		svcName := environment.ProjectServiceName(proj.Path)
 		epEnvVars := maps.Clone(p.EnvVars)
 		epEnvVars["OTEL_SERVICE_NAME"] = svcName
 
@@ -481,7 +482,7 @@ func (p *NodeInstrumentationPlan) Execute() error {
 		bootstrap := "./" + filepath.ToSlash(filepath.Join(".otel", "nuxt-otel-bootstrap.mjs"))
 		cmd := exec.Command("node", "--import", bootstrap, nitroEntry)
 		cmd.Dir = proj.Path
-		cmd.Env = append(os.Environ(), formatEnvVars(epEnvVars)...)
+		cmd.Env = append(os.Environ(), environment.FormatEnvVars(epEnvVars)...)
 
 		mp := launchEntrypoint(svcName, proj.Path, nitroEntry, cmd)
 		if mp != nil {
@@ -499,7 +500,7 @@ func (p *NodeInstrumentationPlan) Execute() error {
 			relEntrypoint := "../" + filepath.ToSlash(ep)
 			cmd := exec.Command("node", "--require", "@opentelemetry/auto-instrumentations-node/register", relEntrypoint)
 			cmd.Dir = p.OtelDir
-			cmd.Env = append(os.Environ(), formatEnvVars(epEnvVars)...)
+			cmd.Env = append(os.Environ(), environment.FormatEnvVars(epEnvVars)...)
 
 			mp := launchEntrypoint(svcName, proj.Path, ep, cmd)
 			if mp != nil {
@@ -568,7 +569,7 @@ func InstallOtelNode(envURL, token, platformToken, serviceName, projectPath stri
 		}
 		fmt.Println()
 		fmt.Println("  Environment variables:")
-		for _, line := range formatPrintableEnvVars(envVars) {
+		for _, line := range environment.FormatPrintableEnvVars(envVars) {
 			fmt.Printf("    %s\n", line)
 		}
 		return nil

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/featureflags"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -411,7 +412,7 @@ func selectProject(projects []detectedProject) (detectedProject, bool) {
 
 func createRuntimePlan(proj detectedProject, httpPort int, token, envURL, platformToken string) InstrumentationPlan {
 	collectorEndpoint := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
-	svcName := projectServiceName(proj.Path)
+	svcName := environment.ProjectServiceName(proj.Path)
 
 	switch proj.Runtime {
 	case "Python":
@@ -435,7 +436,7 @@ func createRuntimePlan(proj detectedProject, httpPort int, token, envURL, platfo
 		}
 		return &GoInstrumentationPlan{
 			Project: goProj,
-			EnvVars: generateBaseOtelEnvVars(collectorEndpoint, svcName),
+			EnvVars: environment.GenerateBaseOtelEnvVars(collectorEndpoint, svcName),
 		}
 	}
 	return nil

--- a/pkg/installer/otel/python.go
+++ b/pkg/installer/otel/python.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/dynatrace-oss/dtwiz/pkg/display"
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
 func generateOtelPythonEnvVars(collectorEndpoint, serviceName string) map[string]string {
-	envVars := generateBaseOtelEnvVars(collectorEndpoint, serviceName)
+	envVars := environment.GenerateBaseOtelEnvVars(collectorEndpoint, serviceName)
 	envVars["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"] = "true"
 	return envVars
 }
@@ -27,7 +28,7 @@ func printManualInstructions(envVars map[string]string) {
 	fmt.Printf("    pip install %s\n", strings.Join(otelPythonPackages, " "))
 	fmt.Println("    opentelemetry-bootstrap -a install")
 	fmt.Println()
-	fmt.Print(GenerateEnvExportScript(envVars))
+	fmt.Print(environment.GenerateEnvExportScript(envVars))
 	fmt.Println()
 	fmt.Println("  Then run your application with:")
 	fmt.Println("    opentelemetry-instrument python your_app.py")
@@ -56,7 +57,7 @@ func buildPythonInstrumentationPlan(proj ScannedProject, collectorEndpoint, envU
 	needsVenv := !isVenvHealthy(proj.Path)
 	logger.Debug("python project venv evaluation complete", "project", proj.Path, "needs_venv", needsVenv, "entrypoints", entrypoints)
 
-	svcName := projectServiceName(proj.Path)
+	svcName := environment.ProjectServiceName(proj.Path)
 	envVars := generateOtelPythonEnvVars(collectorEndpoint, svcName)
 
 	return &PythonInstrumentationPlan{
@@ -269,7 +270,7 @@ func (p *PythonInstrumentationPlan) Execute() error {
 			cmd = exec.Command(venvPython, otelInstrument, pythonBin, ep)
 		}
 		cmd.Dir = proj.Path
-		cmd.Env = append(os.Environ(), formatEnvVars(epEnvVars)...)
+		cmd.Env = append(os.Environ(), environment.FormatEnvVars(epEnvVars)...)
 
 		mp, err := StartManagedProcess(svcName, logName, ep, cmd, logFile)
 		if err != nil {
@@ -319,7 +320,7 @@ func InstallOtelPython(envURL, token, platformToken, serviceName, projectPath st
 		fmt.Println("    opentelemetry-bootstrap -a install")
 		fmt.Println()
 		fmt.Println("  Environment variables:")
-		for _, line := range formatPrintableEnvVars(envVars) {
+		for _, line := range environment.FormatPrintableEnvVars(envVars) {
 			fmt.Printf("    %s\n", line)
 		}
 		return nil

--- a/pkg/installer/otel/python_test.go
+++ b/pkg/installer/otel/python_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/dynatrace-oss/dtwiz/pkg/installer"
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/test/helpers"
 )
 
@@ -444,7 +445,7 @@ func TestGenerateOtelPythonEnvVars_NonDefaultPort(t *testing.T) {
 
 func TestGenerateEnvExportScript_AllKeysPresent(t *testing.T) {
 	vars := generateOtelPythonEnvVars("http://127.0.0.1:4318", "my-svc")
-	script := GenerateEnvExportScript(vars)
+	script := environment.GenerateEnvExportScript(vars)
 	for k := range vars {
 		if !strings.Contains(script, k) {
 			t.Fatalf("script missing key %q, got:\n%s", k, script)

--- a/pkg/installer/otel/uninstall_node.go
+++ b/pkg/installer/otel/uninstall_node.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dynatrace-oss/dtwiz/pkg/installer/otel/environment"
 	"github.com/dynatrace-oss/dtwiz/pkg/logger"
 )
 
@@ -138,5 +139,5 @@ func nodeServiceNameFromCommand(projectDir, command string) string {
 		}
 	}
 	// Framework (next/nuxt) or unrecognized pattern — use project name.
-	return projectServiceName(projectDir)
+	return environment.ProjectServiceName(projectDir)
 }

--- a/test/e2e/otel_test.go
+++ b/test/e2e/otel_test.go
@@ -32,6 +32,26 @@ type otelCase struct {
 func TestOTelAutoInstrumentation(t *testing.T) {
 	integration.Parallelize(t)
 
+	env := integration.SetupIntegration(t)
+
+	// The language-specific installers now route telemetry through a local OTel
+	// Collector (http://127.0.0.1:4318). Install it once here so all parallel
+	// language subtests share the same running collector.
+	origAC := installer.AutoConfirm
+	installer.AutoConfirm = true
+	t.Cleanup(func() { installer.AutoConfirm = origAC })
+
+	t.Log("installing OTel Collector for auto-instrumentation tests")
+	if err := otel.InstallOtelCollectorOnly(env.EnvURL, env.ClassicToken, env.PlatformToken, false); err != nil {
+		t.Fatalf("InstallOtelCollectorOnly: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Log("uninstalling OTel Collector")
+		if err := otel.UninstallOtelCollector(env.EnvURL, env.PlatformToken, false); err != nil {
+			t.Logf("warning: UninstallOtelCollector: %v", err)
+		}
+	})
+
 	cases := []otelCase{
 		{
 			lang:    "python",


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe):

* Extracts environment related code in `otel` package to separate package for better maintainability
* Install OTel collector in integration tests
* Updates the pull-request template to remind contributors to run `make test-integration`

## How to test
1. Run `make test-integration` locally

## Which other features are affected?
1. This touches the OTel installation flow, but is purely a mechanical move, without logic changes.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
