### PR TITLE
fix(watch): hide section links when terminal doesn't support hyperlinks

### DIFF
--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -145,8 +145,18 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 	bold := color.New(color.Bold)
 	_ = green
 
+	supportsHyperlinks := display.StdoutSupportsHyperlinks()
 	linkFn := func(url, label string) string {
-		return termHyperlink(url, label, display.StdoutSupportsHyperlinks())
+		return termHyperlink(url, label, supportsHyperlinks)
+	}
+	// Section headers and item links omit the URL when hyperlinks are not
+	// supported — the raw URL breaks the watch layout without adding value.
+	// The footer CTA always uses linkFn so the URL stays visible.
+	sectionLinkFn := func(url, label string) string {
+		if !supportsHyperlinks {
+			return label
+		}
+		return termHyperlink(url, label, true)
 	}
 
 	var prevLines int
@@ -247,7 +257,7 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 		buf.WriteString("\n")
 
 		// Sections
-		renderWatchSections(&buf, state, appsURL, highlight, dim, bold, linkFn)
+		renderWatchSections(&buf, state, appsURL, highlight, dim, bold, sectionLinkFn)
 
 		// Footer
 		separator := " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"


### PR DESCRIPTION
## Summary

- Section headers and item links in `dtwiz watch` now omit the raw URL when the terminal cannot render OSC 8 hyperlinks — the bare URL broke the layout without adding value
- The footer CTA (QuickStart / Clouds app link) retains the `label (url)` fallback since it is the primary call-to-action that users need to copy

Fixes BIZOBS-2731

## Test plan

- [x] Run `dtwiz watch` in a terminal that supports OSC 8 hyperlinks (e.g. iTerm2, WezTerm) — section headers should render as clickable links, footer CTA should be clickable
- [x] Run `dtwiz watch` in a terminal without hyperlink support (e.g. plain `xterm`, CI output) — section headers should show plain names only, footer CTA should fall back to `label (url)` with the URL visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)