### PR TITLE
feat: associate host monitoring logs with host in Dynatrace

### DIFF
--- a/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/design.md
+++ b/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/design.md
@@ -1,0 +1,67 @@
+# Design: Consolidate Host Monitoring Logs Pipeline
+
+## Context
+
+`pkg/installer/otel/otel.tmpl` is a Go text template that renders the OTel Collector config. The `otelConfigData` struct (in `pkg/installer/otel/collector.go`) drives the template. Two relevant fields:
+
+- `HostMonitoring bool` — true when `featureflags.Experimental` is enabled
+- `IncludeJournald bool` — true on Linux when `HostMonitoring` is true
+
+The current template service block for logs:
+
+```yaml
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp_http]
+{{- if and .HostMonitoring .IncludeJournald }}
+    logs/host:
+      receivers: [otlp, journald]
+      processors: [resource_detection]
+      exporters: [otlp_http]
+{{- end }}
+```
+
+`resource_detection` is already defined as a processor in the template (under `processors:`) when `HostMonitoring` is true — it is used by `metrics/host`. No new processor definition is needed; only the pipeline reference changes.
+
+## Decision: Single `logs` pipeline, conditional receivers and processors
+
+Replace both pipelines with one:
+
+```yaml
+    logs:
+      receivers: [otlp{{- if and .HostMonitoring .IncludeJournald }}, journald{{- end }}]
+      processors: [{{- if .HostMonitoring }}resource_detection{{- end }}]
+      exporters: [otlp_http]
+```
+
+This is the minimal change that fixes both problems:
+
+- `resource_detection` is applied when `HostMonitoring` is true regardless of platform, so OTLP logs get host attributes on all platforms
+- `journald` is added as a receiver on Linux only, exactly as before, eliminating the separate pipeline and the double-export of OTLP logs
+- App-only mode (`HostMonitoring = false`) renders `processors: []` — unchanged from today
+
+### Why not keep `logs/host` and fix `logs` separately?
+
+Fixing the `logs` pipeline to add `resource_detection` while keeping `logs/host` would still double-export OTLP logs on Linux (both pipelines receive from `otlp`). Removing `otlp` from `logs/host` receivers would fix the duplication but leave a pipeline named `logs/host` that only collects journald — misleading and unnecessarily complex. The single-pipeline design is simpler, matches the reference config, and has no duplication.
+
+### Journald guard remains unchanged
+
+The `IncludeJournald` field continues to gate both the `journald` receiver definition and any pipeline reference to it. The field is set in `prepareCollectorPlan` in `collector.go` based on `runtime.GOOS == "linux"` and `HostMonitoring`. No changes to that logic are needed.
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `pkg/installer/otel/otel.tmpl` | Replace `logs` + `logs/host` blocks with single conditional `logs` pipeline |
+| `pkg/installer/otel/collector_test.go` | Update assertions from `logs/host` to check `logs` pipeline processors and receivers |
+
+## Test Changes
+
+Three test functions reference `logs/host`:
+
+- `TestGenerateOtelConfig_AppOnly_Default` — remove the now-dead `logs/host` absence check
+- `TestGenerateOtelConfig_Combined_ExperimentalEnabled` — replace `logs/host` existence check with assertions that `logs` has `resource_detection` in processors and `journald` in receivers (Linux) or not (non-Linux)
+- `TestGenerateOtelConfig_JournaldConsistency` — update to check journald reference in `logs` pipeline instead of `logs/host`
+
+No new test functions are needed; the existing ones cover the behavior after adjustment.

--- a/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/proposal.md
+++ b/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: Consolidate Host Monitoring Logs Pipeline
+
+## Why
+
+When host monitoring is enabled, `otel.tmpl` generates two separate log pipelines:
+
+- `logs` — receives from `otlp` only, no processors — application logs reach Dynatrace but carry no host resource attributes
+- `logs/host` — receives from `otlp` + `journald` (Linux only), applies `resource_detection` — journald logs are correlated with the host
+
+This split has two problems:
+
+1. **OTLP logs are not correlated with the host.** Because the `logs` pipeline has no `resource_detection` processor, logs arriving over OTLP (from instrumented apps running on the host) have no `host.name`, `host.id`, or other host attributes. Dynatrace cannot associate them with the host entity, so they are invisible in the host's log view.
+
+2. **OTLP logs are double-exported on Linux.** When `IncludeJournald` is true, `otlp` appears as a receiver in both `logs` and `logs/host`. OTel fans a single receiver out to all pipelines that reference it, so every OTLP log record is exported twice to Dynatrace.
+
+The intended behavior — consistent with the reference Dynatrace host-monitoring config — is a single `logs` pipeline that applies `resource_detection` for all logs, with `journald` added as a source on Linux.
+
+## What Changes
+
+- The separate `logs/host` pipeline is removed from the template
+- The `logs` pipeline conditionally applies `resource_detection` when host monitoring is enabled, ensuring all logs (OTLP and journald) are correlated with the host in Dynatrace
+- On Linux (`IncludeJournald = true`), `journald` is added as a receiver in the `logs` pipeline alongside `otlp`
+- On macOS and Windows, the `logs` pipeline receives only from `otlp` (journald is still omitted — this is unchanged)
+- Tests are updated to assert the new pipeline shape instead of `logs/host`
+
+## Unchanged
+
+- The `journald` receiver definition itself — still gated behind `IncludeJournald`, still Linux-only
+- All host metrics pipelines (`metrics/host`, `metrics/apps`)
+- App-only mode (experimental flag off) — no `resource_detection` added, behavior identical to today
+- The `IncludeJournald` field in `otelConfigData` — the guard remains; only the pipeline that references it changes

--- a/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-08-20-consolidate-host-monitoring-logs-pipeline/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Consolidate Host Monitoring Logs Pipeline
+
+## 1. Update `otel.tmpl`
+
+- [x] In `pkg/installer/otel/otel.tmpl`, replace the `logs` + `logs/host` service pipeline block with a single `logs` pipeline:
+  - `receivers`: `[otlp]` by default; append `, journald` when `{{- if and .HostMonitoring .IncludeJournald }}`
+  - `processors`: empty (`[]`) by default; set to `[resource_detection]` when `{{- if .HostMonitoring }}`
+  - `exporters`: `[otlp_http]` (unchanged)
+- [x] Remove the `{{- if and .HostMonitoring .IncludeJournald }} logs/host: ... {{- end }}` block entirely
+
+## 2. Update tests in `collector_test.go`
+
+- [x] `TestGenerateOtelConfig_AppOnly_Default` — remove the stale check `if _, ok := parsed.Service.Pipelines["logs/host"]; ok { t.Error(...) }`
+- [x] `TestGenerateOtelConfig_Combined_ExperimentalEnabled` — replace the `logs/host` existence assertions with:
+  - Assert `logs` pipeline exists
+  - Assert `resource_detection` is present in `logs` pipeline processors
+  - On `runtime.GOOS == "linux"`: assert `journald` is in `logs` pipeline receivers
+  - On other platforms: assert `journald` is NOT in `logs` pipeline receivers
+- [x] `TestGenerateOtelConfig_JournaldConsistency` — update to check the `logs` pipeline (not `logs/host`) for the journald receiver reference
+
+## 3. Update the spec
+
+- [x] In `openspec/specs/otel-host-monitoring/spec.md`, update the "Platform-aware host signal selection" requirement and its scenarios to describe the consolidated `logs` pipeline behavior:
+  - Replace the `logs/host` pipeline description with: `logs` pipeline applies `resource_detection` on all platforms when host monitoring is enabled; `journald` added as receiver on Linux only
+  - Update the Linux scenario: `logs` pipeline includes `journald` receiver and `resource_detection` processor
+  - Update the macOS/Windows scenario: `logs` pipeline has no `journald` receiver but still applies `resource_detection`
+
+## 4. Verification
+
+- [x] `make test` — all tests pass
+- [x] `make lint` — no new issues

--- a/openspec/specs/otel-host-monitoring/spec.md
+++ b/openspec/specs/otel-host-monitoring/spec.md
@@ -31,21 +31,21 @@ Define how `dtwiz install otel` configures host monitoring via the Dynatrace Ope
 
 ### Requirement: Platform-aware host signal selection
 
-The generated configuration SHALL include host metrics on all supported platforms. A `logs/host` pipeline collecting journald logs through the `resource_detection` processor SHALL be included on Linux only; on macOS and Windows no host log pipeline is added. Application logs reach Dynatrace on all platforms through the existing `logs` pipeline fed by the `otlp` receiver.
+The generated configuration SHALL include host metrics on all supported platforms. The `logs` pipeline SHALL apply `resource_detection` on all platforms when host monitoring is enabled, so all logs are correlated with the host in Dynatrace. On Linux, the `journald` receiver SHALL additionally be included in the `logs` pipeline to collect system journal logs; on macOS and Windows, `journald` is omitted.
 
 #### Scenario: Linux collects metrics and journald logs
 
 - **GIVEN** the target platform is Linux
 - **WHEN** the configuration is generated
-- **THEN** it SHALL include the `journald` receiver and a `logs/host` pipeline forwarding journald logs to Dynatrace through the `resource_detection` processor
-- **AND** the `logs` pipeline fed by the `otlp` receiver SHALL remain present for application logs
+- **THEN** it SHALL include the `journald` receiver in the `logs` pipeline alongside `otlp`
+- **AND** the `logs` pipeline SHALL apply `resource_detection` so all logs are associated with the host
 
-#### Scenario: macOS and Windows collect metrics only, no host logs pipeline
+#### Scenario: macOS and Windows collect metrics only, no journald
 
 - **GIVEN** the target platform is macOS or Windows
 - **WHEN** the configuration is generated
-- **THEN** it SHALL NOT include the `journald` receiver or a `logs/host` pipeline
-- **AND** the `logs` pipeline fed by the `otlp` receiver SHALL remain present for application logs
+- **THEN** it SHALL NOT include the `journald` receiver
+- **AND** the `logs` pipeline SHALL still apply `resource_detection` so application logs are associated with the host
 
 ### Requirement: Preview and confirmation before applying
 

--- a/pkg/installer/otel/collector_test.go
+++ b/pkg/installer/otel/collector_test.go
@@ -193,9 +193,6 @@ func TestGenerateOtelConfig_AppOnly_Default(t *testing.T) {
 	if _, ok := parsed.Service.Pipelines["metrics/host"]; ok {
 		t.Error("app-only config must not contain metrics/host pipeline")
 	}
-	if _, ok := parsed.Service.Pipelines["logs/host"]; ok {
-		t.Error("app-only config must not contain logs/host pipeline")
-	}
 	if _, ok := parsed.Service.Pipelines["metrics"]; !ok {
 		t.Error("app-only config must contain metrics pipeline")
 	}
@@ -236,13 +233,34 @@ func TestGenerateOtelConfig_Combined_ExperimentalEnabled(t *testing.T) {
 		}
 	}
 
+	logsPipeline, logsOk := parsed.Service.Pipelines["logs"]
+	if !logsOk {
+		t.Fatal("combined config missing logs pipeline")
+	}
+	hasResourceDetection := false
+	for _, p := range logsPipeline.Processors {
+		if p == "resource_detection" {
+			hasResourceDetection = true
+			break
+		}
+	}
+	if !hasResourceDetection {
+		t.Errorf("combined config logs pipeline missing resource_detection processor, got %v", logsPipeline.Processors)
+	}
+	hasJournald := false
+	for _, r := range logsPipeline.Receivers {
+		if r == "journald" {
+			hasJournald = true
+			break
+		}
+	}
 	if runtime.GOOS == "linux" {
-		if _, ok := parsed.Service.Pipelines["logs/host"]; !ok {
-			t.Error("combined config missing logs/host pipeline on Linux")
+		if !hasJournald {
+			t.Error("combined config logs pipeline missing journald receiver on Linux")
 		}
 	} else {
-		if _, ok := parsed.Service.Pipelines["logs/host"]; ok {
-			t.Error("combined config must not contain logs/host pipeline on non-Linux (no journald)")
+		if hasJournald {
+			t.Error("combined config logs pipeline must not contain journald receiver on non-Linux")
 		}
 	}
 
@@ -284,10 +302,10 @@ func TestGenerateOtelConfig_JournaldConsistency(t *testing.T) {
 	parsed := parseOtelConfig(t, cfg)
 
 	_, receiverDefined := parsed.Receivers["journald"]
-	logsHost, logsHostExists := parsed.Service.Pipelines["logs/host"]
+	logsPipeline, logsExists := parsed.Service.Pipelines["logs"]
 	var pipelineReferences bool
-	if logsHostExists {
-		for _, r := range logsHost.Receivers {
+	if logsExists {
+		for _, r := range logsPipeline.Receivers {
 			if r == "journald" {
 				pipelineReferences = true
 				break
@@ -296,7 +314,7 @@ func TestGenerateOtelConfig_JournaldConsistency(t *testing.T) {
 	}
 
 	if receiverDefined != pipelineReferences {
-		t.Errorf("journald receiver defined=%v but pipeline reference=%v — guards must stay in sync",
+		t.Errorf("journald receiver defined=%v but logs pipeline reference=%v — guards must stay in sync",
 			receiverDefined, pipelineReferences)
 	}
 }

--- a/pkg/installer/otel/otel.tmpl
+++ b/pkg/installer/otel/otel.tmpl
@@ -281,15 +281,9 @@ service:
       exporters: [otlp_http]
 {{- end }}
     logs:
-      receivers: [otlp]
-      processors: []
+      receivers: [otlp{{- if and .HostMonitoring .IncludeJournald }}, journald{{- end }}]
+      processors: [{{- if .HostMonitoring }}resource_detection{{- end }}]
       exporters: [otlp_http]
-{{- if and .HostMonitoring .IncludeJournald }}
-    logs/host:
-      receivers: [journald]
-      processors: [resource_detection]
-      exporters: [otlp_http]
-{{- end }}
 
 exporters:
   otlp_http:


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

<!-- What does this PR add? Why is it relevant? -->

## How to test
1. run `dtwiz install otel --experimental`
2. select an app to instrument
3. make sure logs are visible on the host in InfraOps app

## Which other features are affected?
1.

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
