### PR TITLE
feat(otel): cleaner wizard output for OTel instrumentation

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -158,14 +158,15 @@ var installOtelCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := otel.InstallOtelCollectorWithProject(envURL, classicTok, platformTok, otelProject, installDryRun); err != nil {
+		manualLang, err := otel.InstallOtelCollectorWithProject(envURL, classicTok, platformTok, otelProject, installDryRun)
+		if err != nil {
 			if errors.Is(err, installer.ErrInstallCancelled) {
 				return nil
 			}
 			return err
 		}
 		if !installDryRun {
-			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format(installer.IngestTimeFormat))
+			installer.WatchIngestOtel(envURL, platformTok, StartTime.UTC().Format(installer.IngestTimeFormat), manualLang)
 		}
 		return nil
 	},

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -145,6 +145,7 @@ var setupCmd = &cobra.Command{
 		}
 
 		var installErr error
+		var otelManualLang string
 		switch selected.Method {
 		case recommender.MethodOneAgent:
 			installErr = oneagent.InstallOneAgentV2(c, oneagent.InstallOptions{
@@ -162,7 +163,7 @@ var setupCmd = &cobra.Command{
 		case recommender.MethodDocker:
 			installErr = installer.InstallDocker(envURL, classicTok, setupDryRun)
 		case recommender.MethodOtelCollector:
-			installErr = otel.InstallOtelCollector(envURL, classicTok, platformTok, setupDryRun)
+			otelManualLang, installErr = otel.InstallOtelCollector(envURL, classicTok, platformTok, setupDryRun)
 		case recommender.MethodOtelUpdate:
 			installErr = otel.UpdateOtelConfigInteractive(envURL, classicTok, platformTok, setupDryRun)
 		case recommender.MethodAWS:
@@ -194,9 +195,10 @@ var setupCmd = &cobra.Command{
 		case recommender.MethodOneAgent,
 			recommender.MethodKubernetes,
 			recommender.MethodDocker,
-			recommender.MethodOtelCollector,
 			recommender.MethodOtelUpdate:
 			installer.WatchIngest(envURL, platformTok, StartTime.UTC().Format(installer.IngestTimeFormat))
+		case recommender.MethodOtelCollector:
+			installer.WatchIngestOtel(envURL, platformTok, StartTime.UTC().Format(installer.IngestTimeFormat), otelManualLang)
 		}
 		return nil
 	},

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -282,13 +282,19 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 		separator := " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
 		highlight.Fprint(&buf, separator)
 		if manualLang != "" {
-			langName := otelLangNames[manualLang]
-			if langName == "" {
-				langName = manualLang
+			if manualLang == "other" {
+				otelURL := "https://dt-url.net/otel-walkthroughs"
+				highlight.Fprintf(&buf, " 👉 Browse OTel instrumentation walkthroughs\n")
+				fmt.Fprintf(&buf, "    %s\n", linkFn(otelURL, "→ "+otelURL))
+			} else {
+				langName := otelLangNames[manualLang]
+				if langName == "" {
+					langName = manualLang
+				}
+				otelURL := "https://dt-url.net/otel-" + manualLang
+				highlight.Fprintf(&buf, " 👉 Instrument your %s app\n", langName)
+				fmt.Fprintf(&buf, "    %s\n", linkFn(otelURL, "→ "+otelURL))
 			}
-			otelURL := "https://dt-url.net/otel-" + manualLang
-			highlight.Fprintf(&buf, " 👉 Instrument your %s app\n", langName)
-			fmt.Fprintf(&buf, "    %s\n", linkFn(otelURL, "→ "+otelURL))
 		}
 		if cloudInstall {
 			highlight.Fprintf(&buf, " 👉 See your cloud resources in the Clouds app\n")

--- a/pkg/installer/ingest_watch.go
+++ b/pkg/installer/ingest_watch.go
@@ -95,7 +95,14 @@ type watchState struct {
 // fromClause is injected directly into DQL queries — accepts RFC3339 timestamps
 // or DQL relative expressions (e.g. "now()-1h").
 func WatchIngest(envURL, pToken, fromClause string) {
-	watchIngest(envURL, pToken, fromClause, nil, "", false)
+	watchIngest(envURL, pToken, fromClause, nil, "", false, "")
+}
+
+// WatchIngestOtel is like WatchIngest but also shows a call to action to
+// instrument the application when manualLang is the URL slug of a language
+// the user selected for manual instrumentation (e.g. "go", "php").
+func WatchIngestOtel(envURL, pToken, fromClause, manualLang string) {
+	watchIngest(envURL, pToken, fromClause, nil, "", false, manualLang)
 }
 
 // WatchIngestCloudFromTime is like WatchIngest but calls WatchIngestCloud.
@@ -112,24 +119,36 @@ func WatchIngestCloudFromTime(envURL, pToken string, startTime time.Time) {
 // The caller sends status messages to statusCh; the most recent message is
 // shown on every render. Passing a nil channel disables status updates.
 func WatchIngestWithStatus(envURL, pToken, fromClause string, statusCh <-chan string) {
-	watchIngest(envURL, pToken, fromClause, statusCh, "", false)
+	watchIngest(envURL, pToken, fromClause, statusCh, "", false, "")
 }
 
 // WatchIngestAWS is like WatchIngestWithStatus but additionally scopes the
 // cloud-platform signal queries (metrics + da-* logs) to a specific AWS
 // account ID so noise from other accounts in the same tenant is filtered out.
 func WatchIngestAWS(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string) {
-	watchIngest(envURL, pToken, fromClause, statusCh, awsAccountID, true)
+	watchIngest(envURL, pToken, fromClause, statusCh, awsAccountID, true, "")
 }
 
 // WatchIngestCloud is like WatchIngest but shows a "See your cloud resources
 // in the Clouds app" footer instead of the QuickStart link. Use this for
 // AWS, GCP, and Azure installs.
 func WatchIngestCloud(envURL, pToken, fromClause string) {
-	watchIngest(envURL, pToken, fromClause, nil, "", true)
+	watchIngest(envURL, pToken, fromClause, nil, "", true, "")
 }
 
-func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string, cloudInstall bool) {
+// otelLangNames maps a manual-language URL slug to its display name.
+var otelLangNames = map[string]string{
+	"php":    "PHP",
+	"cpp":    "C++",
+	"dotnet": ".NET",
+	"elixir": "Elixir",
+	"erlang": "Erlang",
+	"go":     "Go",
+	"ruby":   "Ruby",
+	"rust":   "Rust",
+}
+
+func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsAccountID string, cloudInstall bool, manualLang string) {
 	if pToken == "" {
 		fmt.Println("  Platform token required for watch. Set --platform-token or DT_PLATFORM_TOKEN.")
 		return
@@ -262,6 +281,15 @@ func watchIngest(envURL, pToken, fromClause string, statusCh <-chan string, awsA
 		// Footer
 		separator := " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
 		highlight.Fprint(&buf, separator)
+		if manualLang != "" {
+			langName := otelLangNames[manualLang]
+			if langName == "" {
+				langName = manualLang
+			}
+			otelURL := "https://dt-url.net/otel-" + manualLang
+			highlight.Fprintf(&buf, " 👉 Instrument your %s app\n", langName)
+			fmt.Fprintf(&buf, "    %s\n", linkFn(otelURL, "→ "+otelURL))
+		}
 		if cloudInstall {
 			highlight.Fprintf(&buf, " 👉 See your cloud resources in the Clouds app\n")
 			fmt.Fprintf(&buf, "    %s\n", linkFn(appsURL+"/ui/apps/dynatrace.clouds/smartscape/services", "→ Open Clouds"))

--- a/pkg/installer/otel/collector.go
+++ b/pkg/installer/otel/collector.go
@@ -767,7 +767,8 @@ func extractOtlpHTTPPort(configYAML []byte) (httpPort int, portFound bool) {
 }
 
 // printConfigPreview prints the OTel Collector config preview.
-// Default: head (up to OTLP receiver endpoints) + "..." + pipelines section.
+// Default: head (up to OTLP receiver endpoints) + "..." + exporters section.
+// Pipelines are always hidden in non-debug output.
 // With --debug: full config.
 func (cp *collectorPlan) printConfigPreview(sep string) {
 	const headLines = 20
@@ -787,10 +788,16 @@ func (cp *collectorPlan) printConfigPreview(sep string) {
 		}
 	} else {
 		headEnd := configHeadEnd(lines, headLines)
+		exportersStart := exportersSectionStart(lines)
 		for _, line := range lines[:headEnd] {
 			fmt.Printf("    %s\n", line)
 		}
-		if len(lines) > headEnd {
+		if exportersStart > headEnd {
+			fmt.Printf("    # ... (%d lines) — run with --debug to see full %s\n", exportersStart-headEnd, label)
+			for _, line := range lines[exportersStart:] {
+				fmt.Printf("    %s\n", line)
+			}
+		} else if len(lines) > headEnd {
 			fmt.Printf("    # ... (%d lines) — run with --debug to see full %s\n", len(lines)-headEnd, label)
 		}
 	}
@@ -816,6 +823,16 @@ func configHeadEnd(lines []string, headLines int) int {
 func pipelinesSectionStart(lines []string) int {
 	for i, line := range lines {
 		if strings.TrimRight(line, " ") == "  pipelines:" {
+			return i
+		}
+	}
+	return -1
+}
+
+// exportersSectionStart returns the index of the top-level "exporters:" line, or -1 if not found.
+func exportersSectionStart(lines []string) int {
+	for i, line := range lines {
+		if strings.TrimRight(line, " ") == "exporters:" {
 			return i
 		}
 	}

--- a/pkg/installer/otel/collector.go
+++ b/pkg/installer/otel/collector.go
@@ -787,27 +787,11 @@ func (cp *collectorPlan) printConfigPreview(sep string) {
 		}
 	} else {
 		headEnd := configHeadEnd(lines, headLines)
-		pipeStart := pipelinesSectionStart(lines)
 		for _, line := range lines[:headEnd] {
 			fmt.Printf("    %s\n", line)
 		}
-		const truncateThreshold = 30
-		switch {
-		case pipeStart > headEnd && pipeStart-headEnd > truncateThreshold:
-			fmt.Printf("    # ... (%d lines) — run with --debug to see full %s\n", pipeStart-headEnd, label)
-			for _, line := range lines[pipeStart:] {
-				fmt.Printf("    %s\n", line)
-			}
-		case pipeStart > headEnd:
-			for _, line := range lines[headEnd:] {
-				fmt.Printf("    %s\n", line)
-			}
-		case len(lines)-headEnd > truncateThreshold:
-			fmt.Printf("    # ... (%d more lines) — run with --debug to see full %s\n", len(lines)-headEnd, label)
-		case len(lines) > headEnd:
-			for _, line := range lines[headEnd:] {
-				fmt.Printf("    %s\n", line)
-			}
+		if len(lines) > headEnd {
+			fmt.Printf("    # ... (%d lines) — run with --debug to see full %s\n", len(lines)-headEnd, label)
 		}
 	}
 

--- a/pkg/installer/otel/collector_test.go
+++ b/pkg/installer/otel/collector_test.go
@@ -971,6 +971,8 @@ func TestCollectorPlanPrintDryRun(t *testing.T) {
 	}
 }
 
+// buildPreviewConfig builds a synthetic config for preview tests.
+// Structure: headLines head lines, middleLines middle lines, optional pipelines, then 5 exporter lines.
 func buildPreviewConfig(headLines, middleLines int, withPipelines bool) string {
 	var b strings.Builder
 	for i := range headLines {
@@ -984,6 +986,11 @@ func buildPreviewConfig(headLines, middleLines int, withPipelines bool) string {
 		b.WriteString("    traces:\n")
 		b.WriteString("      receivers: [otlp]\n")
 	}
+	b.WriteString("exporters:\n")
+	b.WriteString("  otlp_http:\n")
+	b.WriteString("    endpoint: https://example.com/api/v2/otlp\n")
+	b.WriteString("    headers:\n")
+	b.WriteString("      Authorization: \"Bearer ***\"\n")
 	return b.String()
 }
 
@@ -999,33 +1006,33 @@ func TestPrintConfigPreview_Truncation(t *testing.T) {
 		wantMsg       string // substring expected in ellipsis line (if wantEllipsis)
 	}{
 		{
-			name:          "short tail with pipelines — truncated, pipelines hidden",
+			name:          "short tail with pipelines — truncated, pipelines hidden, exporters shown",
 			headLines:     20,
-			middleLines:   9, // 9 middle + 3 pipeline lines = 12 hidden
+			middleLines:   9, // 9 middle + 3 pipeline lines = 12 hidden before exporters
 			withPipelines: true,
 			wantEllipsis:  true,
 			wantMsg:       "12 lines",
 		},
 		{
-			name:          "long tail with pipelines — truncated, pipelines hidden",
+			name:          "long tail with pipelines — truncated, pipelines hidden, exporters shown",
 			headLines:     20,
-			middleLines:   31, // 31 middle + 3 pipeline lines = 34 hidden
+			middleLines:   31, // 31 middle + 3 pipeline lines = 34 hidden before exporters
 			withPipelines: true,
 			wantEllipsis:  true,
 			wantMsg:       "34 lines",
 		},
 		{
-			name:          "short tail without pipelines — truncated",
+			name:          "short tail without pipelines — truncated, exporters shown",
 			headLines:     20,
-			middleLines:   9,
+			middleLines:   9, // 9 middle lines hidden before exporters
 			withPipelines: false,
 			wantEllipsis:  true,
 			wantMsg:       "9 lines",
 		},
 		{
-			name:          "long tail without pipelines — truncated",
+			name:          "long tail without pipelines — truncated, exporters shown",
 			headLines:     20,
-			middleLines:   31,
+			middleLines:   31, // 31 middle lines hidden before exporters
 			withPipelines: false,
 			wantEllipsis:  true,
 			wantMsg:       "31 lines",
@@ -1051,6 +1058,10 @@ func TestPrintConfigPreview_Truncation(t *testing.T) {
 			// Pipelines section must never appear in default (non-debug) output.
 			if strings.Contains(out, "pipelines:") {
 				t.Errorf("pipelines section must not appear in default output\noutput:\n%s", out)
+			}
+			// Exporters section must always appear in default (non-debug) output.
+			if !strings.Contains(out, "exporters:") {
+				t.Errorf("exporters section must appear in default output\noutput:\n%s", out)
 			}
 		})
 	}

--- a/pkg/installer/otel/collector_test.go
+++ b/pkg/installer/otel/collector_test.go
@@ -999,34 +999,36 @@ func TestPrintConfigPreview_Truncation(t *testing.T) {
 		wantMsg       string // substring expected in ellipsis line (if wantEllipsis)
 	}{
 		{
-			name:          "short middle with pipelines — no truncation",
+			name:          "short tail with pipelines — truncated, pipelines hidden",
 			headLines:     20,
-			middleLines:   9, // 9 ≤ 30: show everything
+			middleLines:   9, // 9 middle + 3 pipeline lines = 12 hidden
 			withPipelines: true,
-			wantEllipsis:  false,
+			wantEllipsis:  true,
+			wantMsg:       "12 lines",
 		},
 		{
-			name:          "long middle with pipelines — truncate, show pipelines after",
+			name:          "long tail with pipelines — truncated, pipelines hidden",
 			headLines:     20,
-			middleLines:   31, // 31 > 30: hide middle
+			middleLines:   31, // 31 middle + 3 pipeline lines = 34 hidden
 			withPipelines: true,
+			wantEllipsis:  true,
+			wantMsg:       "34 lines",
+		},
+		{
+			name:          "short tail without pipelines — truncated",
+			headLines:     20,
+			middleLines:   9,
+			withPipelines: false,
+			wantEllipsis:  true,
+			wantMsg:       "9 lines",
+		},
+		{
+			name:          "long tail without pipelines — truncated",
+			headLines:     20,
+			middleLines:   31,
+			withPipelines: false,
 			wantEllipsis:  true,
 			wantMsg:       "31 lines",
-		},
-		{
-			name:          "short tail without pipelines — no truncation",
-			headLines:     20,
-			middleLines:   9, // 9 ≤ 30: show everything
-			withPipelines: false,
-			wantEllipsis:  false,
-		},
-		{
-			name:          "long tail without pipelines — truncate",
-			headLines:     20,
-			middleLines:   31, // 31 > 30: hide tail
-			withPipelines: false,
-			wantEllipsis:  true,
-			wantMsg:       "31 more lines",
 		},
 	}
 
@@ -1046,19 +1048,9 @@ func TestPrintConfigPreview_Truncation(t *testing.T) {
 			if tc.wantEllipsis && !strings.Contains(out, tc.wantMsg) {
 				t.Errorf("ellipsis line missing %q\noutput:\n%s", tc.wantMsg, out)
 			}
-			if !tc.wantEllipsis {
-				for i := range tc.middleLines {
-					marker := fmt.Sprintf("middle_%02d", i)
-					if !strings.Contains(out, marker) {
-						t.Errorf("expected %q in full output\noutput:\n%s", marker, out)
-					}
-				}
-				if tc.withPipelines && !strings.Contains(out, "pipelines:") {
-					t.Errorf("expected pipelines section in full output\noutput:\n%s", out)
-				}
-			}
-			if tc.wantEllipsis && tc.withPipelines && !strings.Contains(out, "pipelines:") {
-				t.Errorf("pipelines section missing after ellipsis\noutput:\n%s", out)
+			// Pipelines section must never appear in default (non-debug) output.
+			if strings.Contains(out, "pipelines:") {
+				t.Errorf("pipelines section must not appear in default output\noutput:\n%s", out)
 			}
 		})
 	}

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -339,5 +339,6 @@ func InstallDemo(envURL, token, platformTok string, dryRun bool) error {
 	}
 
 	installer.AutoConfirm = true
-	return InstallOtelCollectorWithProject(envURL, token, platformTok, demoPath, dryRun)
+	_, err = InstallOtelCollectorWithProject(envURL, token, platformTok, demoPath, dryRun)
+	return err
 }

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -36,20 +36,26 @@ func TestConfirmProceedAutoConfirm(t *testing.T) {
 func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 	dir := t.TempDir()
 	helpers.SetTestWorkingDir(t, dir)
-	setTestStdin(t, "y\n")
+	// Isolate scan roots: HOME/USERPROFILE point at the temp dir so no real
+	// projects are detected and the scan completes quickly.
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	// "s" selects Skip in the project-selection UI.
+	// platformToken is empty so buildTenantPrerequisitePreview skips API calls.
+	setTestStdin(t, "s\n")
 
 	output := helpers.CaptureStdout(t, func() {
-		err := InstallOtelCollectorWithProject(
-			"https://fake.live.dynatrace.com", "tok", "tok", "", true,
+		_, err := InstallOtelCollectorWithProject(
+			"https://fake.live.dynatrace.com", "tok", "", "", true,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	// The collector config preview (printed via fmt.Printf) must be present.
-	if !strings.Contains(output, "fake.live.dynatrace.com") {
-		t.Fatalf("expected collector config in dry-run output, got:\n%s", output)
+	// The collector config header must appear in the dry-run output.
+	if !strings.Contains(output, "health_check:") {
+		t.Fatalf("expected collector config preview in dry-run output, got:\n%s", output)
 	}
 	// No files must be written.
 	if _, err := os.Stat(filepath.Join(dir, "opentelemetry")); !os.IsNotExist(err) {
@@ -58,7 +64,7 @@ func TestInstallOtelCollectorWithProject_DryRun(t *testing.T) {
 }
 
 func TestInstallOtelCollectorWithProjectPathNotFound(t *testing.T) {
-	err := InstallOtelCollectorWithProject("https://fake.live.dynatrace.com", "tok", "tok", "/nonexistent/path", false)
+	_, err := InstallOtelCollectorWithProject("https://fake.live.dynatrace.com", "tok", "tok", "/nonexistent/path", false)
 	if err == nil {
 		t.Fatal("expected error for non-existent project path")
 	}

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -378,21 +378,23 @@ func detectAllProjects(runtimes []runtimeInfo, roots []string) []detectedProject
 	return all
 }
 
-const openTelemetryWalkthroughsURL = "https://docs.dynatrace.com/docs/ingest-from/opentelemetry/walkthroughs"
+// manualLanguageEntry describes a language that dtwiz does not auto-instrument.
+// The user can select it to receive an OTel instrumentation guide after install.
+type manualLanguageEntry struct {
+	Key     string // single-character selection key
+	Name    string // display name
+	URLSlug string // slug for https://dt-url.net/otel-<slug>
+}
 
-// printSupportedRuntimesInfoBox tells the user which runtimes dtwiz can
-// auto-instrument and where to find manual walkthroughs for the rest.
-func printSupportedRuntimesInfoBox() {
-	linkText := openTelemetryWalkthroughsURL
-	if display.StdoutSupportsHyperlinks() {
-		linkText = display.Hyperlink("OpenTelemetry walkthroughs", openTelemetryWalkthroughsURL)
-	}
-	display.PrintInfoBox(
-		"(i) dtwiz automatically instruments Python, Java, and Node.js projects.",
-		"",
-		"To instrument PHP, C++, .NET, Elixir, Erlang, Go, Ruby, or Rust, follow the walkthroughs:",
-		linkText,
-	)
+var manualLanguages = []manualLanguageEntry{
+	{Key: "p", Name: "PHP", URLSlug: "php"},
+	{Key: "c", Name: "C++", URLSlug: "cpp"},
+	{Key: "n", Name: ".NET", URLSlug: "dotnet"},
+	{Key: "e", Name: "Elixir", URLSlug: "elixir"},
+	{Key: "l", Name: "Erlang", URLSlug: "erlang"},
+	{Key: "g", Name: "Go", URLSlug: "go"},
+	{Key: "r", Name: "Ruby", URLSlug: "ruby"},
+	{Key: "u", Name: "Rust", URLSlug: "rust"},
 }
 
 func printProjectList(projects []detectedProject) {
@@ -412,28 +414,39 @@ func printProjectList(projects []detectedProject) {
 		}
 		fmt.Println(line)
 	}
-	fmt.Printf("  [%d]  ", len(projects)+1)
-	display.ColorMessage.Println("Skip — If skipped, you need to send application signals to the OpenTelemetry Collector yourself so they show up in Dynatrace.")
+	fmt.Println()
+	for _, lang := range manualLanguages {
+		fmt.Printf("  [%s]  %-10s — OTel instrumentation guide shown after install\n", lang.Key, lang.Name)
+	}
+	fmt.Println()
+	fmt.Println("  [s]  Skip — I already have my application instrumented with OpenTelemetry or just want host monitoring")
 }
 
-func selectProject(projects []detectedProject) (detectedProject, bool) {
+// selectProject prompts the user to select a detected project, a manual language, or skip.
+// Returns (project, languageSlug, ok):
+//   - ok=false means skip / cancel
+//   - languageSlug != "" means a manual language was selected (no project)
+//   - otherwise a detected project was selected
+func selectProject(projects []detectedProject) (detectedProject, string, bool) {
 	fmt.Println()
-	fmt.Printf("  Select a project to instrument [1-%d]: ", len(projects)+1)
+	fmt.Print("  Your selection: ")
 	reader := bufio.NewReader(os.Stdin)
 	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(answer)
-	if answer == "" {
-		return detectedProject{}, false
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer == "" || answer == "s" {
+		return detectedProject{}, "", false
+	}
+	for _, lang := range manualLanguages {
+		if answer == lang.Key {
+			return detectedProject{}, lang.URLSlug, true
+		}
 	}
 	num, err := strconv.Atoi(answer)
-	if err != nil || num < 1 || num > len(projects)+1 {
+	if err != nil || num < 1 || num > len(projects) {
 		fmt.Println("  Invalid selection, skipping instrumentation.")
-		return detectedProject{}, false
+		return detectedProject{}, "", false
 	}
-	if num == len(projects)+1 {
-		return detectedProject{}, false
-	}
-	return projects[num-1], true
+	return projects[num-1], "", true
 }
 
 func createRuntimePlan(proj detectedProject, httpPort int, token, envURL, platformToken string) InstrumentationPlan {
@@ -495,14 +508,20 @@ func inferRuntimeFromPath(path string) string {
 	return ""
 }
 
-func InstallOtelCollector(envURL, token, platformToken string, dryRun bool) error {
+// InstallOtelCollector installs the OTel Collector with interactive project selection.
+// Returns the URL slug of the manually-selected language (e.g. "go", "php") when
+// the user chose a language that requires manual instrumentation; empty otherwise.
+func InstallOtelCollector(envURL, token, platformToken string, dryRun bool) (string, error) {
 	return InstallOtelCollectorWithProject(envURL, token, platformToken, "", dryRun)
 }
 
-func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath string, dryRun bool) error {
+// InstallOtelCollectorWithProject installs the OTel Collector, optionally with
+// auto-instrumentation for a pre-selected project path.
+// Returns the URL slug of the manually-selected language when the user chose one.
+func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath string, dryRun bool) (string, error) {
 	if projectPath != "" {
 		if _, err := os.Stat(projectPath); err != nil {
-			return fmt.Errorf("project path not found: %s", projectPath)
+			return "", fmt.Errorf("project path not found: %s", projectPath)
 		}
 	}
 
@@ -523,8 +542,7 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 			fmt.Println("        without it, metrics for services and other users' processes are skipped.")
 		}
 	case "darwin":
-		fmt.Println("  Note: system.processes.created and process.disk.io are unavailable on macOS")
-		fmt.Println("        regardless of privilege level and will not appear in Dynatrace.")
+		logger.Debug("system.processes.created and process.disk.io are unavailable on macOS regardless of privilege level")
 	}
 	fmt.Println()
 
@@ -532,17 +550,18 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 
 	cp, err := prepareCollectorPlan(envURL, token)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var plan InstrumentationPlan
+	var manualLang string
 	if projectPath != "" {
-		runtime := inferRuntimeFromPath(projectPath)
-		if runtime == "" {
-			return fmt.Errorf("could not detect runtime from project path: %s", projectPath)
+		rt := inferRuntimeFromPath(projectPath)
+		if rt == "" {
+			return "", fmt.Errorf("could not detect runtime from project path: %s", projectPath)
 		}
 		projects := []ScannedProject{{Path: projectPath}}
-		switch runtime {
+		switch rt {
 		case "Java":
 			matchProcessesToProjects(projects, detectJavaProcesses())
 		case "Node.js":
@@ -550,51 +569,42 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 		default:
 			matchProcessesToProjects(projects, detectPythonProcesses())
 		}
-		proj := detectedProject{ScannedProject: projects[0], Runtime: runtime}
+		proj := detectedProject{ScannedProject: projects[0], Runtime: rt}
 		plan = createRuntimePlanFn(proj, cp.httpPort, token, envURL, platformToken)
 	} else {
 		roots, err := selectScanRoots()
 		if err != nil {
-			return err
+			return "", err
 		}
 		logger.Debug("scanning for projects", "roots", roots)
 		projects := detectAllProjects(runtimes, roots)
-		if len(projects) == 0 {
-			fmt.Println("  No projects detected.")
-			cont, err := installer.ConfirmProceed("  Continue installation?")
-			if err != nil {
-				return fmt.Errorf("reading confirmation: %w", err)
-			}
-			if !cont {
-				return installer.ErrInstallCancelled
-			}
+		if len(projects) > 0 {
+			display.ColorMessage.Println("  Detected projects:")
 		} else {
-			infoBoxShown := false
-			for {
-				display.ColorMessage.Println("  Detected projects:")
-				display.PrintSectionDivider()
-				printProjectList(projects)
-
-				if !infoBoxShown {
-					fmt.Println()
-					printSupportedRuntimesInfoBox()
-					infoBoxShown = true
-				}
-
-				selected, ok := selectProject(projects)
-				if !ok {
-					break
-				}
-				plan = createRuntimePlanFn(selected, cp.httpPort, token, envURL, platformToken)
-				if plan != nil {
-					break
-				}
-				// Project can't be auto-instrumented; ask if the user wants to try another.
-				again, err := installer.ConfirmProceed("  Select another project?")
-				if err != nil || !again {
-					break
-				}
+			display.ColorMessage.Println("  Select how to instrument your application:")
+		}
+		display.PrintSectionDivider()
+		printProjectList(projects)
+		for {
+			selected, lang, ok := selectProject(projects)
+			if !ok {
+				break
 			}
+			if lang != "" {
+				manualLang = lang
+				break
+			}
+			plan = createRuntimePlanFn(selected, cp.httpPort, token, envURL, platformToken)
+			if plan != nil {
+				break
+			}
+			// Project can't be auto-instrumented; ask if the user wants to try another.
+			again, err := installer.ConfirmProceed("  Select another project?")
+			if err != nil || !again {
+				break
+			}
+			display.PrintSectionDivider()
+			printProjectList(projects)
 		}
 	}
 	fmt.Println()
@@ -632,16 +642,16 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 
 	if dryRun {
 		display.PrintStatusLine("dry-run", "no changes made", display.ColorMuted)
-		return nil
+		return "", nil
 	}
 
 	ok, err := installer.ConfirmProceed("  Proceed with installation?")
 	if err != nil {
-		return fmt.Errorf("reading confirmation: %w", err)
+		return "", fmt.Errorf("reading confirmation: %w", err)
 	}
 	if !ok {
 		fmt.Println("  Installation cancelled.")
-		return installer.ErrInstallCancelled
+		return "", installer.ErrInstallCancelled
 	}
 	fmt.Println()
 
@@ -651,15 +661,15 @@ func InstallOtelCollectorWithProject(envURL, token, platformToken, projectPath s
 	applyAndValidateGrailRoutes(grailC, grailPlans)
 
 	if err := executeCollectorPlanFn(cp, envURL, platformToken, plan != nil); err != nil {
-		return err
+		return "", err
 	}
 
 	if plan != nil {
 		fmt.Printf("\n  ── %s auto-instrumentation ──\n\n", plan.Runtime())
 		if err := plan.Execute(); err != nil {
-			return err
+			return "", err
 		}
 	}
 
-	return nil
+	return manualLang, nil
 }

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -418,7 +418,7 @@ func printProjectList(projects []detectedProject) {
 	fmt.Println()
 	display.ColorMuted.Println("  Following languages don't support automatic project detection yet:")
 	for _, lang := range manualLanguages {
-		fmt.Printf("  [%s]  %-10s — OTel instrumentation guide shown after install\n", lang.Key, lang.Name)
+		fmt.Printf("  [%s]  %-14s — OTel instrumentation guide shown after install\n", lang.Key, lang.Name)
 	}
 	fmt.Println()
 	fmt.Println("  [s]  Skip — I already have my application instrumented with OpenTelemetry or just want host monitoring")

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -416,8 +416,7 @@ func printProjectList(projects []detectedProject) {
 		fmt.Println(line)
 	}
 	fmt.Println()
-	display.ColorMuted.Println("  No auto-instrumentation yet — select your language for a manual walkthrough:")
-	fmt.Println()
+	display.ColorMuted.Println("  Following languages don't support automatic project detection yet:")
 	for _, lang := range manualLanguages {
 		fmt.Printf("  [%s]  %-10s — OTel instrumentation guide shown after install\n", lang.Key, lang.Name)
 	}

--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -395,6 +395,7 @@ var manualLanguages = []manualLanguageEntry{
 	{Key: "g", Name: "Go", URLSlug: "go"},
 	{Key: "r", Name: "Ruby", URLSlug: "ruby"},
 	{Key: "u", Name: "Rust", URLSlug: "rust"},
+	{Key: "o", Name: "Other language", URLSlug: "other"},
 }
 
 func printProjectList(projects []detectedProject) {
@@ -414,6 +415,8 @@ func printProjectList(projects []detectedProject) {
 		}
 		fmt.Println(line)
 	}
+	fmt.Println()
+	display.ColorMuted.Println("  No auto-instrumentation yet — select your language for a manual walkthrough:")
 	fmt.Println()
 	for _, lang := range manualLanguages {
 		fmt.Printf("  [%s]  %-10s — OTel instrumentation guide shown after install\n", lang.Key, lang.Name)

--- a/pkg/installer/otel/otel_test.go
+++ b/pkg/installer/otel/otel_test.go
@@ -280,9 +280,12 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		"github.com/example/go-svc",
 		"[s]",
 		"Skip —",
-		// manual language entries
+		// manual language entries + separator + other option
 		"PHP",
 		"Ruby",
+		"[o]",
+		"Other language",
+		"No auto-instrumentation yet",
 	}
 	for _, c := range checks {
 		if !strings.Contains(output, c) {
@@ -375,6 +378,7 @@ func TestSelectProject(t *testing.T) {
 		{name: "language key selects go", input: "g\n", wantOK: true, wantIdx: -1, wantLang: "go"},
 		{name: "language key selects php", input: "p\n", wantOK: true, wantIdx: -1, wantLang: "php"},
 		{name: "language key selects rust", input: "u\n", wantOK: true, wantIdx: -1, wantLang: "rust"},
+		{name: "language key selects other", input: "o\n", wantOK: true, wantIdx: -1, wantLang: "other"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/installer/otel/otel_test.go
+++ b/pkg/installer/otel/otel_test.go
@@ -69,7 +69,7 @@ func captureInstallOutput(t *testing.T, isElevated bool) string {
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	// dryRun=true prevents any download or process execution.
-	_ = InstallOtelCollector("https://env.example.com", "mytoken", "", true)
+	_, _ = InstallOtelCollector("https://env.example.com", "mytoken", "", true)
 
 	w.Close()
 	out, _ := io.ReadAll(r)
@@ -278,7 +278,11 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		"/home/user/svc",
 		"pom.xml",
 		"github.com/example/go-svc",
-		"Skip — If skipped",
+		"[s]",
+		"Skip —",
+		// manual language entries
+		"PHP",
+		"Ruby",
 	}
 	for _, c := range checks {
 		if !strings.Contains(output, c) {
@@ -357,29 +361,36 @@ func TestSelectProject(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		input   string
-		wantOK  bool
-		wantIdx int
+		name     string
+		input    string
+		wantOK   bool
+		wantIdx  int
+		wantLang string
 	}{
 		{name: "empty input skips", input: "\n", wantOK: false, wantIdx: -1},
-		{name: "non numeric skips", input: "abc\n", wantOK: false, wantIdx: -1},
+		{name: "s skips", input: "s\n", wantOK: false, wantIdx: -1},
+		{name: "invalid input skips", input: "xyz\n", wantOK: false, wantIdx: -1},
 		{name: "out of range skips", input: "9\n", wantOK: false, wantIdx: -1},
-		{name: "explicit skip option", input: "3\n", wantOK: false, wantIdx: -1},
-		{name: "valid selection", input: "2\n", wantOK: true, wantIdx: 1},
+		{name: "valid project selection", input: "2\n", wantOK: true, wantIdx: 1},
+		{name: "language key selects go", input: "g\n", wantOK: true, wantIdx: -1, wantLang: "go"},
+		{name: "language key selects php", input: "p\n", wantOK: true, wantIdx: -1, wantLang: "php"},
+		{name: "language key selects rust", input: "u\n", wantOK: true, wantIdx: -1, wantLang: "rust"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setTestStdin(t, tt.input)
 
-			project, ok := selectProject(projects)
+			project, lang, ok := selectProject(projects)
 
 			if ok != tt.wantOK {
 				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
 			}
 			if tt.wantIdx >= 0 && project.Path != projects[tt.wantIdx].Path {
 				t.Fatalf("expected selected path %s, got %s", projects[tt.wantIdx].Path, project.Path)
+			}
+			if tt.wantLang != "" && lang != tt.wantLang {
+				t.Fatalf("expected lang=%q, got %q", tt.wantLang, lang)
 			}
 		})
 	}
@@ -770,7 +781,7 @@ func TestInstallOtelCollector_RoutesBeforeCollectorVerification(t *testing.T) {
 	}
 	t.Cleanup(func() { executeCollectorPlanFn = origExecute })
 
-	if err := InstallOtelCollector("https://env.example.com", "tok", "dt0s16.test", false); err != nil {
+	if _, err := InstallOtelCollector("https://env.example.com", "tok", "dt0s16.test", false); err != nil {
 		t.Fatalf("InstallOtelCollector() error = %v", err)
 	}
 }
@@ -823,7 +834,7 @@ func TestInstallOtelCollectorWithProject_RoutesBeforeCollectorAndApp(t *testing.
 	}
 	t.Cleanup(func() { executeCollectorPlanFn = origExecute })
 
-	if err := InstallOtelCollectorWithProject("https://env.example.com", "tok", "dt0s16.test", projectDir, false); err != nil {
+	if _, err := InstallOtelCollectorWithProject("https://env.example.com", "tok", "dt0s16.test", projectDir, false); err != nil {
 		t.Fatalf("InstallOtelCollectorWithProject() error = %v", err)
 	}
 	if !plan.executed {
@@ -905,7 +916,8 @@ func runInstallWithAutoConfirm(t *testing.T, platformToken string) error {
 	}
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
-	return InstallOtelCollectorWithProject("https://env.example.com", "tok", platformToken, "", false)
+	_, err = InstallOtelCollectorWithProject("https://env.example.com", "tok", platformToken, "", false)
+	return err
 }
 
 // TestInstallOtelCollector_CallsActivation verifies that the extension
@@ -955,7 +967,7 @@ func TestInstallOtelCollector_DryRun_SkipsActivation(t *testing.T) {
 	installer.AutoConfirm = true
 	t.Cleanup(func() { installer.AutoConfirm = origAC })
 
-	_ = InstallOtelCollector("https://env.example.com", "tok", "", true /* dryRun */)
+	_, _ = InstallOtelCollector("https://env.example.com", "tok", "", true /* dryRun */)
 
 	if *called {
 		t.Error("expected activateHostMonitoringExtensionFn NOT to be called on dry run")
@@ -1445,10 +1457,10 @@ func TestPrintGrailPlanAndApplyResults(t *testing.T) {
 	}
 }
 
-// TestInstallOtelCollector_Darwin_AlwaysShowsUnavailableNotice verifies that on
+// TestInstallOtelCollector_Darwin_NeverShowsUnavailableNotice verifies that on
 // macOS the advisory about system.processes.created / process.disk.io being
-// unavailable is printed regardless of privilege level.
-func TestInstallOtelCollector_Darwin_AlwaysShowsUnavailableNotice(t *testing.T) {
+// unavailable is NOT printed (it is debug-only).
+func TestInstallOtelCollector_Darwin_NeverShowsUnavailableNotice(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("Darwin-only test")
 	}
@@ -1462,8 +1474,8 @@ func TestInstallOtelCollector_Darwin_AlwaysShowsUnavailableNotice(t *testing.T) 
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			output := captureInstallOutput(t, tt.isElevated)
-			if !strings.Contains(output, "macOS") {
-				t.Errorf("expected macOS unavailability notice in output:\n%s", output)
+			if strings.Contains(output, "system.processes.created") {
+				t.Errorf("macOS unavailability notice must not appear in non-debug output:\n%s", output)
 			}
 		})
 	}

--- a/pkg/installer/otel/otel_test.go
+++ b/pkg/installer/otel/otel_test.go
@@ -285,7 +285,7 @@ func TestPrintProjectList_Formatting(t *testing.T) {
 		"Ruby",
 		"[o]",
 		"Other language",
-		"No auto-instrumentation yet",
+		"Following languages don't support automatic project detection yet",
 	}
 	for _, c := range checks {
 		if !strings.Contains(output, c) {

--- a/pkg/installer/otel/runtime_scan.go
+++ b/pkg/installer/otel/runtime_scan.go
@@ -97,7 +97,8 @@ const (
 // The scan root itself is exempted from the skip-children rule: it's the
 // user's cwd, not necessarily a project boundary, so a marker match there
 // (e.g. a stray lockfile) must not hide every nested project underneath it.
-func walkCandidateDirs(root string, parentLevels int, visit func(dir string, entries []os.DirEntry) bool, shouldSkip func(name string) bool) {
+// shouldSkip receives the full absolute child path (not just the name).
+func walkCandidateDirs(root string, parentLevels int, visit func(dir string, entries []os.DirEntry) bool, shouldSkip func(path string) bool) {
 	concurrency := max(runtime.NumCPU()*scanConcurrencyPerCPU, minScanConcurrency)
 	// When full, child scans run synchronously instead of spawning more goroutines.
 	sem := make(chan struct{}, concurrency)
@@ -123,10 +124,13 @@ func walkCandidateDirs(root string, parentLevels int, visit func(dir string, ent
 		}
 
 		for _, entry := range entries {
-			if !entry.IsDir() || shouldSkip(entry.Name()) {
+			if !entry.IsDir() {
 				continue
 			}
 			childPath := filepath.Join(dir, entry.Name())
+			if shouldSkip(childPath) {
+				continue
+			}
 			if _, loaded := queued.LoadOrStore(childPath, struct{}{}); loaded {
 				continue
 			}
@@ -310,6 +314,19 @@ func isDescendant(child, parent string) bool {
 	return true
 }
 
+// effectiveGOPATH returns the Go workspace directory, defaulting to ~/go when
+// GOPATH is not set. Returns "" if the home directory cannot be determined.
+func effectiveGOPATH() string {
+	if gp := os.Getenv("GOPATH"); gp != "" {
+		return filepath.Clean(gp)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "go")
+}
+
 func scanProjectDirs(markers []string, excludeNames []string, roots []string) []ScannedProject {
 	if len(roots) == 0 {
 		return nil
@@ -320,8 +337,14 @@ func scanProjectDirs(markers []string, excludeNames []string, roots []string) []
 		excludedDirNames[name] = true
 	}
 
-	shouldSkipDir := func(name string) bool {
-		return strings.HasPrefix(name, ".") || strings.HasPrefix(name, "$") || excludedDirNames[name] || ignoredProjectDirNames[name]
+	gopath := effectiveGOPATH()
+	shouldSkipDir := func(path string) bool {
+		name := filepath.Base(path)
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "$") || excludedDirNames[name] || ignoredProjectDirNames[name] {
+			return true
+		}
+		// Skip the Go workspace directory (module cache lives inside it).
+		return gopath != "" && (path == gopath || isDescendant(path, gopath))
 	}
 
 	// The first root is the working directory; progress and relative-path
@@ -341,7 +364,7 @@ func scanProjectDirs(markers []string, excludeNames []string, roots []string) []
 	var subtreeCounts sync.Map   // relative top-level child → *atomic.Int64
 
 	dirMatches := func(dir string, entries []os.DirEntry) bool {
-		if shouldSkipDir(filepath.Base(dir)) {
+		if shouldSkipDir(dir) {
 			return false
 		}
 


### PR DESCRIPTION
## Summary

- **Filter GOPATH from project scan** — `~/go` (the Go toolchain) is no longer shown as a candidate project to instrument
- **macOS metrics advisory → debug-only** — `system.processes.created`/`process.disk.io` unavailability message is now `logger.Debug` only; removes noise from normal output
- **`[s] Skip` replaces numbered Skip entry** — separated by a blank line, no color highlight, cleaner visually
- **Selectable manual-language entries** — PHP, C++, .NET, Elixir, Erlang, Go, Ruby, Rust appear as `[p]`/`[c]`/`[n]`/… options above Skip; selecting one threads a `manualLang` slug through `InstallOtelCollector` → `WatchIngestOtel` and shows a CTA with `https://dt-url.net/otel-<lang>` in the watch footer
- **Simpler config preview truncation** — non-debug path now always shows head lines then a single `# ... (N lines)` comment for everything after; pipelines section is always hidden in non-debug output

## Test plan

- [x] `make test` — only pre-existing Java failures (no JDK on dev machine), zero new failures
- [x] `make lint` — 0 issues
- [x] Manual: run `dtwiz install otel` on macOS, verify macOS advisory not shown, verify `[s]` Skip renders correctly, verify language selection `[g]` shows Go CTA in watch section
- [x] Manual: run with `--debug`, verify macOS advisory appears and full config is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)