### PR TITLE
fix: add 'resoure_detection' to processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-08-24
+
+### Fixed
+
+- `install otel` (experimental): traces pipeline now includes the `resource_detection` processor when host monitoring is enabled, so spans carry the host resource attributes needed for Dynatrace to associate them with the monitored host
+
 ## [1.5.0] - 2026-08-24
 
 ### Changed
@@ -504,7 +510,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bootstrap install scripts (`scripts/install.sh`, `scripts/install.ps1`)
 - Embedded Go templates for Dynakube CR, OTel Collector config, and AWS config
 
-[Unreleased]: https://github.com/dynatrace-oss/dtwiz/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/dynatrace-oss/dtwiz/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/dynatrace-oss/dtwiz/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/dynatrace-oss/dtwiz/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/dynatrace-oss/dtwiz/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/dynatrace-oss/dtwiz/compare/v1.2.0...v1.3.0

--- a/pkg/installer/otel/collector_test.go
+++ b/pkg/installer/otel/collector_test.go
@@ -196,6 +196,16 @@ func TestGenerateOtelConfig_AppOnly_Default(t *testing.T) {
 	if _, ok := parsed.Service.Pipelines["metrics"]; !ok {
 		t.Error("app-only config must contain metrics pipeline")
 	}
+	tracesPipeline, tracesOk := parsed.Service.Pipelines["traces"]
+	if !tracesOk {
+		t.Fatal("app-only config missing traces pipeline")
+	}
+	for _, p := range tracesPipeline.Processors {
+		if p == "resource_detection" {
+			t.Errorf("app-only config traces pipeline must not contain resource_detection processor, got %v", tracesPipeline.Processors)
+			break
+		}
+	}
 }
 
 func TestGenerateOtelConfig_Combined_ExperimentalEnabled(t *testing.T) {
@@ -267,8 +277,19 @@ func TestGenerateOtelConfig_Combined_ExperimentalEnabled(t *testing.T) {
 	if _, ok := parsed.Service.Pipelines["metrics/apps"]; !ok {
 		t.Error("combined config missing metrics/apps pipeline")
 	}
-	if _, ok := parsed.Service.Pipelines["traces"]; !ok {
-		t.Error("combined config missing traces pipeline")
+	tracesPipeline, tracesOk := parsed.Service.Pipelines["traces"]
+	if !tracesOk {
+		t.Fatal("combined config missing traces pipeline")
+	}
+	hasResourceDetectionInTraces := false
+	for _, p := range tracesPipeline.Processors {
+		if p == "resource_detection" {
+			hasResourceDetectionInTraces = true
+			break
+		}
+	}
+	if !hasResourceDetectionInTraces {
+		t.Errorf("combined config traces pipeline missing resource_detection processor, got %v", tracesPipeline.Processors)
 	}
 	if _, ok := parsed.Service.Pipelines["logs"]; !ok {
 		t.Error("combined config missing logs pipeline")

--- a/pkg/installer/otel/otel.tmpl
+++ b/pkg/installer/otel/otel.tmpl
@@ -263,12 +263,12 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: []
+      processors: [{{- if .HostMonitoring }}resource_detection{{- end }}]
       exporters: [otlp_http]
 {{- if .HostMonitoring }}
     metrics/apps:
       receivers: [otlp]
-      processors: [cumulative_to_delta]
+      processors: [resource_detection, cumulative_to_delta]
       exporters: [otlp_http]
     metrics/host:
       receivers: [hostmetrics/10s, hostmetrics/5m, hostmetrics/1h]


### PR DESCRIPTION
## Description

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

Fixes the association between OTEL Hosts and logs, metrics and spans.


## How to test
1. Run `dtwiz install otel --experimental`
2. Instrument any application, I used the schnitzel demo
3. Create some traffic on the app
4. In the Settings of the tenant, check under "Process and contextualize", "OpenPipeline" and then either "Spans", "Logs" or "Metrics" that the dynamic route receives data

## Which other features are affected?
1. None, this is purely OTel collector configuraion

## Checklist
- [x] Make sure Copilot has reviewed the PR as a preliminary check.
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.
