### PR TITLE
feat: clarify system analysis and recommendation wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `setup`, `analyze`, `status`: system analysis now labels the platform line `This host:` instead of `Platform:`, removing the collision with `Platform Token:` in `status` output
+- `setup`, `analyze`, `status`: the OneAgent line now appears directly below OpenTelemetry, so both monitoring-status lines sit together near the top of the analysis instead of being separated by the container and cloud lines
+- `setup`, `analyze`, `status`: the `Services:` line is now labelled `Runtimes:`, matching what it actually detects — runtimes installed on PATH, not running services
+- `setup`, `recommend`: the recommendation list is now introduced by `Monitor Logs, Metrics, Traces of:`, stating once what every option ingests
+- `setup`, `recommend`: recommendation titles now read `This host and its services (via …)`, distinguishing the existing-collector, new-collector, and OneAgent options that previously all opened with `This machine's services`
+
 ## [1.5.1] - 2026-08-24
 
 ### Fixed

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -61,6 +61,8 @@ var setupCmd = &cobra.Command{
 
 		fmt.Println()
 		display.Header("Recommendations — What do you want to monitor?")
+		fmt.Println("  Monitor Logs, Metrics, Traces of:")
+		fmt.Println()
 		recs := recommender.GenerateRecommendations(info)
 
 		// Collect actionable (non-done, non-not-supported, non-coming-soon) recommendations.

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/.openspec.yaml
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-27

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/design.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/design.md
@@ -1,3 +1,5 @@
+# Design: clarify-analysis-and-recommendation-wording
+
 ## Context
 
 `dtwiz setup` prints two blocks back to back: the System Analysis produced by `analyzer.SystemInfo.Summary()`, then the recommendation list. Together they are the only information a first-time user has when choosing an ingestion method, and the moderated testing round showed both blocks failing at that job.

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/design.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`dtwiz setup` prints two blocks back to back: the System Analysis produced by `analyzer.SystemInfo.Summary()`, then the recommendation list. Together they are the only information a first-time user has when choosing an ingestion method, and the moderated testing round showed both blocks failing at that job.
+
+Constraints shaping this design:
+
+- **80 columns.** The menu must stay readable in a default terminal. Any per-entry text describing which signals are ingested pushes the longest entry past 80 and wraps only that line, which reads as a rendering defect.
+- **Two renderers, already drifted.** `setup` renders the list inline while `recommend` uses `recommender.FormatRecommendations`. They differ in divider width (50 vs 42), badge style (`[1]` vs ` 1 `), trailer options, and feature-flag filtering. Any wording added has to be added in both places.
+- **`Title` is a public field.** It is serialized by `recommend --json`, so retitling is visible to anything parsing that output.
+- **Display-only.** The findings are about comprehension, not behavior. Nothing here should alter detection, ranking, or dispatch.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make monitoring scope the visible difference between the recommendation entries, so the choice can be made from the menu alone.
+- State once, and accurately, which signals every option ingests.
+- Remove the two labels in the System Analysis block that name something other than what they carry.
+- Place the two lines that determine the menu contents where they are read before the menu.
+
+**Non-Goals:**
+
+- Unifying the `setup` and `recommend` renderers.
+- Fixing `recommend` ignoring the `Experimental` filter, which makes it advertise an entry `setup` will not offer.
+- Removing the unused `Priority`, `ComingSoon`, and `MethodNotSupported` fields, or the unreachable render branches that read them.
+- Changing which recommendations are produced, their order, or their gating.
+- Surfacing OneAgent's host-wide instrumentation scope at install time — that is the other half of the same finding and belongs with the installer's preview.
+
+## Decisions
+
+**Hoist the signal list into a lead-in rather than per entry.**
+A single `Monitor Logs, Metrics, Traces of:` above the list names the signals once and turns each entry into a grammatical object completing it. Per-entry alternatives were tried first and all failed the 80-column constraint: naming signals inside a title costs roughly 40 characters, which pushes the longest entry to 117. A two-line-per-entry layout fits but triples the list's height and repeats a clause identical across every entry. The lead-in costs one line total and is the only option that scales as recommendations are added.
+
+**Differentiate on scope, keeping a shared noun phrase.**
+Every entry keeps `This host and its services` and varies only in the parenthetical. Making the entries fully distinct was considered and rejected: all three genuinely monitor the same host, and only trace instrumentation differs, so wording that implies different footprints would be inaccurate. Naming the mechanism in the parenthetical — existing collector, new collector, OneAgent — is the honest distinction and reads as one decision along one axis.
+
+**`This host` over `This machine`.**
+Dynatrace's own entity vocabulary is Host, and dtwiz already says host in `install oneagent`'s help text and the `--host-group` flag. Choosing "machine" would open a vocabulary seam at the handoff into the Dynatrace UI, which is exactly where the tested users lost the thread. "Host" risks reading as *a server somewhere* to a laptop developer; the System Analysis block resolves that by printing the actual hostname on the `This host:` line directly above.
+
+**`Runtimes` over `Services`.**
+`detectServices()` resolves runtime binaries with `which` and probes a few daemons with `pgrep`. "Services" overstates that — it implies running workloads, and it collides with "services" in the recommendation titles directly below, where the word means something else. The line keeps its position at the bottom of the block: it is the only line in the analysis that no recommendation reads, so it is the least decision-relevant and belongs last.
+
+**Move OneAgent up rather than reordering the whole block.**
+OneAgent and OpenTelemetry are the only lines answering "is this host already monitored?", and the only two whose state changes the menu below — `OneAgentRunning` suppresses the OneAgent entry, `OtelCollector` adds the existing-collector entry. Grouping them under `This host:` puts the causes adjacent and directly above their effect. OpenTelemetry is already in position 2 and the runtimes line is already last, so this reduces to moving one block up five positions — a smaller diff than a full reshuffle, and it leaves the container and cloud lines in their established order.
+
+## Risks / Trade-offs
+
+**The retitled `Title` values appear in `recommend --json`.** → Anything parsing that output for exact title strings breaks. Mitigated by treating `Method` as the stable identifier — it is unchanged, and it is what `setup` already dispatches on. Called out under Changed in the changelog.
+
+**Three entries still share the same six opening words.** → Under `--experimental` with a collector running, the difference is one word inside the parentheses. Accepted: they describe genuinely similar scopes, and the parentheticals now carry a real distinction rather than restating the noun phrase. The larger clarity gap for this finding is at install time, where OneAgent's host-wide scope is still not previewed at all.
+
+**The lead-in is duplicated across two renderers.** → It must be edited in both `cmd/setup.go` and `FormatRecommendations` or they drift again. Accepted deliberately: unifying the renderers is a refactor with a behavior fix attached and does not belong in a wording change.
+
+**`recommend` advertises an entry `setup` will not offer.** → Pre-existing and untouched here; the new lead-in makes the list look more authoritative without making it more consistent. Tracked as follow-up.

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/proposal.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/proposal.md
@@ -1,3 +1,5 @@
+# Proposal: clarify-analysis-and-recommendation-wording
+
 ## Why
 
 Moderated user testing of the Dynatrace QuickStart flow (three participants, 24.08.2026) produced a most-severe finding: a participant chose OneAgent over OpenTelemetry, had his entire laptop instrumented instead of his project, and afterwards stated he "had no basis to choose between OneAgent and OpenTelemetry" — he picked on name recognition alone.

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/proposal.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Moderated user testing of the Dynatrace QuickStart flow (three participants, 24.08.2026) produced a most-severe finding: a participant chose OneAgent over OpenTelemetry, had his entire laptop instrumented instead of his project, and afterwards stated he "had no basis to choose between OneAgent and OpenTelemetry" — he picked on name recognition alone.
+
+The recommendation menu is the screen where that choice is made, and it gives the user nothing to choose on. Two of its entries open with the identical phrase "This machine's services", and neither states what data will actually be ingested. The System Analysis block printed immediately above shares the problem: it labels the host line "Platform:", which in `dtwiz status` sits eight lines from "Platform Token:" meaning something unrelated, and it labels detected runtimes "Services:" when what it detects is binaries on `PATH`.
+
+## What Changes
+
+System Analysis block (`analyze`, `setup`, `status`):
+
+- The host line is labelled `This host:` instead of `Platform:`, so "platform" refers to exactly one thing in dtwiz output.
+- The OneAgent line moves directly below OpenTelemetry. These are the only two lines answering "is this host already monitored?" and the only two whose state changes the recommendation menu printed below; they are no longer separated by the container and cloud lines.
+- The runtimes line is labelled `Runtimes:` instead of `Services:`, matching what is detected — runtimes present on `PATH` plus a small set of daemons — rather than implying a set of running services.
+
+Recommendation list (`setup`, `recommend`):
+
+- The list is introduced by a single lead-in, `Monitor Logs, Metrics, Traces of:`, stating once what every option ingests. Each entry then reads as an object completing that phrase.
+- The three colliding entries are retitled so scope is the visible difference: `This host and its services (via existing OpenTelemetry Collector)`, `... (via new OpenTelemetry Collector)`, and `... (via OneAgent)`.
+
+No behavior changes: detection logic, method selection, install dispatch, and the `analyze --json` / `recommend --json` payloads are untouched. `analyze --json` still emits the `platform` key.
+
+## Capabilities
+
+### New Capabilities
+
+- `system-analysis-output`: the labels, vocabulary, and line order of the System Analysis block shared by `analyze`, `setup`, and `status`.
+
+### Modified Capabilities
+
+- `setup-recommendations`: the recommendation list gains a signal lead-in, and entry titles must distinguish monitoring scope rather than repeating a shared prefix.
+
+## Impact
+
+- `pkg/analyzer/analyzer.go` — `Summary()` labels and block order.
+- `pkg/recommender/recommender.go` — three `Title` values; the lead-in in `FormatRecommendations`.
+- `cmd/setup.go` — the lead-in in the interactive menu.
+- `pkg/analyzer/analyzer_test.go` — label assertions.
+
+Affects the rendered output of four commands: `analyze`, `setup`, `status`, `recommend`.
+
+Feature flag interaction: the `via existing OpenTelemetry Collector` entry (`MethodOtelUpdate`) is only selectable in `setup` when `Experimental` is enabled, so the three-way title collision is visible in `setup` only under `--experimental`. `recommend` does not apply that filter and shows the entry unconditionally — a pre-existing inconsistency this change does not address.
+
+No rollback plan required: the change is display-only, carries no migration, and reverts cleanly with the commit.

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/specs/setup-recommendations/spec.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/specs/setup-recommendations/spec.md
@@ -1,3 +1,5 @@
+# Spec: setup-recommendations
+
 ## ADDED Requirements
 
 ### Requirement: The recommendation list is introduced by a signal lead-in

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/specs/setup-recommendations/spec.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/specs/setup-recommendations/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: The recommendation list is introduced by a signal lead-in
+
+Both the interactive menu and the non-interactive recommendation listing SHALL print a single lead-in immediately below the section divider and above the entries, naming the signal types every recommendation ingests: logs, metrics, and traces. The signal types SHALL NOT be repeated inside individual entry titles.
+
+#### Scenario: Interactive menu rendered
+
+- **GIVEN** at least one actionable recommendation exists
+- **WHEN** `dtwiz setup` renders the recommendations section
+- **THEN** a lead-in naming logs, metrics, and traces is printed between the divider and the first entry
+
+#### Scenario: Non-interactive listing rendered
+
+- **GIVEN** at least one recommendation exists
+- **WHEN** `dtwiz recommend` renders its list
+- **THEN** the same lead-in is printed between the divider and the first entry
+
+#### Scenario: Entry titles omit signal types
+
+- **GIVEN** the lead-in has been printed
+- **WHEN** any recommendation entry is rendered
+- **THEN** its title describes what is monitored and by which method, and does not restate logs, metrics, or traces
+
+---
+
+### Requirement: Host-scoped recommendation titles state scope and method
+
+Every recommendation that monitors the local host SHALL be titled with a shared scope phrase naming the host and its services, followed by a parenthetical naming the method that distinguishes it from the others. Two host-scoped entries SHALL NOT be distinguishable only by a trailing method name appended to an otherwise unrelated phrase, and no host-scoped title SHALL describe its scope as a machine's services.
+
+#### Scenario: New collector option
+
+- **GIVEN** the recommendation to deploy a new OpenTelemetry Collector is produced
+- **WHEN** it is rendered in either the menu or the listing
+- **THEN** its title names the host and its services, and identifies the method as a new OpenTelemetry Collector
+
+#### Scenario: Existing collector option
+
+- **GIVEN** an OpenTelemetry Collector is already running on the host
+- **WHEN** the resulting recommendation is rendered
+- **THEN** its title names the host and its services, and identifies the method as the existing OpenTelemetry Collector
+
+#### Scenario: OneAgent option
+
+- **GIVEN** the recommendation to install OneAgent on the host is produced
+- **WHEN** it is rendered
+- **THEN** its title names the host and its services, and identifies the method as OneAgent
+
+#### Scenario: All three host-scoped options offered together
+
+- **GIVEN** a collector is running, the platform supports OneAgent, and experimental recommendations are enabled
+- **WHEN** the menu is rendered
+- **THEN** all three entries share the same scope phrase and differ only in the method named in their parenthetical
+
+---
+
+### Requirement: Recommendation identity is independent of title text
+
+Selection and dispatch SHALL key on a recommendation's method identifier rather than its title. Changing title wording SHALL NOT change which installer a selection invokes, nor the set or order of recommendations produced.
+
+#### Scenario: Selecting a retitled entry
+
+- **GIVEN** a recommendation's title wording has changed
+- **WHEN** the user selects that entry in the menu
+- **THEN** the same installer runs as before the wording changed
+
+#### Scenario: Recommendation set unchanged
+
+- **GIVEN** the same analyzed system
+- **WHEN** recommendations are generated
+- **THEN** the same methods are produced in the same order as before the wording changed

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/specs/system-analysis-output/spec.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/specs/system-analysis-output/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: The host line is labelled `This host`
+
+The System Analysis block SHALL label the operating-system and hostname line `This host:`. The word "platform" SHALL NOT be used as a label for the operating system, so that within a single screen it refers only to the Dynatrace platform.
+
+#### Scenario: Host line rendered
+
+- **GIVEN** a system analysis has been produced
+- **WHEN** the System Analysis block is rendered
+- **THEN** the first line is labelled `This host:` and carries the operating system, architecture, and hostname
+
+#### Scenario: Host line does not collide with credential labels
+
+- **GIVEN** a command renders both credential status and the System Analysis block in one output
+- **WHEN** that output is rendered
+- **THEN** the only label containing the word "Platform" is the credential label, and the operating-system line is labelled `This host:`
+
+---
+
+### Requirement: Monitoring-status lines are grouped directly below the host line
+
+The System Analysis block SHALL render the OpenTelemetry line and the OneAgent line consecutively, immediately after the host line and before any container, orchestrator, or cloud-provider line. These are the lines reporting whether the host is already monitored, and they determine which recommendations are offered.
+
+#### Scenario: Both monitoring-status lines present
+
+- **GIVEN** a system analysis has been produced
+- **WHEN** the System Analysis block is rendered
+- **THEN** the OpenTelemetry line is rendered second and the OneAgent line third
+- **THEN** the Docker, Kubernetes, and cloud-provider lines follow them
+
+#### Scenario: Neither monitoring method is present
+
+- **GIVEN** no OpenTelemetry Collector is running and no OneAgent is installed
+- **WHEN** the System Analysis block is rendered
+- **THEN** both lines are still rendered in the same positions, each reporting that nothing was detected
+
+#### Scenario: OneAgent unavailable for the platform
+
+- **GIVEN** the analysis runs on a platform where OneAgent cannot be installed
+- **WHEN** the System Analysis block is rendered
+- **THEN** the OneAgent line reports that nothing was detected together with the reason, in position three
+
+---
+
+### Requirement: Detected runtimes are labelled `Runtimes` and rendered last
+
+The System Analysis block SHALL label the detected-runtimes line `Runtimes:` and render it as the final line. The label SHALL NOT be `Services:`, because the underlying detection reports runtimes available on the executable search path rather than running workloads. Rendering it last reflects that no recommendation is derived from it.
+
+#### Scenario: Runtimes detected
+
+- **GIVEN** one or more runtimes are detected on the host
+- **WHEN** the System Analysis block is rendered
+- **THEN** the final line is labelled `Runtimes:` and lists the detected runtime names
+
+#### Scenario: No runtimes detected
+
+- **GIVEN** no runtimes are detected on the host
+- **WHEN** the System Analysis block is rendered
+- **THEN** the final line is labelled `Runtimes:` and reports that nothing was detected
+
+---
+
+### Requirement: Analysis labels are presentation-only
+
+Renaming or reordering lines in the System Analysis block SHALL NOT change the machine-readable analysis output. Field names in the JSON representation SHALL remain stable regardless of how the block is labelled.
+
+#### Scenario: JSON output unaffected by label changes
+
+- **GIVEN** the System Analysis block labels the operating-system line `This host:`
+- **WHEN** the analysis is requested in JSON form
+- **THEN** the operating-system field is still emitted under its original key name

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/specs/system-analysis-output/spec.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/specs/system-analysis-output/spec.md
@@ -1,3 +1,5 @@
+# Spec: system-analysis-output
+
 ## ADDED Requirements
 
 ### Requirement: The host line is labelled `This host`

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/tasks.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/tasks.md
@@ -1,0 +1,30 @@
+## 1. System Analysis block
+
+- [x] 1.1 Rename the operating-system label in `Summary()` from `Platform` to `This host` in `pkg/analyzer/analyzer.go`
+- [x] 1.2 Move the OneAgent rendering block in `Summary()` so it follows the OpenTelemetry block and precedes the Docker block
+- [x] 1.3 Rename the detected-runtimes label from `Services` to `Runtimes`, keeping the line last in the block
+- [x] 1.4 Confirm the label width constant still aligns every line after the renames
+
+## 2. Recommendation titles
+
+- [x] 2.1 Retitle the existing-collector recommendation to `This host and its services (via existing OpenTelemetry Collector)` in `pkg/recommender/recommender.go`
+- [x] 2.2 Retitle the new-collector recommendation to `This host and its services (via new OpenTelemetry Collector)`
+- [x] 2.3 Retitle the OneAgent recommendation to `This host and its services (via OneAgent)`
+
+## 3. Signal lead-in
+
+- [x] 3.1 Print `Monitor Logs, Metrics, Traces of:` followed by a blank line after the recommendations header in `cmd/setup.go`
+- [x] 3.2 Print the same lead-in after the divider in `FormatRecommendations` in `pkg/recommender/recommender.go` so `recommend` matches `setup`
+
+## 4. Tests
+
+- [x] 4.1 Update the System Analysis assertions in `pkg/analyzer/analyzer_test.go` from `Services:` to `Runtimes:`
+- [x] 4.2 Add a `This host:` assertion to `pkg/analyzer/analyzer_test.go` so the renamed label is covered
+- [x] 4.3 Run `go test ./pkg/analyzer/... ./pkg/recommender/... ./cmd/...` and confirm all pass
+- [x] 4.4 Verify `analyze --json` still emits the original `platform` key
+
+## 5. Verification and documentation
+
+- [x] 5.1 Render `dtwiz analyze`, `dtwiz status`, `dtwiz setup`, `dtwiz setup --experimental`, and `dtwiz recommend` from a fresh build and confirm each matches the specs
+- [x] 5.2 Confirm the longest recommendation entry stays within 80 columns
+- [x] 5.3 Add a `Changed` entry to `CHANGELOG.md` covering the renamed labels, the reordered line, the lead-in, and the retitled recommendations

--- a/openspec/changes/clarify-analysis-and-recommendation-wording/tasks.md
+++ b/openspec/changes/clarify-analysis-and-recommendation-wording/tasks.md
@@ -1,3 +1,5 @@
+# Tasks: clarify-analysis-and-recommendation-wording
+
 ## 1. System Analysis block
 
 - [x] 1.1 Rename the operating-system label in `Summary()` from `Platform` to `This host` in `pkg/analyzer/analyzer.go`

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -178,7 +178,7 @@ func (s *SystemInfo) Summary() string {
 		osName = string(s.Platform)
 	}
 	sb.WriteString(fmt.Sprintf("  %s %s  %s  (%s)\n",
-		label("Platform"), osName, s.Arch, s.Hostname))
+		label("This host"), osName, s.Arch, s.Hostname))
 
 	if s.OtelCollector {
 		var line string
@@ -191,6 +191,20 @@ func (s *SystemInfo) Summary() string {
 	} else {
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
 			label("OpenTelemetry"),
+			display.ColorMuted.Sprint("<none>")))
+	}
+
+	switch {
+	case s.OneAgentRunning:
+		sb.WriteString(fmt.Sprintf("  %s running\n",
+			label("OneAgent")))
+	case s.Platform == PlatformDarwin:
+		sb.WriteString(fmt.Sprintf("  %s %s\n",
+			label("OneAgent"),
+			display.ColorMuted.Sprint("<none>")+display.ColorMuted.Sprint(" (macOS not supported)")))
+	default:
+		sb.WriteString(fmt.Sprintf("  %s %s\n",
+			label("OneAgent"),
 			display.ColorMuted.Sprint("<none>")))
 	}
 
@@ -281,27 +295,13 @@ func (s *SystemInfo) Summary() string {
 			display.ColorMuted.Sprint(gcpNoneMsg)))
 	}
 
-	switch {
-	case s.OneAgentRunning:
-		sb.WriteString(fmt.Sprintf("  %s running\n",
-			label("OneAgent")))
-	case s.Platform == PlatformDarwin:
-		sb.WriteString(fmt.Sprintf("  %s %s\n",
-			label("OneAgent"),
-			display.ColorMuted.Sprint("<none>")+display.ColorMuted.Sprint(" (macOS not supported)")))
-	default:
-		sb.WriteString(fmt.Sprintf("  %s %s\n",
-			label("OneAgent"),
-			display.ColorMuted.Sprint("<none>")))
-	}
-
 	if len(s.Services) > 0 {
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
-			label("Services"),
+			label("Runtimes"),
 			strings.Join(s.Services, ", ")))
 	} else {
 		sb.WriteString(fmt.Sprintf("  %s %s\n",
-			label("Services"),
+			label("Runtimes"),
 			display.ColorMuted.Sprint("<none>")))
 	}
 

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -88,9 +88,10 @@ func TestSystemInfoSummary_WithDetectedCloudAndRuntimeSignals(t *testing.T) {
 		"account=111111111111  region=eu-west-1  services: Lambda (2), RDS (1)",
 		"subscription=sub-123  services: VMs (5)",
 		"project=project-123  services: Cloud Run (6)",
+		"This host:",
 		"OneAgent:",
 		"running",
-		"Services:",
+		"Runtimes:",
 		"nginx, redis",
 	} {
 		if !strings.Contains(summary, want) {

--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -71,7 +71,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		recs = append(recs, Recommendation{
 			Method:   MethodOtelUpdate,
 			Priority: 0,
-			Title:    "This machine's services (update existing OpenTelemetry Collector)",
+			Title:    "This host and its services (via existing OpenTelemetry Collector)",
 			Description: fmt.Sprintf(
 				"An OpenTelemetry Collector is running%s. Add the Dynatrace OTLP exporter to send telemetry to Dynatrace.",
 				configHint,
@@ -89,7 +89,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 	recs = append(recs, Recommendation{
 		Method:        MethodOtelCollector,
 		Priority:      0,
-		Title:         "This machine's services (via new OpenTelemetry Collector)",
+		Title:         "This host and its services (via new OpenTelemetry Collector)",
 		Description:   "Deploy the Dynatrace OpenTelemetry Collector to ingest traces, metrics, and logs via OTLP.",
 		Prerequisites: []string{"Dynatrace API token with ingest scopes"},
 		Steps: []string{
@@ -138,7 +138,7 @@ func GenerateRecommendations(system *analyzer.SystemInfo) []Recommendation {
 		recs = append(recs, Recommendation{
 			Method:        MethodOneAgent,
 			Priority:      40,
-			Title:         "This machine's services (via OneAgent)",
+			Title:         "This host and its services (via OneAgent)",
 			Description:   "No container runtime detected. Install OneAgent directly for full-stack host monitoring.",
 			Prerequisites: []string{"Root/Administrator privileges", "Dynatrace API token"},
 			Steps: []string{
@@ -215,7 +215,8 @@ func FormatRecommendations(recs []Recommendation) string {
 
 	var sb strings.Builder
 	sb.WriteString(recHeader.Sprint("  Recommendations — What do you want to monitor?") + "\n")
-	sb.WriteString(recMuted.Sprint("  "+strings.Repeat("─", 42)) + "\n\n")
+	sb.WriteString(recMuted.Sprint("  "+strings.Repeat("─", 42)) + "\n")
+	sb.WriteString("  Monitor Logs, Metrics, Traces of:\n\n")
 
 	n := 0
 	for _, r := range recs {


### PR DESCRIPTION
## Why

From the QuickStart intern feedback round (P2/P3/P4, 24.08.2026), finding 1.1: participants **had no basis to choose between OneAgent and OpenTelemetry**. The cause was literal — both recommendation entries opened with the same five words, `This machine's services`, and OneAgent's title promised "this machine's services" while it actually instruments every process on the host.

## What changed

### System analysis

- `Platform:` → `This host:`. In `dtwiz status` this label sat eight lines from `Platform Token:`, with the two meaning unrelated things. "Platform" now means exactly one thing in dtwiz output.
- The `OneAgent` line moves from position 8 to position 3, directly below `OpenTelemetry`. These are the only two lines answering *"is this host already monitored?"*, and the only two whose state changes the menu three lines later — they now sit together, above the container and cloud context.
- `Services:` → `Runtimes:`. `detectServices()` finds runtimes installed on PATH via `which` plus a few daemons via `pgrep` — not running services. The old label overstated what it knows.

### Recommendations

- New lead-in: `Monitor Logs, Metrics, Traces of:`. States once what every option ingests, so each entry becomes a grammatical object completing it. This is what wouldn't fit inside individual 80-column titles.
- The three colliding titles become `This host and its services (via existing / new OpenTelemetry Collector / OneAgent)` — the distinction now reads as **existing / new / OneAgent**.

## Before / after

Before:
```
  Platform:          macOS  arm64  (DT-KGKVFYF3X2)
  OpenTelemetry:     .../dynatrace-otel-collector  (running)
  Docker:            <none>
  ...
  OneAgent:          <none> (macOS not supported)
  Services:          java, node, python, go

  Recommendations — What do you want to monitor?
  ──────────────────────────────────────────────────
  [1]  This machine's services (via new OpenTelemetry Collector)
  [2]  This machine's services (via OneAgent)
```

After:
```
  This host:         macOS  arm64  (DT-KGKVFYF3X2)
  OpenTelemetry:     .../dynatrace-otel-collector  (running)
  OneAgent:          <none> (macOS not supported)
  Docker:            <none>
  ...
  Runtimes:          java, node, python, go

  Recommendations — What do you want to monitor?
  ──────────────────────────────────────────────────
  Monitor Logs, Metrics, Traces of:

  [1]  This host and its services (via new OpenTelemetry Collector)
  [2]  This host and its services (via OneAgent)
```

## Scope

Display-only — no detection logic, no JSON keys, no struct changes. `analyze --json` still emits `"platform"`. Six command outputs change (`setup`, `analyze`, `status` share the analyzer edits from one site; `setup` and `recommend` share the title edits).

## Testing

- `go build ./...` passes; `gofmt` clean
- `pkg/analyzer`, `pkg/recommender`, `cmd` pass uncached
- All six command outputs verified against a fresh build

Two pre-existing failures on this machine, **verified unrelated** by re-running on a stashed tree:

- `pkg/installer/otel` — `TestValidateJavaPrerequisites_ValidVersion`, `TestInstallOtelJava_DryRun`, `TestInstallOtelJava_SkipReturnsInstallCancelled` fail with `unable to determine Java version: exit status 1`. These shell out to a real `java` binary instead of stubbing it, so they can't pass without a JDK installed.
- `make lint` fails before linting anything: `golangci-lint` v1 is installed but `.golangci.yml` is a v2 config. **The lint step is therefore unverified in this PR.**

## Follow-ups found while working, not included here

- `recommend` ignores `--experimental`, so it advertises `MethodOtelUpdate` and `MethodDocker` that `setup` won't offer — and the numbering between the two commands doesn't match.
- `recommend` and `setup` are two separate renderers that have drifted (42- vs 50-char dividers, ` 1 ` chips vs `[1]`); `pkg/recommender` declares nine private color vars duplicating `pkg/display`.
- `Priority`, `ComingSoon`, and `MethodNotSupported` are never assigned or constructed, yet are serialized into `recommend --json`. Two branches of `FormatRecommendations` and `setup.go`'s `ComingSoon` loop are unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)