### PR TITLE
feat: clarify unsupported runtime message for Node.js 

### DIFF
--- a/pkg/installer/otel/nodejs.go
+++ b/pkg/installer/otel/nodejs.go
@@ -68,7 +68,7 @@ func buildNodeInstrumentationPlan(proj ScannedProject, apiURL, token string) *No
 			"https://docs.dynatrace.com/docs/ingest-from/opentelemetry/walkthroughs/nodejs",
 		)
 		fmt.Println()
-		fmt.Println("  This project can't be auto-instrumented.")
+		fmt.Println("  This project can't be auto-instrumented because of an unsupported runtime. Only Node.js/Next.js/Nuxt are supported at the moment.")
 		fmt.Printf("  See %s to instrument it manually.\n", docLink)
 		return nil
 	}


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. run `dtwiz install otel`
2. select a "pure" React project to instrument
3. make sure "This project can't be auto-instrumented because of an unsupported runtime. Only Node.js/Next.js/Nuxt are supported at the moment." is present

## Which other features are affected?
1. none

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
