### PR TITLE
feat: add OneAgent silent install on Windows

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -403,7 +403,7 @@ func init() {
 	installOtelJavaCmd.Flags().StringVar(&otelProject, "project", "", "path to the Java project to instrument (skips interactive scan)")
 	installOtelJavaCmd.Flags().StringVar(&otelJavaServiceName, "service-name", "", "OTEL_SERVICE_NAME for the instrumented application (default: my-service)")
 
-	installOneAgentCmd.Flags().Bool("quiet", false, "Run a silent/unattended installation with no output")
+	installOneAgentCmd.Flags().Bool("quiet", false, "Suppress prompts and output; requires an elevated terminal on Windows")
 	installOneAgentCmd.Flags().String("host-group", "", "Assign the host to a host group (--set-host-group)")
 	installOneAgentCmd.Flags().StringVar(&flagMonitoringMode, "monitoring-mode", string(oneagent.InstallModeFullStack), "OneAgent monitoring mode to pass to the installer")
 	installOneAgentCmd.Flags().BoolVar(&flagNoVerifySignature, "no-verify-signature", false, "Skip installer signature verification (Linux only)")

--- a/pkg/installer/oneagent/install_agent.go
+++ b/pkg/installer/oneagent/install_agent.go
@@ -45,10 +45,7 @@ func BuildInstallCommand(env Environment, cfg AgentConfig, opts InstallOptions, 
 			argv = append([]string{sudoPath}, argv...)
 		}
 	case "windows":
-		argv = []string{installerPath}
-		if opts.Quiet {
-			argv = append(argv, "--quiet")
-		}
+		argv = []string{installerPath, "--quiet"}
 		argv = append(argv,
 			fmt.Sprintf("--set-monitoring-mode=%s", cfg.MonitoringMode),
 			fmt.Sprintf("--set-app-log-content-access=%t", cfg.AppLogContentAccess),

--- a/pkg/installer/oneagent/install_agent_test.go
+++ b/pkg/installer/oneagent/install_agent_test.go
@@ -110,17 +110,13 @@ func TestBuildInstallCommand_Windows_Basic(t *testing.T) {
 	if argv[0] != `C:\agent.exe` {
 		t.Errorf("argv[0] = %q, want installer path", argv[0])
 	}
+	assertContains(t, argv, "--quiet")
 	assertContains(t, argv, "--set-monitoring-mode=fullstack")
 	assertContains(t, argv, "--set-app-log-content-access=true")
-	for _, a := range argv {
-		if a == "--quiet" {
-			t.Error("--quiet should not be present when opts.Quiet is false")
-		}
-	}
 }
 
 func TestBuildInstallCommand_Windows_Quiet_OrderFirst(t *testing.T) {
-	argv, err := BuildInstallCommand(Environment{OS: "windows", Arch: "x86"}, testLinuxCfg("https://env.live.dynatrace.com"), InstallOptions{Quiet: true}, `C:\agent.exe`)
+	argv, err := BuildInstallCommand(Environment{OS: "windows", Arch: "x86"}, testLinuxCfg("https://env.live.dynatrace.com"), InstallOptions{}, `C:\agent.exe`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/installer/oneagent/preflight.go
+++ b/pkg/installer/oneagent/preflight.go
@@ -43,7 +43,7 @@ func runPreflightChecks(env Environment, opts InstallOptions) (preflightResult, 
 	}
 
 	if env.OS == "windows" && !opts.DryRun && !opts.ConnectivityCheckOnly && !isElevatedFn() && opts.Quiet {
-		return preflightResult{}, fmt.Errorf("installer requires Administrator privileges: run from an elevated terminal or omit --quiet to allow UAC prompt")
+		return preflightResult{}, fmt.Errorf("installer requires Administrator privileges: run dtwiz from an elevated terminal")
 	}
 
 	return result, nil


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. run `dtwiz install oneagent` on windows
2. make sure OneAgent installed silently, no windows installer is present

## Which other features are affected?
1. none

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
