### PR TITLE
fix(ui): fix ASCII art alignment and tighten header spacing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,10 +49,10 @@ Then use dtwiz commands to analyze and instrument your system.`,
 
 func printBanner() {
 	purple := color.New(color.FgMagenta, color.Bold)
-	purple.Printf("  ____   _______   __        __ ___  ____\n")
-	purple.Printf(" |  _ \\ |__   __| \\ \\      / /|_ _||_  /\n")
-	purple.Printf(" | | | |   | |     \\ \\ /\\ / /  | |  / / \n")
-	purple.Printf(" | |_| |   | |      \\ V  V /   | | / /_ \n")
+	purple.Printf("  ____   _______  __        __ ___  _____\n")
+	purple.Printf(" |  _ \\ |__   __| \\ \\      / /|_ _||__  /\n")
+	purple.Printf(" | | | |   | |     \\ \\ /\\ / /  | |   / / \n")
+	purple.Printf(" | |_| |   | |      \\ V  V /   | |  / /_ \n")
 	purple.Printf(" |____/    |_|       \\_/\\_/   |___|/____| %s\n", version.Version)
 	fmt.Printf("\n HASTA LA VISTA - BLIND SPOTS!\n\n")
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -36,13 +36,12 @@ var setupCmd = &cobra.Command{
 		printBanner()
 
 		if env := environmentHint(); env != "" {
-			display.ColorDefault.Printf(" Environment: %s\n\n", env)
+			display.ColorDefault.Printf(" Environment: %s\n", env)
 		} else {
 			display.ColorDefault.Println(" Environment: (not configured)")
-			fmt.Println()
 		}
 
-		fmt.Printf(" Looking for more deployment options beyond these popular ones? %s\n\n", display.Hyperlink("Visit docs", "https://docs.dynatrace.com/docs/ingest-from"))
+		fmt.Printf(" Looking for more deployment options beyond these popular ones? %s\n", display.Hyperlink("Visit docs", "https://docs.dynatrace.com/docs/ingest-from"))
 		fmt.Printf(" Learn about needed permissions? %s\n\n", display.Hyperlink("Visit docs", "https://github.com/dynatrace-oss/dtwiz/blob/main/README.md"))
 
 		display.Header("Analyzing system...")


### PR DESCRIPTION
## Summary
- Fix off-by-one characters in the DTWIZ banner ASCII art
- Remove blank lines between Environment, docs, and permissions lines so the header reads as one compact block

## Test plan
- [x] Run `dtwiz setup` and verify the banner and header lines look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)