### PR TITLE
chore: remove Copilot pre-review checklist item from PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -14,7 +14,6 @@
 1.
 
 ## Checklist
-- [ ] Make sure Copilot has reviewed the PR as a preliminary check.
 - [ ] I have tested these changes locally.
 - [ ] I updated OpenSpec and other documentation where necessary.
 - [ ] I added or updated tests where appropriate.

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -6,6 +6,5 @@
 <!-- Describe the change. For dependency updates, note the version diff and any breaking changes. -->
 
 ## Checklist
-- [ ] Make sure Copilot has reviewed the PR as a preliminary check.
 - [ ] No unintended behavior changes were introduced.
 - [ ] CHANGELOG and/or documentation was updated where necessary.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -8,7 +8,6 @@
 1.
 
 ## Checklist
-- [ ] Make sure Copilot has reviewed the PR as a preliminary check.
 - [ ] I have tested these changes locally.
 - [ ] I updated OpenSpec and other documentation where necessary.
 - [ ] I added or updated tests where appropriate.


### PR DESCRIPTION
## Chore Description
<!-- Use for refactoring, dependency updates, tooling, CI, documentation, or cleanup. -->
Removes the "Make sure Copilot has reviewed the PR as a preliminary check." checklist item from the bugfix, chore, and feature PR templates.

## What changed and why?
Dropped the Copilot pre-review checklist line from `.github/PULL_REQUEST_TEMPLATE/bugfix.md`, `chore.md`, and `feature.md` (the default `pull_request_template.md` never had this item). No other content changed.

## Checklist
- [x] No unintended behavior changes were introduced.
- [x] CHANGELOG and/or documentation was updated where necessary.