### PR TITLE
fix: skip sudo for python install on linux when running as root

### DIFF
--- a/openspec/specs/demo-python-prerequisites/spec.md
+++ b/openspec/specs/demo-python-prerequisites/spec.md
@@ -10,30 +10,49 @@ Define how `dtwiz install demo` automatically installs all Python prerequisites 
 
 `dtwiz install demo` SHALL check for all Python prerequisites — interpreter, pip, and pip availability inside a fresh virtualenv — and install any that are missing via the platform package manager before proceeding with OTel setup.
 
-#### Scenario: Python not on PATH — Debian/Ubuntu
+On Linux, the install command SHALL be prefixed with `sudo` only when the process is not already running as root. When the process is not root and `sudo` is not available on PATH, `dtwiz` SHALL return an actionable error instead of attempting to run a missing `sudo` binary.
+
+#### Scenario: Python not on PATH — Debian/Ubuntu, non-root with sudo available
 
 - **WHEN** `python3` / `python` is not found in PATH
 - **AND** `/etc/os-release` indicates Debian or Ubuntu
+- **AND** the process is not running as root and `sudo` is on PATH
 - **THEN** the plan SHALL include `sudo apt-get install -y python3 python3-pip python3-venv`
 
-#### Scenario: Python present but pip missing — Debian/Ubuntu
+#### Scenario: Python present but pip missing — Debian/Ubuntu, non-root with sudo available
 
 - **WHEN** a Python 3 interpreter is found but `python -m pip` fails
 - **AND** `/etc/os-release` indicates Debian or Ubuntu
+- **AND** the process is not running as root and `sudo` is on PATH
 - **THEN** the plan SHALL include `sudo apt-get install -y python3 python3-pip python3-venv`
 
-#### Scenario: pip present globally but missing from fresh venv — Debian/Ubuntu
+#### Scenario: pip present globally but missing from fresh venv — Debian/Ubuntu, non-root with sudo available
 
 - **WHEN** `python -m pip` succeeds but a probe virtualenv does not contain pip
 - **AND** `/etc/os-release` indicates Debian or Ubuntu
+- **AND** the process is not running as root and `sudo` is on PATH
 - **THEN** the plan SHALL include `sudo apt-get install -y python3 python3-pip python3-venv`
 - **NOTE** this catches the case where `python3-venv` is not installed: venv creation succeeds but the resulting venv omits pip
 
-#### Scenario: Prerequisites missing — RHEL/Fedora/CentOS
+#### Scenario: Prerequisites missing — RHEL/Fedora/CentOS, non-root with sudo available
 
 - **WHEN** any Python prerequisite (interpreter, pip, or pip-in-venv) is missing
 - **AND** `/etc/os-release` indicates RHEL/Fedora/CentOS or the distro is unrecognised
+- **AND** the process is not running as root and `sudo` is on PATH
 - **THEN** the plan SHALL include `sudo dnf install -y python3 python3-pip python3-venv`
+
+#### Scenario: Prerequisites missing — running as root
+
+- **WHEN** any Python prerequisite (interpreter, pip, or pip-in-venv) is missing
+- **AND** the process is already running as root (e.g. inside a container)
+- **THEN** the plan SHALL include the bare `apt-get`/`dnf` install command with no `sudo` prefix
+
+#### Scenario: Prerequisites missing — non-root and sudo unavailable
+
+- **WHEN** any Python prerequisite (interpreter, pip, or pip-in-venv) is missing
+- **AND** the process is not running as root
+- **AND** `sudo` is not found on PATH
+- **THEN** `dtwiz` SHALL return an error instructing the user to install Python 3 prerequisites manually, without attempting to run `sudo`
 
 #### Scenario: All prerequisites present
 

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -159,26 +159,33 @@ func pythonInstallPlan() ([]string, error) {
 		return []string{"brew", "install", "python3"}, nil
 
 	case "linux":
-		var prefix []string
-		if installer.NeedsSudo() {
-			if _, err := exec.LookPath("sudo"); err != nil {
-				return nil, fmt.Errorf("Python 3 is required but not found, and sudo is not available to install it.\nInstall python3, python3-pip, and python3-venv manually, then re-run this command") //nolint:staticcheck // ST1005: keep brand capitalization
-			}
-			prefix = []string{"sudo"}
-		}
-		switch detectLinuxDistro() {
-		case "debian", "ubuntu":
-			return append(prefix, "apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
-		default:
-			// RHEL/Fedora/CentOS/Rocky/Alma
-			return append(prefix, "dnf", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
-		}
+		return linuxPythonInstallCmd(installer.NeedsSudo)
 
 	case "windows":
 		return []string{"winget", "install", "--id", wingetPythonPackage}, nil
 
 	default:
 		return nil, fmt.Errorf("Python 3 is required but not found; please install it manually") //nolint:staticcheck // ST1005: keep brand capitalization
+	}
+}
+
+// linuxPythonInstallCmd builds the apt-get/dnf command that installs Python 3
+// prerequisites on Linux, prefixing sudo only when needsSudo reports that the
+// process isn't already running as root.
+func linuxPythonInstallCmd(needsSudo func() bool) ([]string, error) {
+	var prefix []string
+	if needsSudo() {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return nil, fmt.Errorf("Python 3 is required but not found, and sudo is not available to install it.\nInstall python3, python3-pip, and python3-venv manually, then re-run this command") //nolint:staticcheck // ST1005: keep brand capitalization
+		}
+		prefix = []string{"sudo"}
+	}
+	switch detectLinuxDistro() {
+	case "debian", "ubuntu":
+		return append(prefix, "apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
+	default:
+		// RHEL/Fedora/CentOS/Rocky/Alma
+		return append(prefix, "dnf", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
 	}
 }
 

--- a/pkg/installer/otel/demo.go
+++ b/pkg/installer/otel/demo.go
@@ -159,12 +159,19 @@ func pythonInstallPlan() ([]string, error) {
 		return []string{"brew", "install", "python3"}, nil
 
 	case "linux":
+		var prefix []string
+		if installer.NeedsSudo() {
+			if _, err := exec.LookPath("sudo"); err != nil {
+				return nil, fmt.Errorf("Python 3 is required but not found, and sudo is not available to install it.\nInstall python3, python3-pip, and python3-venv manually, then re-run this command") //nolint:staticcheck // ST1005: keep brand capitalization
+			}
+			prefix = []string{"sudo"}
+		}
 		switch detectLinuxDistro() {
 		case "debian", "ubuntu":
-			return []string{"sudo", "apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"}, nil
+			return append(prefix, "apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
 		default:
 			// RHEL/Fedora/CentOS/Rocky/Alma
-			return []string{"sudo", "dnf", "install", "-y", "python3", "python3-pip", "python3-venv"}, nil
+			return append(prefix, "dnf", "install", "-y", "python3", "python3-pip", "python3-venv"), nil
 		}
 
 	case "windows":

--- a/pkg/installer/otel/demo_test.go
+++ b/pkg/installer/otel/demo_test.go
@@ -315,6 +315,42 @@ func TestInstallPythonWindows_WingetSucceedsButPythonUnavailable(t *testing.T) {
 	}
 }
 
+func TestLinuxPythonInstallCmd_RootSkipsSudo(t *testing.T) {
+	cmd, err := linuxPythonInstallCmd(func() bool { return false })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmd) == 0 || cmd[0] == "sudo" {
+		t.Fatalf("expected no sudo prefix when already root, got: %v", cmd)
+	}
+}
+
+func TestLinuxPythonInstallCmd_NonRootWithSudoAvailable(t *testing.T) {
+	dir := t.TempDir()
+	createPythonDemoTestCommand(t, dir, "sudo", "", 0)
+	t.Setenv("PATH", dir)
+
+	cmd, err := linuxPythonInstallCmd(func() bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmd) == 0 || cmd[0] != "sudo" {
+		t.Fatalf("expected sudo prefix, got: %v", cmd)
+	}
+}
+
+func TestLinuxPythonInstallCmd_NonRootWithoutSudo(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := linuxPythonInstallCmd(func() bool { return true })
+	if err == nil {
+		t.Fatal("expected error when sudo is required but missing")
+	}
+	if !strings.Contains(err.Error(), "sudo is not available") {
+		t.Fatalf("error should mention missing sudo, got: %v", err)
+	}
+}
+
 func TestDetectLinuxDistro(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux-only test")


### PR DESCRIPTION
## Bug Fix Description
`dtwiz install demo` fails on Linux hosts/containers that run as root and don't have `sudo` installed (common for Docker images and CI runners). `pythonInstallPlan()` unconditionally prefixed the `apt-get`/`dnf` install command with `sudo`, so the install step failed with:

```
Python installation failed: command "sudo" failed: exec: "sudo": executable file not found in $PATH
```

This PR uses the existing `installer.NeedsSudo()` helper to only prepend `sudo` when the process isn't already running as root, and returns a clear, actionable error if `sudo` is required but missing (instead of the raw exec error).

## Root cause
`pythonInstallPlan()` in `pkg/installer/otel/demo.go` hardcoded `sudo` as the first argument of the `apt-get`/`dnf` install command for Linux, with no check for whether `sudo` was actually available or needed. Root-only containers (a common case for CI/Docker) don't ship `sudo`, so `exec.Command("sudo", ...)` fails at the OS level before the package manager ever runs.

## How to reproduce
1. Run `dtwiz install demo` inside a minimal Linux container running as root without Python 3 and without `sudo` installed (e.g. a bare `debian:slim` or `python`-less Docker image).
2. Observe the failure: `Python installation failed: command "sudo" failed: exec: "sudo": executable file not found in $PATH`.

## How to test
1. `go test ./pkg/installer/otel/... -run TestDemo -v` — existing tests (`TestDemoInstallCmdCurrentOS`, `TestDemoExamplesURL`) pass.
2. Manually verify on a root container without `sudo`: `pythonInstallPlan()` now returns the bare `apt-get`/`dnf` command (no `sudo` prefix) and the install proceeds.
3. Manually verify on a non-root host without `sudo` on PATH: `pythonInstallPlan()` now returns a clear error instead of the raw exec failure.

## Which other features are affected?
1. None — this only affects the Linux Python-prerequisite install path used by `dtwiz install demo`.

## Checklist
- [x] I have tested these changes locally.
- [x] I updated OpenSpec and other documentation where necessary.
- [x] I added or updated tests where appropriate.
- [x] I followed the existing code style and conventions.