### PR TITLE
feat(otel): reorder manual language list by new-project excitement

### DIFF
--- a/pkg/installer/otel/otel.go
+++ b/pkg/installer/otel/otel.go
@@ -387,14 +387,14 @@ type manualLanguageEntry struct {
 }
 
 var manualLanguages = []manualLanguageEntry{
+	{Key: "g", Name: "Go", URLSlug: "go"},
+	{Key: "n", Name: ".NET", URLSlug: "dotnet"},
 	{Key: "p", Name: "PHP", URLSlug: "php"},
 	{Key: "c", Name: "C++", URLSlug: "cpp"},
-	{Key: "n", Name: ".NET", URLSlug: "dotnet"},
-	{Key: "e", Name: "Elixir", URLSlug: "elixir"},
-	{Key: "l", Name: "Erlang", URLSlug: "erlang"},
-	{Key: "g", Name: "Go", URLSlug: "go"},
 	{Key: "r", Name: "Ruby", URLSlug: "ruby"},
 	{Key: "u", Name: "Rust", URLSlug: "rust"},
+	{Key: "e", Name: "Elixir", URLSlug: "elixir"},
+	{Key: "l", Name: "Erlang", URLSlug: "erlang"},
 	{Key: "o", Name: "Other language", URLSlug: "other"},
 }
 


### PR DESCRIPTION
## Summary

- Reorders the manual language selection list in the OTel instrumentation wizard to reflect which languages developers are most excited about when starting new projects today
- New order: Go, .NET, PHP, C++, Ruby, Rust, Elixir, Erlang, Other language

## Test plan

- [x] Run `dtwiz install otel` and verify the language list appears in the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)