### PR TITLE
docs: add table of contents to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@
 
 > **Early Development**: This project is in active development. If you encounter any bugs or issues, please [file a GitHub issue](https://github.com/dynatrace-oss/dtwiz/issues/new). Contributions and feedback are welcome!
 
+## Table of Contents
+
+- [Quickstart](#quickstart)
+  - [Linux / macOS](#linux--macos)
+  - [Windows (PowerShell)](#windows-powershell)
+- [Prerequisites](#prerequisites)
+  - [Platform token scopes](#platform-token-scopes)
+- [Installation](#installation)
+  - [Install channels](#install-channels)
+- [Supported versions](#supported-versions)
+  - [OneAgent](#oneagent)
+  - [OpenTelemetry Collector](#opentelemetry-collector)
+- [Available commands](#available-commands)
+- [Flags](#flags)
+  - [`--yes` / `-y`](#--yes---y)
+  - [`--project <path>`](#--project-path)
+- [Demo](#demo)
+- [Example workflow](#example-workflow)
+- [JSON output](#json-output)
+- [Building](#building)
+- [Architecture](#architecture)
+
 ## Quickstart
 
 Run the following commands in your terminal/console to install and launch `dtwiz`:


### PR DESCRIPTION
## Chore Description

Adds a Table of Contents to the top of the README for easier navigation.

## What changed and why?

The README has grown significantly as new sections were added, making it harder to discover the information you're after at a glance. A Table of Contents right after the intro surfaces everything up front and lets readers jump straight to the section they need or be interested in.

## Checklist
- [x] No unintended behavior changes were introduced.
- [x] CHANGELOG and/or documentation was updated where necessary.